### PR TITLE
Add new unit testing github action when opening/syncing a PR

### DIFF
--- a/.github/workflows/pr_open_sync_workflow.yml
+++ b/.github/workflows/pr_open_sync_workflow.yml
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get install libxml2-utils
     # Run "checkout_externals":
     - name: Checkout externals
-      run: manage_externals/checkout_externals
+      run: manage_externals/checkout_externals --externals Externals_CAM.cfg ccpp-framework
     # Run python unit and doctests:
     - name: python unit tests
       run: |


### PR DESCRIPTION
This PR adds a new Github Action workflow that will automatically run CAMDEN-related python unittests and doctests whenever a PR is opened, re-opened, or a new commit is pushed to an open PR (called "synchronizing" in Github action parlance).  The actual code that is tested is whatever is in your fork's branch.  Thus any additional changes you commit to your branch will be tested as well (assuming the PR is still open).  

Currently this action will run these python tests on a linux system (Ubuntu) for python versions 2.7 to 3.8.  If the action should also run these tests on a another OS (say MacOS) then just let me know.  Along with that, if you believe the tests should be run on more (or less) versions of python then that is fine too.

Finally, right now this action's runtime is about one minute, with the xmllint installation and manage_externals taking up the most time.  Thus if we decide that these actions are simply taking too long to run then we might be able to skip and/or optimize these steps in the future.  However, for now I figured a minute to run all the tests wasn't too bad.

Resolves #41 

