### PR TITLE
Updated CIME to cime5.8.28

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -9,7 +9,7 @@ local_path = components/cice
 required = False
 
 [cime]
-tag = cime5.8.20
+tag = cime5.8.28
 protocol = git
 repo_url = https://github.com/ESMCI/cime
 local_path = cime


### PR DESCRIPTION
Update CIME to cime5.8.28 in order to allow CAMDEN to build with updated compilers.
I need to make this change as a hotfix so that others can use CAMDEN.
Tested by building a suite.