### PR TITLE
Add pylint Github Action to PR Open and Sync workflow.

### DIFF
--- a/.github/scripts/pr_mod_file_tests.py
+++ b/.github/scripts/pr_mod_file_tests.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python
+
+"""
+Script name:  pr_mod_file_tests.py
+
+Goal:  To generate a list of files modified in the associated
+       Github Pull Request (PR), using the PyGithub interface,
+       and then to run tests on those files when appropriate.
+
+Written by:  Jesse Nusbaumer <nusbaume@ucar.edu> - November, 2020
+"""
+
+#+++++++++++++++++++++
+#Import needed modules
+#+++++++++++++++++++++
+
+import sys
+import os
+import subprocess
+import shlex
+import argparse
+
+from stat import S_ISREG
+from github import Github
+
+#Local scripts:
+from pylint_threshold_test import pylint_check
+
+#################
+
+class PrModTestFail(ValueError):
+    """Class used to handle file test failures
+    (i.e., raise test failures without backtrace)"""
+
+#################
+#HELPER FUNCTIONS
+#################
+
+def _file_is_python(filename):
+
+    """
+    Checks whether a given file
+    is a python script or
+    python source code.
+    """
+
+    #Initialize return logical:
+    is_python = False
+
+    #Extract status of provided file:
+    file_stat = os.stat(filename)
+
+    #Check if it is a "regular" file:
+    if S_ISREG(file_stat.st_mode):
+
+        #Next, check if file ends in ".py":
+        file_ext = os.path.splitext(filename)[1]
+
+        if file_ext.strip() == ".py":
+            #Assume file is python:
+            is_python = True
+        else:
+            #If no ".py" extension exists, then
+            #open the file and look for a shabang
+            #that contains the word "python".
+            with open(filename, "r") as mod_file:
+                #Loop over lines in file:
+                for line in mod_file:
+
+                    #Ignore blank lines:
+                    if line.strip():
+
+                        #Check that first non-blank
+                        #line is a shabang:
+                        if line[0:2] == '#!':
+                            #If so, then check that the word
+                            #"python" is also present:
+                            if line.find("python") != -1:
+                                #If the word exists, then assume
+                                #it is a python file:
+                                is_python = True
+
+                        #Exit loop, as only the first non-blank
+                        #line should be examined:
+                        break
+
+    #Return file type result:
+    return is_python
+
+#++++++++++++++++++++++++++++++
+#Input Argument parser function
+#++++++++++++++++++++++++++++++
+
+def parse_arguments():
+
+    """
+    Parses command-line input arguments using the argparse
+    python module and outputs the final argument object.
+    """
+
+    #Create parser object:
+    parser = argparse.ArgumentParser(description='Generate list of all files modified by pull request.')
+
+    #Add input arguments to be parsed:
+    parser.add_argument('--access_token', metavar='<GITHUB_TOKEN>', action='store', type=str,
+                        help="access token used to access GitHub API")
+
+    parser.add_argument('--pr_num', metavar='<PR_NUMBER>', action='store', type=int,
+                        help="pull request number")
+
+    parser.add_argument('--rcfile', metavar='<pylintrc file path>', action='store', type=str,
+                       help="location of pylintrc file (full path)")
+
+    parser.add_argument('--pylint_level', metavar='<number>', action='store', type=float,
+                        required=False, help="pylint score that file(s) must exceed")
+
+    #Parse Argument inputs
+    args = parser.parse_args()
+    return args
+
+#############
+#MAIN PROGRAM
+#############
+
+def _main_prog():
+
+    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
+
+    #++++++++++++
+    #Begin script
+    #++++++++++++
+
+    print("Generating list of modified files...")
+
+    #+++++++++++++++++++++++
+    #Read in input arguments
+    #+++++++++++++++++++++++
+
+    args = parse_arguments()
+
+    #Add argument values to variables:
+    token = args.access_token
+    pr_num = args.pr_num
+    rcfile = args.rcfile
+    pylev = args.pylint_level
+
+    #++++++++++++++++++++++++++++++++
+    #Log-in to github API using token
+    #++++++++++++++++++++++++++++++++
+
+    ghub = Github(token)
+
+    #++++++++++++++++++++
+    #Open ESCOMP/CAM repo
+    #++++++++++++++++++++
+
+    #Official CAM repo:
+    cam_repo = ghub.get_repo("NCAR/CAMDEN")
+
+    #++++++++++++++++++++++++++++++++++++++++++
+    #Open Pull Request which triggered workflow
+    #++++++++++++++++++++++++++++++++++++++++++
+
+    pull_req = cam_repo.get_pull(pr_num)
+
+    #++++++++++++++++++++++++++++++
+    #Extract list of modified files
+    #++++++++++++++++++++++++++++++
+
+    #Create empty list to store python files:
+    pyfiles = list()
+
+    #Extract Github file objects:
+    file_obj_list = pull_req.get_files()
+
+    for file_obj in file_obj_list:
+
+        #Check if file exists. If not,
+        #then it was likely deleted in the
+        #PR itself, so don't check its file type:
+        if os.path.exists(file_obj.filename):
+
+            #Check if it is a python file:
+            if _file_is_python(file_obj.filename):
+                #If so, then add to python list:
+                pyfiles.append(file_obj.filename)
+
+    #++++++++++++++++++++++++++++++++++++++++++++
+    #Check if any python files are being modified:
+    #++++++++++++++++++++++++++++++++++++++++++++
+    if pyfiles:
+
+        #Notify users of python files that will
+        #be tested:
+        print("The following modified python files will be tested:")
+        for pyfile in pyfiles:
+            print(pyfile)
+
+        #+++++++++++++++++++++++++
+        #Run pylint threshold test
+        #+++++++++++++++++++++++++
+
+        lint_msgs = pylint_check(pyfiles, rcfile,
+                                 threshold=pylev)
+
+        #++++++++++++++++++
+        #Check test results
+        #++++++++++++++++++
+
+        #If pylint check lists are non-empty, then
+        #a test has failed, and an exception should
+        #be raised with the relevant pytlint info:
+        if lint_msgs:
+            #Print pylint results for failed tests to screen:
+            print("+++++++++++PYLINT FAILURE MESSAGES+++++++++++++")
+            for lmsg in lint_msgs:
+                print(lmsg)
+            print("+++++++++++++++++++++++++++++++++++++++++++++++")
+
+            #Raise test failure exception:
+            fail_msg = "One or more files are below allowed pylint " \
+                       "score of {}.\nPlease see pylint message(s) " \
+                       "above for possible fixes."
+            raise PrModTestFail(fail_msg)
+        else:
+            #All tests have passed, so exit normally:
+            print("All pylint tests passed!")
+            sys.exit(0)
+
+    #If no python files exist in PR, then exit script:
+    else:
+        print("No python files present in PR, so there is nothing to test.")
+        sys.exit(0)
+
+#############################################
+
+#Run the main script program:
+if __name__ == "__main__":
+    _main_prog()

--- a/.github/scripts/pylint_threshold_test.py
+++ b/.github/scripts/pylint_threshold_test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+
+"""
+Modle name: pylint_threshold_test.py
+
+Purpose:  To test whether the provided list of python
+          files pass a pylint check at the specified
+          score threshold.
+
+Written by:  Jesse Nusbaumer <nusbaume@ucar.edu> - November, 2020
+"""
+
+#+++++++++++++++++++++
+#Import needed modules
+#+++++++++++++++++++++
+
+import argparse
+import io
+import pylint.lint as lint
+
+from pylint.reporters.text import TextReporter
+
+#################
+#HELPER FUNCTIONS
+#################
+
+#++++++++++++++++++++++++++++++
+#Input Argument parser function
+#++++++++++++++++++++++++++++++
+
+def parse_arguments():
+
+    """
+    Parses command-line input arguments using the argparse
+    python module and outputs the final argument object.
+    """
+
+    #Create parser object:
+    parser = argparse.ArgumentParser(description='Generate list of all files modified by pull request.')
+
+    #Add input arguments to be parsed:
+    parser.add_argument('--python_files', metavar='<comma-separated list>',
+                        nargs='+', action='store', type=str,
+                        help="list of python files to test")
+
+    parser.add_argument('--rcfile', metavar='<pylintrc file path>', action='store', type=str,
+                       help="location of pylintrc file (full path)")
+
+    parser.add_argument('--pylint_level', metavar='<number>', action='store', type=float,
+                        required=False, help="pylint score that file(s) must exceed")
+
+    #Parse Argument inputs
+    args = parser.parse_args()
+    return args
+
+#################
+#Main test script
+#################
+
+def pylint_check(pyfile_list, rcfile, threshold=10.0):
+
+    """
+    Checks if the pylint scores of the provided
+    python files are greater than a specified
+    threshold.
+    """
+
+    #Creat empty list to store pylint output:
+    lint_msgs = list()
+
+    #Check if pyfile_list is empty.  If so then exit
+    #script, as their are no python files to test:
+    if not pyfile_list:
+        return lint_msgs
+
+    #Create rcfile option string:
+    rcstr = '--rcfile={}'.format(rcfile)
+
+    #If files exist, then loop through the list:
+    for pyfile in pyfile_list:
+
+        #Create IO object to receive pylint messages:
+        pylint_output = io.StringIO()
+
+        #Create pylint reporter object using new IO object:
+        pylint_report = TextReporter(pylint_output)
+
+        #Run linter:
+        lint_results = lint.Run([rcstr, '--exit-zero', pyfile],
+                                reporter=pylint_report, do_exit=False)
+
+        #Extract linter score:
+        lint_score = lint_results.linter.stats['global_note']
+
+        #Save pylint output as string:
+        lint_msg = pylint_output.getvalue()
+
+        #Close IO object:
+        pylint_output.close()
+
+        #Add file score and message to list if
+        #below pylint threshold:
+        if lint_score < threshold:
+            lint_msgs.append(lint_msg)
+
+    #Return plyint lists:
+    return lint_msgs
+
+####################
+#Command-line script
+####################
+
+def _pylint_check_commandline():
+
+    """
+    Runs the "pylint_check" test using
+    command line inputs. This will
+    print the test results to stdout
+    (usually the screen).
+    """
+
+    #Read in command-line arguments:
+    args = parse_arguments()
+
+    #Add argument values to variables:
+    python_files = args.python_files
+    pylintrc = args.rcfile
+    pylint_level = args.pylint_level
+
+    #run pylint threshold check:
+    if pylint_level:
+        msgs = pylint_check(python_files, pylintrc,
+                            threshold=pylint_level)
+    else:
+        msgs = pylint_check(python_files, pylintrc)
+
+    #print pylint info to screen:
+    if msgs:
+        #If test(s) failed, then print pylint message(s):
+        for msg in msgs:
+            print(msg)
+    else:
+        print("All files scored above pylint threshold")
+
+#############################################
+
+#Run main script using provided command line arguments:
+if __name__ == "__main__":
+    _pylint_check_commandline()

--- a/.github/workflows/pr_open_sync_workflow.yml
+++ b/.github/workflows/pr_open_sync_workflow.yml
@@ -43,3 +43,34 @@ jobs:
         python test/unit/test_registry.py
         # Physics variable init (phys_init) generator unit tests:
         python test/unit/write_init_unit_tests.py
+
+#####
+
+  #This job is designed to run tests on all source-code files
+  #modified by the Pull Request (PR).  This is done by running
+  #a master python script which collects all modified files,
+  #and then passes those files off to additional scripts
+  #to run the actual tests.
+  source_code_tests:
+    runs-on: ubuntu-latest
+    steps:
+    # acquire github action routines
+    - uses: actions/checkout@v2
+    # acquire specific version of python
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.8' # Use python 3.8
+    # install required python packages
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip  # Install latest version of PIP
+        pip install PyGithub                 # Install PyGithub python package
+        pip install pylint                   # Install Pylint python package
+    # run CAM source code testing master script:
+    - name: source-code testing python script
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+        ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: .github/scripts/pr_mod_file_tests.py --access_token $ACCESS_TOKEN --pr_num $PR_NUMBER --rcfile test/.pylintrc --pylint_level 9.5
+


### PR DESCRIPTION
Adds a new Github Action to the PR open and sync workflow which runs pylint on all modified python files, and marks a test as "failed" if the pylint score is below a specified threshold.  

Currently the version of python used is 3.8, and the pylint score threshold is set to 9.5, but both can be changed if different versions or thresholds are preferred.

Resolves #79

**TESTS RUN:**

Ran multiple PR test cases on the CAM Github testing repo (https://github.com/NCAR/repoForTestingCAM).  The scripts and workflow appear to behave as expected.

