### PR TITLE
Update atmospheric_physics tag to bring in Held_Suarez

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -23,7 +23,7 @@ required = False
 local_path = src/physics/ncar_ccpp
 protocol = git
 repo_url = https://github.com/NCAR/atmospheric_physics
-tag = version0_00_011
+tag = atmos_phys0_00_011
 required = True
 
 [silhs]


### PR DESCRIPTION
Simple change to bring in updated atmospheric_physics tag

Ran the following:

./create_newcase --case test_camden_heldsuarez_try044 --compset FPHYStest --res f19_f19 --compiler intel --run-unsupported --pecount 1

 ./xmlchange STOP_N=9 ;  ./xmlchange STOP_OPTION=nsteps; ./xmlchange DOUT_S=FALSE; ./xmlchange DEBUG=TRUE ; ./xmlchange CAM_CONFIG_OPTS=" --dyn none --physics-suites held_suarez_1994";  ./xmlchange NTASKS=1

user_nl_cam file:

ncdata = '/project/amp02/cacraig/heldsuarez_data/run_heldsuarez_cam6_3_019_try009.cam.h5.0001-01-01-00000.nc'ncdata_check = '/project/amp02/cacraig/heldsuarez_data/run_heldsuarez_cam6_3_019_try009.cam.h6.0001-01-01-00000.nc'debug_output = 0

The validation tool indicates the run results are identical to the ncdata_check file.