### PR TITLE
Add Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: File a bug report - for CAMDEN developers' use only (all other users should use the CESM forum)
+title: "Put brief (<65 char) bug title here!"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also - what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: What are the steps to reproduce the bug?
+      description: How can we see this issue?
+      placeholder: ex. Sneeze twice and then do a 5-second jig
+    validations:
+      required: true
+  - type: input
+    id: cam-tag
+    attributes:
+      label: What CAMDEN hash were you using?
+      description: Type "git rev-parse --short HEAD" to see the hash
+      placeholder: ex. abc123
+    validations:
+      required: true
+  - type: dropdown
+    id: machine
+    attributes:
+      label: What machine were you running CAMDEN on?
+      multiple: true
+      options:
+        - CISL machine (e.g. cheyenne)
+        - CGD machine (e.g. izumi)
+        - Docker container
+        - Personal Computer
+        - Other (please explain below)
+    validations:
+      required: true
+  - type: dropdown
+    id: compiler
+    attributes:
+      label: What compiler were you using?
+      multiple: true
+      options:
+        - Intel
+        - GNU
+        - NAG
+        - NVHPC
+        - PGI
+        - Other (please specify below)
+    validations:
+      required: true
+  - type: input
+    id: case-directory
+    attributes:
+      label: Path to a case directory, if applicable
+      description: The full path to a case in which the error occurred
+      placeholder: ex. /glade/scratch/3p0/where-could-he-be
+    validations:
+      required: false
+  - type: dropdown
+    id: implemenation
+    attributes:
+      label: Will you be addressing this bug yourself?
+      description: If Yes, please also assign this issue to yourself (if possible)
+      multiple: false
+      options:
+        - "Yes"
+        - "Yes, but I will need some help"
+        - "No"
+        - "Any Software Engineer can do this"
+    validations:
+      required: true
+  - type: textarea
+    id: extra-info
+    attributes:
+      label: Extra info
+      description: Please provide any additional information here that you think might be relevant
+      placeholder: ex. I am running CAMDEN on izumi and I don't know what compiler I'm using.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: CESM forums
+    url: https://bb.cgd.ucar.edu/cesm/forums/cam.133/
+    about: For support with model use, troubleshooting, etc., please use the CESM forum

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yml
@@ -1,0 +1,45 @@
+name: Enhancement Request
+description: Request an enhancement and/or open a science discussion
+title: "Put brief (<65 char) title here!"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: enhancement-description
+    attributes:
+      label: What is the feature/what would you like to discuss?
+      placeholder: ex. I'd like to entirely refactor chemistry and here's how.
+    validations:
+      required: true
+  - type: textarea
+    id: user-reference
+    attributes:
+      label: Is there anyone in particular you want to be part of this conversation?
+      description: Add the user(s) with @<username>
+      placeholder: ex. @confucius
+    validations:
+      required: false
+  - type: dropdown
+    id: answer-changing
+    attributes:
+      label: Will this change (regression test) answers?
+      description: If yes, please also add the "answer changing" label (if possible)
+      multiple: false
+      options:
+        - "Yes"
+        - "No"
+        - "I Don't Know"
+    validations:
+      required: true
+  - type: dropdown
+    id: implemenation
+    attributes:
+      label: Will you be implementing this enhancement yourself?
+      description: If Yes, please also assign this issue to yourself
+      multiple: false
+      options:
+        - "Yes"
+        - "Yes, but I will need some help"
+        - "No"
+        - "Any Software Engineer can do this"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,50 @@
+name: Other
+description: ex. code clean-up, infrastructure updates
+title: "Put brief (<65 char) title here!"
+body:
+  - type: dropdown
+    id: other-type
+    attributes:
+      label: Issue Type
+      description: If applicable, please add relevant label(s)
+      multiple: true
+      options:
+        - Code Clean-up
+        - Infrastructure Update
+        - Externals Update
+        - Documentation Update
+        - Other (please describe below)
+    validations:
+      required: true
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Issue Description
+      description: Describe what will change
+    validations:
+      required: true
+  - type: dropdown
+    id: answer-changing
+    attributes:
+      label: Will this change answers?
+      description: If yes, please also add the "answer changing" label (if possible)
+      multiple: false
+      options:
+        - "Yes"
+        - "No"
+        - "I Don't Know"
+    validations:
+      required: true
+  - type: dropdown
+    id: implemenation
+    attributes:
+      label: Will you be implementing this yourself?
+      description: If Yes, please also assign this issue to yourself (if possible)
+      multiple: false
+      options:
+        - "Yes"
+        - "Yes, but I will need some help"
+        - "No"
+        - "Any Software Engineer can do this"
+    validations:
+      required: true


### PR DESCRIPTION
These should basically be the same as the current ESCOMP/CAM templates, except that I tried to either remove any reference to "CAM", or replaced it with "CAMDEN".  

I also replaced the "tag" request in the bug report with a hash request, as CAMDEN currently doesn't have any tags.  I imagine the first tag will be made once we have history output and have made the repo public, and once the first tag is made then we can switch this back (I can make a general discussion issue so that we can list everything we need to do before the repo goes public). 

Fixes #201 
