### PR TITLE
Update to latest framework tag

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -2,7 +2,7 @@
 local_path = ccpp_framework
 protocol = git
 repo_url = https://github.com/peverwhee/ccpp-framework
-tag = CPF_0.2.042
+tag = CPF_0.2.043
 required = True
 
 [cosp2]

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -18,7 +18,6 @@ module cam_constituents
    public :: const_is_moist
    public :: const_is_wet
    public :: const_qmin
-   public :: const_is_initialized_in_physics
 
    ! Private array of constituent properties (for property interface functions)
    type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:) => NULL()
@@ -57,11 +56,6 @@ module cam_constituents
       module procedure const_qmin_obj
       module procedure const_qmin_index
    end interface const_qmin
-
-   interface const_is_initialized_in_physics
-      module procedure const_is_initialized_in_physics_obj
-      module procedure const_is_initialized_in_physics_index
-   end interface const_is_initialized_in_physics
 
    ! Private interfaces
    private :: check_index_bounds
@@ -483,44 +477,5 @@ CONTAINS
    end function const_qmin_index
 
    !#######################################################################
-
-   logical function const_is_initialized_in_physics_obj(const_obj) result(is_initialized)
-      use cam_abortutils, only: endrun
-      use string_utils,   only: to_str
-
-      ! Return true iff <const_obj> is initialized in physics
-      ! Dummy argument
-      type(ccpp_constituent_prop_ptr_t), intent(in) :: const_obj
-      ! Local variables
-      integer                     :: err_code
-      character(len=256)          :: err_msg
-      character(len=*), parameter :: subname =  'const_is_initialized_in_physics_obj: '
-
-      call const_obj%is_initialized_in_physics(is_initialized, errcode=err_code, errmsg=err_msg)
-      if (err_code /= 0) then
-         call endrun(subname//"Error "//to_str(err_code)//": "//           &
-              trim(err_msg), file=__FILE__, line=__LINE__)
-      end if
-
-   end function const_is_initialized_in_physics_obj
-
-   !#######################################################################
-
-   logical function const_is_initialized_in_physics_index(const_ind) result(is_initialized)
-      use cam_ccpp_cap, only: cam_model_const_properties
-      ! Return true iff the  constituent at <index> is initialized in physics
-      ! Dummy argument
-      integer, intent(in) :: const_ind
-      ! Local variable
-      type(ccpp_constituent_prop_ptr_t), pointer :: const_properties(:)
-      character(len=*), parameter                :: subname = 'const_is_initialized_in_physics_index: '
-
-      const_properties => NULL()
-      if (check_index_bounds(const_ind, subname)) then
-         const_properties => cam_model_const_properties()
-         is_initialized = const_is_initialized_in_physics(const_properties(const_ind))
-      end if
-
-   end function const_is_initialized_in_physics_index
 
 end module cam_constituents

--- a/src/physics/utils/physics_data.F90
+++ b/src/physics/utils/physics_data.F90
@@ -41,7 +41,6 @@ CONTAINS
       use phys_vars_init_check, only: is_initialized
       use phys_vars_init_check, only: is_read_from_file
       use cam_constituents,     only: const_get_index
-      use cam_constituents,     only: const_is_initialized_in_physics
 
       ! Dummy arguments
       ! Variable standard name being checked:
@@ -106,13 +105,8 @@ CONTAINS
          if (find_input_name_idx < 0) then
             find_input_name_idx = no_exist_idx
          else
-            ! Check if constituent is initialized in a physics init routine
-            if (const_is_initialized_in_physics(find_input_name_idx)) then
-               find_input_name_idx = init_mark_idx
-            else
-               constituent_index = find_input_name_idx
-               find_input_name_idx = const_idx
-            end if
+            constituent_index = find_input_name_idx
+            find_input_name_idx = const_idx
          end if
       end if
 


### PR DESCRIPTION
The newest framework tag (which represents the code in the feature/capgen PR) requires some code cleanup on the CAMDEN side. So, this is that.

I've run @cacraigucar 's pear and banana tests to confirm that things run as expected.