### PR TITLE
Replace NCAR/CAMDEN references with ESCOMP/CAM-SIMA.

### DIFF
--- a/.github/scripts/branch_pr_issue_closer.py
+++ b/.github/scripts/branch_pr_issue_closer.py
@@ -138,10 +138,10 @@ def _main_prog():
     ghub = Github(token)
 
     #+++++++++++++++++++++
-    #Open NCAR/CAMDEN repo
+    #Open ESCOMP/CAM-SIMA repo
     #+++++++++++++++++++++
 
-    cam_repo = ghub.get_repo("NCAR/CAMDEN")
+    cam_repo = ghub.get_repo("ESCOMP/CAM-SIMA")
 
     #+++++++++++++++++++++++++++++
     #Get triggering commit message

--- a/.github/scripts/pr_mod_file_tests.py
+++ b/.github/scripts/pr_mod_file_tests.py
@@ -155,7 +155,7 @@ def _main_prog():
     #++++++++++++++++++++
 
     #Official CAM repo:
-    cam_repo = ghub.get_repo("NCAR/CAMDEN")
+    cam_repo = ghub.get_repo("ESCOMP/CAM-SIMA")
 
     #++++++++++++++++++++++++++++++++++++++++++
     #Open Pull Request which triggered workflow

--- a/.github/workflows/branch_push_workflow.yml
+++ b/.github/workflows/branch_push_workflow.yml
@@ -16,7 +16,7 @@ jobs:
   #This job is designed to close any issues or pull requests specified
   #in the body of a pull request merged into a non-default branch.
   issue_closer:
-    if: github.repository == 'NCAR/CAMDEN' # Only run on main repo
+    if: github.repository == 'ESCOMP/CAM-SIMA' # Only run on main repo
     runs-on: ubuntu-latest
     steps:
     # Acquire github action routines

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
   #a PR is either opened or synced (i.e. additional commits are pushed
   #to branch involved in PR).
   python_unit_tests:
-    if: github.event_name == 'pull_request' || github.repository == 'NCAR/CAMDEN'
+    if: github.event_name == 'pull_request' || github.repository == 'ESCOMP/CAM-SIMA'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# CAMDEN
-CAM Developmental and Experimental iNfrastructure
+# CAM-SIMA
+Community Atmosphere Model - System for Integrated Modeling of the Atmosphere
 
 NOTE:  Only developmental code exists at the moment.  This README will be updated once production code becomes available.
 
-## How to checkout and use CAMDEN:
+## How to checkout and use CAM-SIMA:
 
 The instructions below assume you have cloned this repository and are in the repository directory. For example:
 ```
-git clone https://github.com/NCAR/CAMDEN.git
-cd CAMDEN
+git clone https://github.com/ESCOMP/CAM-SIMA.git
+cd CAM-SIMA
 ```
 
-### To use unsupported CAMDEN **development** code:
+### To use unsupported CAM-SIMA **development** code:
 
 ## NOTE: This is **unsupported** development code and is subject to the [CESM developer's agreement](http://www.cgd.ucar.edu/cseg/development-code.html).
 ```


### PR DESCRIPTION
This PR updates both the README and the Github Action workflows to correctly reference ESCOMP/CAM-SIMA.  This is a high priority given that I don't think the automatic testing system will work properly until the workflows point to the correct repo.

Fixes #219 