### PR TITLE
Update CAM-SIMA to run Kessler and Held-Suarez bit-for-bit with CAM

### DIFF
--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         #All of these python versions will be used to run tests:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
     # Acquire github action routines:

--- a/.github/workflows/python_unit_tests.yml
+++ b/.github/workflows/python_unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         #All of these python versions will be used to run tests:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
     # Acquire github action routines:

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -64,9 +64,10 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-tag = cime6.0.156
+#tag = cime6.0.156
+branch = paramgen_py12
 protocol = git
-repo_url = https://github.com/ESMCI/cime
+repo_url = https://github.com/nusbaume/cime
 local_path = cime
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -64,10 +64,9 @@ local_path = libraries/parallelio
 required = True
 
 [cime]
-#tag = cime6.0.156
-branch = paramgen_py12
+tag = cime6.0.175
 protocol = git
-repo_url = https://github.com/nusbaume/cime
+repo_url = https://github.com/ESMCI/cime
 local_path = cime
 required = True
 

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -5,33 +5,12 @@ repo_url = https://github.com/peverwhee/ccpp-framework
 tag = CPF_0.2.045
 required = True
 
-[cosp2]
-local_path = src/physics/cosp2/src
-protocol = svn
-repo_url = https://github.com/CFMIP/COSPv2.0/tags/
-tag = v2.0.3cesm/src
-required = False
-
-[clubb]
-local_path = src/physics/clubb
-protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/clubb_core/vendor_tags/
-tag = clubb_ncar_backwards_compat_20181205_c20190528
-required = False
-
 [ncar-physics]
 local_path = src/physics/ncar_ccpp
 protocol = git
 repo_url = https://github.com/NCAR/atmospheric_physics
 tag = atmos_phys0_00_020
 required = True
-
-[silhs]
-local_path = src/physics/silhs
-protocol = svn
-repo_url = https://svn-ccsm-models.cgd.ucar.edu/silhs/vendor_tags/
-tag = silhs_ncar_backwards_compat_20181205
-required = False
 
 [externals_description]
 schema_version = 1.0.0

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -1,9 +1,8 @@
 [ccpp-framework]
 local_path = ccpp_framework
 protocol = git
-repo_url = https://github.com/nusbaume/ccpp-framework
-branch = water_species_prop
-#tag = CPF_0.2.048
+repo_url = https://github.com/peverwhee/ccpp-framework
+tag = CPF_0.2.049
 required = True
 
 [ncar-physics]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -1,15 +1,17 @@
 [ccpp-framework]
 local_path = ccpp_framework
 protocol = git
-repo_url = https://github.com/peverwhee/ccpp-framework
-tag = CPF_0.2.045
+repo_url = https://github.com/nusbaume/ccpp-framework
+#tag = CPF_0.2.043
+branch = const_updates
 required = True
 
 [ncar-physics]
 local_path = src/physics/ncar_ccpp
 protocol = git
-repo_url = https://github.com/NCAR/atmospheric_physics
-tag = atmos_phys0_00_020
+repo_url = https://github.com/nusbaume/atmospheric_physics
+#tag = atmos_phys0_00_018
+branch = updated_standard_names
 required = True
 
 [externals_description]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -3,7 +3,7 @@ local_path = ccpp_framework
 protocol = git
 repo_url = https://github.com/nusbaume/ccpp-framework
 #tag = CPF_0.2.043
-branch = const_updates
+branch = errflg_fix
 required = True
 
 [ncar-physics]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -1,8 +1,9 @@
 [ccpp-framework]
 local_path = ccpp_framework
 protocol = git
-repo_url = https://github.com/peverwhee/ccpp-framework
-tag = CPF_0.2.047
+repo_url = https://github.com/nusbaume/ccpp-framework
+#tag = CPF_0.2.047
+branch = qmin_setter
 required = True
 
 [ncar-physics]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -8,7 +8,7 @@ required = True
 [ncar-physics]
 local_path = src/physics/ncar_ccpp
 protocol = git
-repo_url = https://github.com/NCAR/atmospheric_physics
+repo_url = https://github.com/ESCOMP/atmospheric_physics
 tag = atmos_phys0_01_000
 required = True
 

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -1,9 +1,8 @@
 [ccpp-framework]
 local_path = ccpp_framework
 protocol = git
-repo_url = https://github.com/nusbaume/ccpp-framework
-#tag = CPF_0.2.043
-branch = errflg_fix
+repo_url = https://github.com/peverwhee/ccpp-framework
+tag = CPF_0.2.047
 required = True
 
 [ncar-physics]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -9,9 +9,8 @@ required = True
 [ncar-physics]
 local_path = src/physics/ncar_ccpp
 protocol = git
-repo_url = https://github.com/nusbaume/atmospheric_physics
-#tag = atmos_phys0_00_018
-branch = updated_standard_names
+repo_url = https://github.com/NCAR/atmospheric_physics
+tag = atmos_phys0_01_000
 required = True
 
 [externals_description]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -2,7 +2,7 @@
 local_path = ccpp_framework
 protocol = git
 repo_url = https://github.com/peverwhee/ccpp-framework
-tag = CPF_0.2.049
+tag = CPF_0.2.050
 required = True
 
 [ncar-physics]

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -2,8 +2,8 @@
 local_path = ccpp_framework
 protocol = git
 repo_url = https://github.com/nusbaume/ccpp-framework
-#tag = CPF_0.2.047
-branch = qmin_setter
+branch = water_species_prop
+#tag = CPF_0.2.048
 required = True
 
 [ncar-physics]

--- a/cime_config/cam_autogen.py
+++ b/cime_config/cam_autogen.py
@@ -437,8 +437,8 @@ def generate_physics_suites(build_cache, preproc_defs, host_name,
         os.makedirs(physics_blddir)
     # End if
     # Collect all source directories
-    source_search = [source_mods_dir,
-                     os.path.join(atm_root, "src", "physics", "ncar_ccpp")]
+    atm_phys_src_dir = os.path.join(atm_root, "src", "physics", "ncar_ccpp")
+    source_search = [source_mods_dir, atm_phys_src_dir]
     # Find all metadata files, organize by scheme name
     all_scheme_files = _find_metadata_files(source_search, find_scheme_names)
 
@@ -449,8 +449,8 @@ def generate_physics_suites(build_cache, preproc_defs, host_name,
     for sdf in phys_suites_str.split(';'):
         sdf_path = _find_file(f"suite_{sdf}.xml", source_search)
         if not sdf_path:
-            emsg = "ERROR: Unable to find SDF for suite '{}'"
-            raise CamAutoGenError(emsg.format(sdf))
+            emsg = f"ERROR: Unable to find SDF for suite '{sdf}'"
+            raise CamAutoGenError(emsg)
         # End if
         sdfs.append(sdf_path)
         # Given an SDF, find all the schemes it calls
@@ -579,6 +579,30 @@ def generate_physics_suites(build_cache, preproc_defs, host_name,
         capgen_db = capgen(run_env, return_db=True)
     else:
         capgen_db = None
+    # end if
+
+    # Several SIMA dycores need some of the physics schemes
+    # located in the "utilities" CCPP physics directory,
+    # even if the actual physics suites don't need them.
+    # So go-ahead and copy all of the source code from
+    # there to the bld directory:
+    if do_gen_ccpp:
+        # Set CCPP physics "utilities" path
+        atm_phys_util_dir = os.path.join(atm_phys_src_dir, "utilities")
+
+        # Check that directory exists
+        if not os.path.isdir(atm_phys_util_dir):
+            #CAM-SIMA will likely not run without this, so raise an error
+            emsg = "ERROR: Unable to find CCPP physics utilities directory:\n"
+            emsg += f" {atm_phys_util_dir}\n Have you run 'checkout_externals'?"
+            raise CamAutoGenError(emsg)
+        # end if
+
+        # Copy all utility source files to the build directory
+        atm_phys_util_files = glob.glob(os.path.join(atm_phys_util_dir, "*.F90"))
+        for util_file in atm_phys_util_files:
+            shutil.copy2(util_file, physics_blddir)
+        # end for
     # end if
 
     if do_gen_ccpp or do_gen_nl:

--- a/cime_config/cam_autogen.py
+++ b/cime_config/cam_autogen.py
@@ -601,7 +601,7 @@ def generate_physics_suites(build_cache, preproc_defs, host_name,
         # Copy all utility source files to the build directory
         atm_phys_util_files = glob.glob(os.path.join(atm_phys_util_dir, "*.F90"))
         for util_file in atm_phys_util_files:
-            shutil.copy2(util_file, physics_blddir)
+            shutil.copy(util_file, physics_blddir)
         # end for
     # end if
 

--- a/cime_config/cam_config.py
+++ b/cime_config/cam_config.py
@@ -165,10 +165,9 @@ class ConfigCAM:
         and associated dictionary.
         """
 
-        # Check if using python 3.7 or later.  If not,
-        # then end build here:
-        if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 7):
-            emsg = "CAM requires python 3.7 or later, currently using python version"
+        # Check if using python 3.8 or later. If not, then end build here:
+        if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 8):
+            emsg = "SIMA requires python 3.8 or later, currently using python version"
             emsg += f" {sys.version_info[0]}.{sys.version_info[1]}"
             raise SystemError(emsg)
         #End if

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -165,7 +165,7 @@
       <value compset="_CAM%HS94">-phys held_suarez</value>
       <value compset="_CAM%KESSLER">-phys kessler -chem terminator -analytic_ic</value> -->
       <value compset="_CAM%KESSLER">--physics-suites kessler --analytic_ic</value>
-      <value compset="_CAM%FHS94">--physics-suites held_suarez_1994 --analytic_ic</value>
+      <value compset="_CAM%HS94">--physics-suites held_suarez_1994 --analytic_ic</value>
       <value compset="_CAM%PHYSTEST">--dyn none --physics-suites adiabatic</value>
 
       <!-- Aquaplanet -->

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -84,14 +84,6 @@
     <science_support grid="T42_T42"/>
   </compset>
 
-  <compset>
-    <alias>FHS94</alias>
-    <lname>2000_CAM%HS94_SLND_SICE_SOCN_SROF_SGLC_SWAV</lname>
-    <science_support grid="T42z30_T42_mg17"/>
-    <science_support grid="T85z30_T85_mg17"/>
-    <science_support grid="T85z60_T85_mg17"/>
-  </compset>
-
   <!-- CAM aquaplanet compsets -->
 
   <compset>
@@ -147,6 +139,11 @@
   <compset>
     <alias>FADIAB</alias>
     <lname>2000_CAM%ADIAB_SLND_SICE_SOCN_SROF_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
+    <alias>FHS94</alias>
+    <lname>2000_CAM%HS94_SLND_SICE_SOCN_SROF_SGLC_SWAV</lname>
   </compset>
 
   <!-- CAM Dycore test compsets -->
@@ -267,7 +264,7 @@
   </compset>
 
   <!-- Untested simple model compsets -->
-  
+
 
   <!-- ****************************** -->
   <!-- WACCM science supported compsets -->
@@ -540,7 +537,7 @@
  <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"	 >hybrid</value> -->
  <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV">hybrid</value> -->
  <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">hybrid</value> -->
-          
+
  <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV">hybrid</value> -->
  <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">hybrid</value> -->
  <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">hybrid</value> -->
@@ -554,7 +551,7 @@
 <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7"	compset="HIST_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV"	 >b.e20.BHIST.f09_g17.20thC.297_01_v2</value> -->
 <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV">b.e16.B1850_WW3.f09_g16.lang_redi_2hr_frz_chl.003</value> -->
 <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v6"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">b.e20.B1850.f09_g16.pi_control.all.123</value> -->
-    
+
 <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM1%NOEVOLVE_SWAV">b.e16.B1850_WW3.f09_g16.lang_redi_2hr_frz_chl.003</value> -->
 <!--	<value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9_1.25_r%r05_m%gx1v7"   compset="2000_CAM60_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">b.e20.B1850.f09_g16.pi_control.all.123</value> -->
 <!--        <value grid="a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_g%gland4_w%null_m%gx1v7" compset="HIST_CAM60%WC.*_CLM50%BGC-CROP_CICE%PRES_DOCN%DOM_MOSART_CISM2%NOEVOLVE_SWAV">b.e21.BWHIST.f09_g17.CMIP6-historical-WACCM.001</value> -->

--- a/src/control/cam_comp.F90
+++ b/src/control/cam_comp.F90
@@ -506,7 +506,7 @@ CONTAINS
       ! Dummy arguments
       type(runtime_options), intent(in) :: cam_runtime_opts
       ! Local variables
-      logical                                        :: is_const
+      logical                                        :: is_constituent
       integer                                        :: num_advect
       integer                                        :: const_idx
       integer                                        :: errflg
@@ -522,7 +522,7 @@ CONTAINS
       ! physics:
       call cam_ccpp_is_scheme_constituent(                                              &
            "water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water",                &
-           is_const, errflg, errmsg)
+           is_constituent, errflg, errmsg)
 
       if (errflg /= 0) then
          call endrun(subname//trim(errmsg), file=__FILE__, line=__LINE__)
@@ -531,7 +531,7 @@ CONTAINS
       !If not requested by the physics, then add water vapor to the
       !constituents object:
       !-------------------------------------------
-      if (.not. is_const) then
+      if (.not. is_constituent) then
 
          ! Allocate host_constituents object:
          allocate(host_constituents(1), stat=errflg)

--- a/src/control/cam_comp.F90
+++ b/src/control/cam_comp.F90
@@ -513,9 +513,12 @@ CONTAINS
       character(len=*), parameter :: subname = 'cam_register_constituents: '
 
       ! Register the constituents to find out what needs advecting
-      call host_constituents(1)%instantiate(std_name="specific_humidity",      &
-           long_name="Specific humidity", units="kg kg-1",                    &
-           vertical_dim="vertical_layer_dimension", advected=.true.,          &
+      call host_constituents(1)%instantiate( &
+           std_name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water",    &
+           long_name="water vapor mixing ratio w.r.t moist air and condensed_water", &
+           units="kg kg-1",                                                          &
+           vertical_dim="vertical_layer_dimension",                                  &
+           advected=.true.,                                                          &
            errcode=errflg, errmsg=errmsg)
       if (errflg /= 0) then
          call endrun(subname//trim(errmsg), file=__FILE__, line=__LINE__)

--- a/src/control/cam_comp.F90
+++ b/src/control/cam_comp.F90
@@ -50,11 +50,10 @@ module cam_comp
 
    logical  :: BFB_CAM_SCAM_IOP = .false.
 
-   ! Currently, the host (CAM) only adds water vapor (specific_humidity)
-   !    as a constituent.
-   ! Does this need to be a configurable variable?
-   integer, parameter :: num_host_advected = 1
-   type(ccpp_constituent_properties_t), target :: host_constituents(num_host_advected)
+   ! Currently, the host (CAM-SIMA) adds only water vapor (specific humidity)
+   ! as a constituent when not requested by the physics.  However, it is
+   ! unclear if this is actually necessary.
+   type(ccpp_constituent_properties_t), allocatable, target :: host_constituents(:)
 
    ! Private interface (here to avoid circular dependency)
    private :: cam_register_constituents
@@ -492,44 +491,84 @@ CONTAINS
    subroutine cam_register_constituents(cam_runtime_opts)
       ! Call the CCPP interface to register all constituents for the
       ! physics suite being invoked during this run.
-      use cam_abortutils,            only: endrun
+      use cam_abortutils,            only: endrun, check_allocate
       use runtime_obj,               only: runtime_options
       use cam_constituents,          only: cam_constituents_init
+      use ccpp_kinds,                only: kind_phys
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       use cam_ccpp_cap,              only: cam_ccpp_register_constituents
       use cam_ccpp_cap,              only: cam_ccpp_number_constituents
       use cam_ccpp_cap,              only: cam_model_const_properties
-      use cam_ccpp_cap,              only: cam_const_get_index
+      use cam_ccpp_cap,              only: cam_ccpp_is_scheme_constituent
 
       ! Dummy arguments
       type(runtime_options), intent(in) :: cam_runtime_opts
       ! Local variables
-      integer                                        :: index
+      logical                                        :: is_const
       integer                                        :: num_advect
       integer,                           allocatable :: ind_water_spec(:)
       integer                                        :: errflg
-      character(len=cx)                              :: errmsg
+      character(len=512)                             :: errmsg
       type(ccpp_constituent_prop_ptr_t), pointer     :: const_props(:)
       character(len=*), parameter :: subname = 'cam_register_constituents: '
 
-      ! Register the constituents to find out what needs advecting
-      call host_constituents(1)%instantiate( &
-           std_name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water",    &
-           long_name="water vapor mixing ratio w.r.t moist air and condensed_water", &
-           units="kg kg-1",                                                          &
-           vertical_dim="vertical_layer_dimension",                                  &
-           advected=.true.,                                                          &
-           errcode=errflg, errmsg=errmsg)
+      ! Initalize error flag and message:
+      errflg = 0
+      errmsg = ''
+
+      ! Check if water vapor is already marked as a constituent by the
+      ! physics:
+      call cam_ccpp_is_scheme_constituent(                                              &
+           "water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water",                &
+           is_const, errflg, errmsg)
+
       if (errflg /= 0) then
          call endrun(subname//trim(errmsg), file=__FILE__, line=__LINE__)
       end if
-      call cam_ccpp_register_constituents(cam_runtime_opts%suite_as_list(),      &
+
+      !If not requested by the physics, then add water vapor to the
+      !constituents object:
+      !-------------------------------------------
+      if (.not. is_const) then
+
+         ! Allocate host_constituents object:
+         allocate(host_constituents(1), stat=errflg)
+         call check_allocate(errflg, subname, 'host_constituents(1)',                   &
+                             file=__FILE__, line=__LINE__)
+
+         ! Register the constituents to find out what needs advecting
+         call host_constituents(1)%instantiate( &
+              std_name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water",    &
+              long_name="water vapor mixing ratio w.r.t moist air and condensed_water", &
+              units="kg kg-1",                                                          &
+              default_value=0._kind_phys,                                               &
+              vertical_dim="vertical_layer_dimension",                                  &
+              advected=.true.,                                                          &
+           errcode=errflg, errmsg=errmsg)
+
+         if (errflg /= 0) then
+            call endrun(subname//trim(errmsg), file=__FILE__, line=__LINE__)
+         end if
+      else
+         ! Allocate zero-size object so nothing is added
+         ! to main constituents object:
+         allocate(host_constituents(0), stat=errflg)
+         call check_allocate(errflg, subname, 'host_constituents(0)',                   &
+                             file=__FILE__, line=__LINE__)
+      end if
+      !-------------------------------------------
+
+      !Combine host and physics constituents into a single
+      !constituents object:
+      call cam_ccpp_register_constituents(cam_runtime_opts%suite_as_list(),             &
            host_constituents, errcode=errflg, errmsg=errmsg)
 
       if (errflg /= 0) then
          call endrun(subname//trim(errmsg), file=__FILE__, line=__LINE__)
       end if
-      call cam_ccpp_number_constituents(num_advect, advected=.true., &
+
+      !Determine total number of advected constituents:
+      call cam_ccpp_number_constituents(num_advect, advected=.true.,                    &
            errcode=errflg, errmsg=errmsg)
 
       if (errflg /= 0) then

--- a/src/control/cam_comp.F90
+++ b/src/control/cam_comp.F90
@@ -538,7 +538,7 @@ CONTAINS
          call check_allocate(errflg, subname, 'host_constituents(1)',                   &
                              file=__FILE__, line=__LINE__)
 
-         ! Register the constituents to find out what needs advecting
+         ! Register the constituents so they can be advected:
          call host_constituents(1)%instantiate( &
               std_name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water",    &
               long_name="water vapor mixing ratio w.r.t moist air and condensed_water", &

--- a/src/data/air_composition.F90
+++ b/src/data/air_composition.F90
@@ -332,8 +332,8 @@ CONTAINS
             !
             ! RAINQM
             !
-         case('rain_water_mixing_ratio_wrt_moist_air')
-            call air_species_info('rain_water_mixing_ratio_wrt_moist_air', ix, mw)
+         case('rain_mixing_ratio_wrt_moist_air_and_condensed_water')
+            call air_species_info('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix, mw)
             thermodynamic_active_species_idx(icnst) = ix
             thermodynamic_active_species_cp (icnst) = cpliq
             thermodynamic_active_species_cv (icnst) = cpliq
@@ -346,8 +346,8 @@ CONTAINS
             !
             ! SNOWQM
             !
-         case('snow_water_mixing_ratio_wrt_moist_air')
-            call air_species_info('snow_water_mixing_ratio_wrt_moist_air', ix, mw)
+         case('snow_mixing_ratio_wrt_moist_air_and_condensed_water')
+            call air_species_info('snow_mixing_ratio_wrt_moist_air_and_condensed_water', ix, mw)
             thermodynamic_active_species_idx(icnst) = ix
             thermodynamic_active_species_cp (icnst) = cpice
             thermodynamic_active_species_cv (icnst) = cpice

--- a/src/data/air_composition.F90
+++ b/src/data/air_composition.F90
@@ -634,7 +634,7 @@ CONTAINS
       use string_utils,    only: to_str
 
       ! Dummy arguments
-      ! tracedr: Tracer array
+      ! tracer: Tracer array
       real(kind_phys),           intent(in)  :: tracer(:,:,:)
       real(kind_phys), optional, intent(in)  :: dp_dry(:,:)
       ! inv_cp: output inverse cp instead of cp
@@ -657,9 +657,9 @@ CONTAINS
          if (SIZE(active_species_idx_dycore) /=                               &
               thermodynamic_active_species_num) then
             call endrun(subname//"SIZE mismatch "//                           &
-                 to_str(SIZE(active_species_idx_dycore))//' /= '//           &
+                 to_str(SIZE(active_species_idx_dycore))//' /= '//            &
                  to_str(thermodynamic_active_species_num))
-        end if
+         end if
          idx_local = active_species_idx_dycore
       else
          idx_local = thermodynamic_active_species_idx
@@ -677,15 +677,14 @@ CONTAINS
               (tracer(:,:,itrac) * factor(:,:))
       end do
 
-      if (dry_air_species_num == 0) then
-         sum_cp = thermodynamic_active_species_cp(0)
-      else
-         call get_cp_dry(tracer, idx_local, sum_cp, fact=factor)
-      end if
+      ! Get Cp for dry air:
+      call get_cp_dry(tracer, idx_local, sum_cp, fact=factor)
+
+      ! Add water species to Cp:
       do qdx = dry_air_species_num + 1, thermodynamic_active_species_num
          itrac = idx_local(qdx)
          sum_cp(:,:) = sum_cp(:,:) +                                      &
-              (thermodynamic_active_species_cp(qdx) * tracer(:,:,itrac) *   &
+              (thermodynamic_active_species_cp(qdx) * tracer(:,:,itrac) * &
               factor(:,:))
       end do
       if (inv_cp) then

--- a/src/data/air_composition.F90
+++ b/src/data/air_composition.F90
@@ -246,6 +246,9 @@ CONTAINS
             thermodynamic_active_species_kc(icnst)  = kc3
             icnst = icnst + 1
             dry_species_num = dry_species_num + 1
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! O2
             !
@@ -260,6 +263,9 @@ CONTAINS
             thermodynamic_active_species_kc(icnst)  = kc1
             icnst = icnst + 1
             dry_species_num = dry_species_num + 1
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! H
             !
@@ -275,6 +281,9 @@ CONTAINS
             thermodynamic_active_species_kc(icnst)  = 0.0_kind_phys
             icnst = icnst + 1
             dry_species_num = dry_species_num + 1
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! N2
             !
@@ -287,12 +296,16 @@ CONTAINS
             thermodynamic_active_species_R  (icnst) = r_universal / mw
             thermodynamic_active_species_mwi(icnst) = 1.0_kind_phys / mw
             thermodynamic_active_species_kv(icnst)  = kv2
-            thermodynamic_active_species_kc(icnst)  = kc2
+            thermodynamic_active_species_kc(icnst)  = kc2a
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! Q
             !
-         case('specific_humidity')
-            call air_species_info('specific_humidity', ix, mw)
+         case('water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water')
+            call air_species_info('water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water', &
+                                  ix, mw)
             thermodynamic_active_species_idx(icnst) = ix
             thermodynamic_active_species_cp (icnst) = cpwv
             thermodynamic_active_species_cv (icnst) = cv3 / mw
@@ -300,12 +313,15 @@ CONTAINS
             icnst = icnst + 1
             water_species_num = water_species_num + 1
             const_is_water_species(ix) = .true.
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! CLDLIQ
             !
-         case('cloud_liquid_water_mixing_ratio_wrt_moist_air')
-            call air_species_info('cloud_liquid_water_mixing_ratio_wrt_moist_air', &
-                 ix, mw)
+         case('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water')
+            call air_species_info('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water', &
+                                  ix, mw)
             thermodynamic_active_species_idx(icnst) = ix
             thermodynamic_active_species_cp (icnst) = cpliq
             thermodynamic_active_species_cv (icnst) = cpliq
@@ -315,11 +331,15 @@ CONTAINS
             water_species_num = water_species_num + 1
             has_liq = .true.
             const_is_water_species(ix) = .true.
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! CLDICE
             !
-         case('cloud_ice_water_mixing_ratio_wrt_moist_air')
-            call air_species_info('cloud_ice_water_mixing_ratio_wrt_moist_air', ix, mw)
+         case('cloud_ice_water_mixing_ratio_wrt_moist_air_and_condensed_water')
+            call air_species_info('cloud_ice_water_mixing_ratio_wrt_moist_air_and_condensed_water', &
+                                  ix, mw)
             thermodynamic_active_species_idx(icnst) = ix
             thermodynamic_active_species_cp (icnst) = cpice
             thermodynamic_active_species_cv (icnst) = cpice
@@ -329,6 +349,9 @@ CONTAINS
             water_species_num = water_species_num + 1
             has_ice = .true.
             const_is_water_species(ix) = .true.
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! RAINQM
             !
@@ -343,6 +366,9 @@ CONTAINS
             water_species_num = water_species_num + 1
             has_liq = .true.
             const_is_water_species(ix) = .true.
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! SNOWQM
             !
@@ -357,11 +383,15 @@ CONTAINS
             water_species_num = water_species_num + 1
             has_ice = .true.
             const_is_water_species(ix) = .true.
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! GRAUQM
             !
-         case('graupel_water_mixing_ratio_wrt_moist_air')
-            call air_species_info('graupel_water_mixing_ratio_wrt_moist_air', ix, mw)
+         case('graupel_water_mixing_ratio_wrt_moist_air_and_conedensed_water')
+            call air_species_info('graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water', &
+                                  ix, mw)
             thermodynamic_active_species_idx(icnst) = ix
             thermodynamic_active_species_cp (icnst) = cpice
             thermodynamic_active_species_cv (icnst) = cpice
@@ -371,6 +401,9 @@ CONTAINS
             water_species_num = water_species_num + 1
             has_ice = .true.
             const_is_water_species(ix) = .true.
+            !Notify constituent object that this species is
+            !thermodynamically active
+            call const_set_thermo_active(idx, .true.)
             !
             ! If support for more major species is to be included add code here
             !

--- a/src/data/air_composition.F90
+++ b/src/data/air_composition.F90
@@ -677,7 +677,7 @@ CONTAINS
               (tracer(:,:,itrac) * factor(:,:))
       end do
 
-      ! Get Cp for dry air:
+      ! Get heat capacity at constant pressure (Cp) for dry air:
       call get_cp_dry(tracer, idx_local, sum_cp, fact=factor)
 
       ! Add water species to Cp:

--- a/src/data/air_composition.F90
+++ b/src/data/air_composition.F90
@@ -133,6 +133,7 @@ CONTAINS
       use physics_grid,         only: pcols => columns_on_task
       use vert_coord,           only: pver
       use cam_constituents,     only: const_name, num_advected
+      use cam_constituents,     only: const_set_thermo_active
 
       integer  :: icnst, ix, ierr, idx
       integer  :: liq_num, ice_num, water_species_num, dry_species_num
@@ -296,7 +297,7 @@ CONTAINS
             thermodynamic_active_species_R  (icnst) = r_universal / mw
             thermodynamic_active_species_mwi(icnst) = 1.0_kind_phys / mw
             thermodynamic_active_species_kv(icnst)  = kv2
-            thermodynamic_active_species_kc(icnst)  = kc2a
+            thermodynamic_active_species_kc(icnst)  = kc2
             !Notify constituent object that this species is
             !thermodynamically active
             call const_set_thermo_active(idx, .true.)

--- a/src/data/air_composition.F90
+++ b/src/data/air_composition.F90
@@ -134,6 +134,7 @@ CONTAINS
       use vert_coord,           only: pver
       use cam_constituents,     only: const_name, num_advected
       use cam_constituents,     only: const_set_thermo_active
+      use cam_constituents,     only: const_set_water_species
 
       integer  :: icnst, ix, ierr, idx
       integer  :: liq_num, ice_num, water_species_num, dry_species_num
@@ -317,6 +318,9 @@ CONTAINS
             !Notify constituent object that this species is
             !thermodynamically active
             call const_set_thermo_active(idx, .true.)
+            !Notify constituent object that this species is
+            !a water species
+            call const_set_water_species(idx, .true.)
             !
             ! CLDLIQ
             !
@@ -335,6 +339,9 @@ CONTAINS
             !Notify constituent object that this species is
             !thermodynamically active
             call const_set_thermo_active(idx, .true.)
+            !Notify constituent object that this species is
+            !a water species
+            call const_set_water_species(idx, .true.)
             !
             ! CLDICE
             !
@@ -353,6 +360,10 @@ CONTAINS
             !Notify constituent object that this species is
             !thermodynamically active
             call const_set_thermo_active(idx, .true.)
+            !Notify constituent object that this species is
+            !a water species
+            call const_set_water_species(idx, .true.)
+
             !
             ! RAINQM
             !
@@ -370,6 +381,9 @@ CONTAINS
             !Notify constituent object that this species is
             !thermodynamically active
             call const_set_thermo_active(idx, .true.)
+            !Notify constituent object that this species is
+            !a water species
+            call const_set_water_species(idx, .true.)
             !
             ! SNOWQM
             !
@@ -387,6 +401,9 @@ CONTAINS
             !Notify constituent object that this species is
             !thermodynamically active
             call const_set_thermo_active(idx, .true.)
+            !Notify constituent object that this species is
+            !a water species
+            call const_set_water_species(idx, .true.)
             !
             ! GRAUQM
             !
@@ -405,6 +422,9 @@ CONTAINS
             !Notify constituent object that this species is
             !thermodynamically active
             call const_set_thermo_active(idx, .true.)
+            !Notify constituent object that this species is
+            !a water species
+            call const_set_water_species(idx, .true.)
             !
             ! If support for more major species is to be included add code here
             !

--- a/src/data/physconst.F90
+++ b/src/data/physconst.F90
@@ -54,8 +54,7 @@ module physconst
    real(kind_phys), public, parameter :: latvap      = real(shr_const_latvap, kind_phys)     ! Latent heat of vaporization (J kg-1)
    real(kind_phys), public, parameter :: pi          = real(shr_const_pi, kind_phys)         ! 3.14...
    real(kind_phys), public, protected :: pstd        = real(shr_const_pstd, kind_phys)       ! Standard pressure (Pascals)
-   real(kind_phys), public, protected :: ps_base     = 1.0e5_kind_phys                       ! Base state surface pressure (Pascals)
-   real(kind_phys), public, protected :: ps_ref      = 1.0e5_kind_phys                       ! Reference surface pressure (Pascals)
+   real(kind_phys), public, protected :: pref        = 1.0e5_kind_phys                       ! Reference surface pressure (Pascals)
    real(kind_phys), public, parameter :: tref        = 288._kind_phys                        ! Reference temperature (K)
    real(kind_phys), public, parameter :: lapse_rate  = 0.0065_kind_phys                      ! reference lapse rate (K m-1)
    real(kind_phys), public, parameter :: r_universal = real(shr_const_rgas, kind_phys)       ! Universal gas constant (J K-1 kmol-1)

--- a/src/data/physconst.meta
+++ b/src/data/physconst.meta
@@ -92,8 +92,8 @@
   dimensions = ()
   protected = True
 [ rhoh2o ]
-  standard_name = density_of_liquid_water_at_0c
-  long_name = Density of liquid water at 0C
+  standard_name = density_of_fresh_liquid_water_at_0c
+  long_name = Density of fresh liquid water at 0C
   units = kg m-3
   type = real | kind = kind_phys
   dimensions = ()

--- a/src/data/physconst.meta
+++ b/src/data/physconst.meta
@@ -68,7 +68,7 @@
   dimensions = ()
   protected = True
 [ pref ]
-  standard_name = reference_pressure_at_surface
+  standard_name = reference_pressure
   units = Pa
   type = real | kind = kind_phys
   dimensions = ()

--- a/src/data/physconst.meta
+++ b/src/data/physconst.meta
@@ -67,14 +67,8 @@
   type = real | kind = kind_phys
   dimensions = ()
   protected = True
-[ ps_base ]
-  standard_name = base_state_surface_pressure_for_hybrid_vertical_coordinate
-  units = Pa
-  type = real | kind = kind_phys
-  dimensions = ()
-  protected = True
-[ ps_ref ]
-  standard_name = reference_pressure_at_surface0
+[ pref ]
+  standard_name = reference_pressure_at_surface
   units = Pa
   type = real | kind = kind_phys
   dimensions = ()

--- a/src/data/physconst.meta
+++ b/src/data/physconst.meta
@@ -92,7 +92,7 @@
   dimensions = ()
   protected = True
 [ rhoh2o ]
-  standard_name = density_of_fresh_liquid_water_at_0c
+  standard_name = fresh_liquid_water_density_at_0c
   long_name = Density of fresh liquid water at 0C
   units = kg m-3
   type = real | kind = kind_phys

--- a/src/data/ref_pres.F90
+++ b/src/data/ref_pres.F90
@@ -171,9 +171,9 @@ contains
       ! pref_edge_in
       call mark_as_initialized("reference_pressure_at_interface")
       ! pref_mid_in
-      call mark_as_initialized("reference_pressure")
+      call mark_as_initialized("reference_pressure_of_atmosphere_layer")
       ! pref_mid_norm
-      call mark_as_initialized("reference_pressure_normalized_by_surface_pressure")
+      call mark_as_initialized("reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure")
       ! ptop_ref
       call mark_as_initialized("air_pressure_at_top_of_atmosphere_model")
       ! num_pr_lev

--- a/src/data/ref_pres.F90
+++ b/src/data/ref_pres.F90
@@ -171,7 +171,7 @@ contains
       ! pref_edge_in
       call mark_as_initialized("reference_pressure_at_interface")
       ! pref_mid_in
-      call mark_as_initialized("reference_pressure_of_atmosphere_layer")
+      call mark_as_initialized("reference_pressure_in_atmosphere_layer")
       ! pref_mid_norm
       call mark_as_initialized("reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure")
       ! ptop_ref

--- a/src/data/ref_pres.F90
+++ b/src/data/ref_pres.F90
@@ -25,10 +25,10 @@ module ref_pres
    real(kind_phys), protected, allocatable :: pref_edge(:)      ! Layer edges
    real(kind_phys), protected, allocatable :: pref_mid(:)       ! Layer midpoints
    real(kind_phys), protected, allocatable :: pref_mid_norm(:)  ! Layer midpoints normalized by
-                                                             ! surface pressure ('eta' coordinate)
+                                                                ! surface pressure ('eta' coordinate)
 
-   real(kind_phys), protected :: ptop_ref             ! Top of model
-   real(kind_phys), protected :: psurf_ref            ! Surface pressure
+   real(kind_phys), protected :: ptop_ref                       ! air pressure at top of model
+                                                                ! reference profile
 
    ! Number of top levels using pure pressure representation
    integer, protected :: num_pr_lev
@@ -117,12 +117,11 @@ contains
       ! arguments
       real(kind_phys), intent(in) :: pref_edge_in(:) ! reference pressure at layer edges (Pa)
       real(kind_phys), intent(in) :: pref_mid_in(:)  ! reference pressure at layer midpoints (Pa)
-      integer,  intent(in) :: num_pr_lev_in   ! number of top levels using pure pressure representation
+      integer,  intent(in) :: num_pr_lev_in          ! number of top levels using pure pressure representation
 
       ! local variables
-
+      real(kind_phys) :: psurf_ref                   ! air pressure at bottom of model reference profile
       integer :: iret ! return status integer
-
       character(len=*), parameter :: subname = 'ref_pres_init'
 
       !---------------------------------------------------------------------------
@@ -177,8 +176,6 @@ contains
       call mark_as_initialized("reference_pressure_normalized_by_surface_pressure")
       ! ptop_ref
       call mark_as_initialized("air_pressure_at_top_of_atmosphere_model")
-      ! psurf_ref
-      call mark_as_initialized("reference_pressure_at_surface")
       ! num_pr_lev
       call mark_as_initialized("number_of_pure_pressure_levels_at_top")
       ! trop_cloud_top_lev

--- a/src/data/ref_pres.meta
+++ b/src/data/ref_pres.meta
@@ -28,12 +28,6 @@
   type = real | kind = kind_phys
   dimensions = ()
   protected = True
-[ psurf_ref ]
-  standard_name = reference_pressure_at_surface
-  units = Pa
-  type = real | kind = kind_phys
-  dimensions = ()
-  protected = True
 [ num_pr_lev ]
   standard_name = number_of_pure_pressure_levels_at_top
   units = count

--- a/src/data/ref_pres.meta
+++ b/src/data/ref_pres.meta
@@ -11,13 +11,13 @@
   dimensions = (vertical_interface_dimension)
   protected = True
 [ pref_mid ]
-  standard_name = reference_pressure
+  standard_name = reference_pressure_of_atmosphere_layer
   units = Pa
   type = real | kind = kind_phys
   dimensions = (vertical_layer_dimension)
   protected = True
 [ pref_mid_norm ]
-  standard_name = reference_pressure_normalized_by_surface_pressure
+  standard_name = reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure
   units = 1
   type = real | kind = kind_phys
   dimensions = (vertical_layer_dimension)

--- a/src/data/ref_pres.meta
+++ b/src/data/ref_pres.meta
@@ -11,7 +11,7 @@
   dimensions = (vertical_interface_dimension)
   protected = True
 [ pref_mid ]
-  standard_name = reference_pressure_of_atmosphere_layer
+  standard_name = reference_pressure_in_atmosphere_layer
   units = Pa
   type = real | kind = kind_phys
   dimensions = (vertical_layer_dimension)

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -38,7 +38,7 @@
       <dimensions>horizontal_dimension</dimensions>
       <ic_file_input_names>psdry state_psdry</ic_file_input_names>
     </variable>
-    <variable local_name="phis" standard_name="geopotential_at_surface"
+    <variable local_name="phis" standard_name="surface_geopotential"
               units="m2 s-2" type="real" kind="kind_phys"
               allocatable="pointer">
       <dimensions>horizontal_dimension</dimensions>
@@ -51,17 +51,17 @@
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>T state_t</ic_file_input_names>
     </variable>
-    <variable local_name="u" standard_name="x_wind"
+    <variable local_name="u" standard_name="eastward_wind"
               units="m s-1" type="real" kind="kind_phys"
               allocatable="pointer">
-      <long_name>Horizontal wind in a direction perpendicular to y_wind</long_name>
+      <long_name>Horizontal wind in a direction perpendicular to northward_wind</long_name>
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>u state_u</ic_file_input_names>
     </variable>
-    <variable local_name="v" standard_name="y_wind"
+    <variable local_name="v" standard_name="northward_wind"
               units="m s-1" type="real" kind="kind_phys"
               allocatable="pointer">
-      <long_name>Horizontal wind in a direction perpendicular to x_wind</long_name>
+      <long_name>Horizontal wind in a direction perpendicular to eastward_wind</long_name>
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>v state_v</ic_file_input_names>
     </variable>
@@ -91,28 +91,28 @@
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>pmiddry state_pmiddry</ic_file_input_names>
     </variable>
-    <variable local_name="pdel" standard_name="pressure_thickness"
+    <variable local_name="pdel" standard_name="air_pressure_thickness"
               units="Pa" type="real" kind="kind_phys"
               allocatable="pointer">
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>pdel state_pdel</ic_file_input_names>
     </variable>
     <variable local_name="pdeldry"
-              standard_name="pressure_thickness_of_dry_air"
+              standard_name="air_pressure_thickness_of_dry_air"
               units="Pa" type="real" kind="kind_phys"
               allocatable="pointer">
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>pdeldry state_pdeldry</ic_file_input_names>
     </variable>
     <variable local_name="rpdel"
-              standard_name="reciprocal_of_pressure_thickness"
+              standard_name="reciprocal_of_air_pressure_thickness"
               units="Pa" type="real" kind="kind_phys"
               allocatable="pointer">
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>rpdel state_rpdel</ic_file_input_names>
     </variable>
     <variable local_name="rpdeldry"
-              standard_name="reciprocal_of_pressure_thickness_of_dry_air"
+              standard_name="reciprocal_of_air_pressure_thickness_of_dry_air"
               units="Pa-1" type="real" kind="kind_phys"
               allocatable="pointer">
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
@@ -133,7 +133,7 @@
       <ic_file_input_names>frontga pbuf_frontga</ic_file_input_names>
     </variable>
     <!-- State helper values -->
-    <variable local_name="lnpmid" standard_name="ln_of_air_pressure"
+    <variable local_name="lnpmid" standard_name="ln_air_pressure"
               units="1" type="real" kind="kind_phys"
               allocatable="pointer">
       <long_name>ln(air pressure)</long_name>
@@ -141,7 +141,7 @@
       <ic_file_input_names>lnpmid state_lnpmid</ic_file_input_names>
     </variable>
     <variable local_name="lnpmiddry"
-              standard_name="ln_of_air_pressure_of_dry_air"
+              standard_name="ln_air_pressure_of_dry_air"
               units="1" type="real" kind="kind_phys"
               allocatable="pointer">
       <long_name>ln(air pressure of dry air)</long_name>
@@ -156,7 +156,7 @@
       <ic_file_input_names>exner state_exner</ic_file_input_names>
     </variable>
     <variable local_name="zm"
-              standard_name="geopotential_height"
+              standard_name="geopotential_height_wrt_surface"
               units="m" type="real" kind="kind_phys"
               allocatable="pointer">
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
@@ -184,7 +184,7 @@
       <ic_file_input_names>pintdry state_pintdry</ic_file_input_names>
     </variable>
     <variable local_name="lnpint"
-              standard_name="ln_of_air_pressure_at_interface"
+              standard_name="ln_air_pressure_at_interface"
               units="1"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -193,7 +193,7 @@
       <ic_file_input_names>lnpint state_lnpint</ic_file_input_names>
     </variable>
     <variable local_name="lnpintdry"
-              standard_name="ln_of_air_pressure_of_dry_air_at_interface"
+              standard_name="ln_air_pressure_of_dry_air_at_interface"
               units="1"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -202,7 +202,7 @@
       <ic_file_input_names>lnpintdry state_lnpintdry</ic_file_input_names>
     </variable>
     <variable local_name="zi"
-              standard_name="geopotential_height_at_interface"
+              standard_name="geopotential_height_wrt_surface_at_interface"
               units="m"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -210,7 +210,7 @@
       <ic_file_input_names>zi state_zi</ic_file_input_names>
     </variable>
     <variable local_name="te_ini"
-              standard_name="column_integrated_total_kinetic_and_static_energy_of_initial_state"
+              standard_name="vertically_integrated_energies_of_initial_state_in_cam"
               units="J m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -218,7 +218,7 @@
       <ic_file_input_names>te_ini state_te_ini</ic_file_input_names>
     </variable>
     <variable local_name="te_cur"
-              standard_name="column_integrated_total_kinetic_and_static_energy_of_current_state"
+              standard_name="vertically_integrated_energies_of_current_state_in_cam"
               units="J m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -226,7 +226,7 @@
       <ic_file_input_names>te_cur state_te_cur</ic_file_input_names>
     </variable>
     <variable local_name="tw_ini"
-              standard_name="column_integrated_total_water_of_initial_state"
+              standard_name="vertically_integrated_total_water_of_initial_state"
               units="kg m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -234,7 +234,7 @@
       <ic_file_input_names>tw_ini state_tw_ini</ic_file_input_names>
     </variable>
     <variable local_name="tw_cur"
-              standard_name="column_integrated_total_water_of_current_state"
+              standard_name="vertically_integrated_total_water_of_current_state"
               units="kg m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -251,18 +251,18 @@
       <ic_file_input_names>dTdt tend_dtdt</ic_file_input_names>
     </variable>
     <variable local_name="dudt_total"
-              standard_name="tendency_of_x_wind_due_to_model_physics"
+              standard_name="tendency_of_eastward_wind_due_to_model_physics"
               units="m s-2" type="real" kind="kind_phys"
               allocatable="pointer">
-      <long_name>Change in x wind from a parameterization</long_name>
+      <long_name>Change in eastward wind from a parameterization</long_name>
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>dudt tend_dudt</ic_file_input_names>
     </variable>
     <variable local_name="dvdt_total"
-              standard_name="tendency_of_y_wind_due_to_model_physics"
+              standard_name="tendency_of_northward_wind_due_to_model_physics"
               units="m s-2" type="real" kind="kind_phys"
               allocatable="pointer">
-      <long_name>Change in y wind from a parameterization</long_name>
+      <long_name>Change in northward wind from a parameterization</long_name>
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>dvdt tend_dvdt</ic_file_input_names>
     </variable>
@@ -281,34 +281,34 @@
     <ddt type="physics_state">
       <data>air_temperature</data>
       <data>dry_static_energy</data>
-      <data>x_wind</data>
-      <data>y_wind</data>
+      <data>eastward_wind</data>
+      <data>northward_wind</data>
       <data>lagrangian_tendency_of_air_pressure</data>
-      <data>pressure_thickness</data>
-      <data>pressure_thickness_of_dry_air</data>
-      <data>reciprocal_of_pressure_thickness</data>
-      <data>reciprocal_of_pressure_thickness_of_dry_air</data>
+      <data>air_pressure_thickness</data>
+      <data>air_pressure_thickness_of_dry_air</data>
+      <data>reciprocal_of_air_pressure_thickness</data>
+      <data>reciprocal_of_air_pressure_thickness_of_dry_air</data>
       <data>air_pressure</data>
       <data>air_pressure_of_dry_air</data>
-      <data>ln_of_air_pressure</data>
-      <data>ln_of_air_pressure_of_dry_air</data>
+      <data>ln_air_pressure</data>
+      <data>ln_air_pressure_of_dry_air</data>
       <data>air_pressure_at_interface</data>
       <data>air_pressure_of_dry_air_at_interface</data>
-      <data>ln_of_air_pressure_at_interface</data>
-      <data>ln_of_air_pressure_of_dry_air_at_interface</data>
+      <data>ln_air_pressure_at_interface</data>
+      <data>ln_air_pressure_of_dry_air_at_interface</data>
       <data>surface_air_pressure</data>
       <data>surface_pressure_of_dry_air</data>
-      <data>geopotential_at_surface</data>
-      <data>geopotential_height</data>
-      <data>geopotential_height_at_interface</data>
+      <data>surface_geopotential</data>
+      <data>geopotential_height_wrt_surface</data>
+      <data>geopotential_height_wrt_surface_at_interface</data>
       <data>inverse_exner_function_wrt_surface_pressure</data>
       <data>frontogenesis_function</data>
       <data>frontogenesis_angle</data>
     </ddt>
     <ddt type="physics_tend">
       <data>tendency_of_air_temperature_due_to_model_physics</data>
-      <data>tendency_of_x_wind_due_to_model_physics</data>
-      <data>tendency_of_y_wind_due_to_model_physics</data>
+      <data>tendency_of_eastward_wind_due_to_model_physics</data>
+      <data>tendency_of_northward_wind_due_to_model_physics</data>
     </ddt>
     <variable local_name="phys_state"
               standard_name="physics_state_due_to_dynamics"

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -162,13 +162,6 @@
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>zm state_zm</ic_file_input_names>
     </variable>
-    <variable local_name = "water_vapor"
-              standard_name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water"
-              units="kg kg-1" type="real" kind="kind_phys"
-              allocatable="pointer">
-      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
-      <ic_file_input_names>Q cnst_Q</ic_file_input_names>
-    </variable>
     <variable local_name="pint" standard_name="air_pressure_at_interface"
               units="Pa"
               type="real" kind="kind_phys"

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -163,7 +163,7 @@
       <ic_file_input_names>zm state_zm</ic_file_input_names>
     </variable>
     <variable local_name = "water_vapor"
-              standard_name="specific_humidity"
+              standard_name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water"
               units="kg kg-1" type="real" kind="kind_phys"
               allocatable="pointer">
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
@@ -339,7 +339,7 @@
       <initial_value>rair</initial_value>
     </variable>
     <variable local_name="cappav"
-              standard_name="composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_at_constant_pressure"
+              standard_name="composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure"
               units="1" type="real" kind="kind_phys"
               allocatable="allocatable">
       <long_name>Composition-dependent ratio of dry air gas constant to specific heat at constant pressure</long_name>
@@ -355,7 +355,7 @@
       <initial_value>mwdry</initial_value>
     </variable>
     <variable local_name="zvirv"
-              standard_name="composition_dependent_ratio_of_water_vapor_to_dry_air_gas_constants_minus_one"
+              standard_name="ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one"
               units="J kg-1 K-1" type="real" kind="kind_phys"
               allocatable="allocatable">
       <long_name>Composition-dependent ratio of water vapor to dry air gas constants minus one</long_name>

--- a/src/data/stdnames_to_inputnames_dictionary.xml
+++ b/src/data/stdnames_to_inputnames_dictionary.xml
@@ -34,7 +34,7 @@
       <ic_file_input_name>state_psdry</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="geopotential_at_surface">
+  <entry stdname="surface_geopotential">
     <ic_file_input_names>
       <ic_file_input_name>phis</ic_file_input_name>
       <ic_file_input_name>state_phis</ic_file_input_name>
@@ -46,13 +46,13 @@
       <ic_file_input_name>state_t</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="x_wind">
+  <entry stdname="eastward_wind">
     <ic_file_input_names>
       <ic_file_input_name>u</ic_file_input_name>
       <ic_file_input_name>state_u</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="y_wind">
+  <entry stdname="northward_wind">
     <ic_file_input_names>
       <ic_file_input_name>v</ic_file_input_name>
       <ic_file_input_name>state_v</ic_file_input_name>
@@ -82,37 +82,37 @@
       <ic_file_input_name>state_pmiddry</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="pressure_thickness">
+  <entry stdname="air_pressure_thickness">
     <ic_file_input_names>
       <ic_file_input_name>pdel</ic_file_input_name>
       <ic_file_input_name>state_pdel</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="pressure_thickness_of_dry_air">
+  <entry stdname="air_pressure_thickness_of_dry_air">
     <ic_file_input_names>
       <ic_file_input_name>pdeldry</ic_file_input_name>
       <ic_file_input_name>state_pdeldry</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="reciprocal_of_pressure_thickness">
+  <entry stdname="reciprocal_of_air_pressure_thickness">
     <ic_file_input_names>
       <ic_file_input_name>rpdel</ic_file_input_name>
       <ic_file_input_name>state_rpdel</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="reciprocal_of_pressure_thickness_of_dry_air">
+  <entry stdname="reciprocal_of_air_pressure_thickness_of_dry_air">
     <ic_file_input_names>
       <ic_file_input_name>rpdeldry</ic_file_input_name>
       <ic_file_input_name>state_rpdeldry</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="ln_of_air_pressure">
+  <entry stdname="ln_air_pressure">
     <ic_file_input_names>
       <ic_file_input_name>lnpmid</ic_file_input_name>
       <ic_file_input_name>state_lnpmid</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="ln_of_air_pressure_of_dry_air">
+  <entry stdname="ln_air_pressure_of_dry_air">
     <ic_file_input_names>
       <ic_file_input_name>lnpmiddry</ic_file_input_name>
       <ic_file_input_name>state_lnpmiddry</ic_file_input_name>
@@ -124,7 +124,7 @@
       <ic_file_input_name>state_exner</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="geopotential_height">
+  <entry stdname="geopotential_height_wrt_surface">
     <ic_file_input_names>
       <ic_file_input_name>zm</ic_file_input_name>
       <ic_file_input_name>state_zm</ic_file_input_name>
@@ -142,43 +142,43 @@
       <ic_file_input_name>state_pintdry</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="ln_of_air_pressure_at_interface">
+  <entry stdname="ln_air_pressure_at_interface">
     <ic_file_input_names>
       <ic_file_input_name>lnpint</ic_file_input_name>
       <ic_file_input_name>state_lnpint</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="ln_of_air_pressure_of_dry_air_at_interface">
+  <entry stdname="ln_air_pressure_of_dry_air_at_interface">
     <ic_file_input_names>
       <ic_file_input_name>lnpintdry</ic_file_input_name>
       <ic_file_input_name>state_lnpintdry</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="geopotential_height_at_interface">
+  <entry stdname="geopotential_height_wrt_surface_at_interface">
     <ic_file_input_names>
       <ic_file_input_name>zi</ic_file_input_name>
       <ic_file_input_name>state_zi</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="column_integrated_total_kinetic_and_static_energy_of_initial_state">
+  <entry stdname="vertically_integrated_energies_of_initial_state_in_cam">
     <ic_file_input_names>
       <ic_file_input_name>te_ini</ic_file_input_name>
       <ic_file_input_name>state_te_ini</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="column_integrated_total_kinetic_and_static_energy_of_current_state">
+  <entry stdname="vertically_integrated_energies_of_current_state_in_cam">
     <ic_file_input_names>
       <ic_file_input_name>te_cur</ic_file_input_name>
       <ic_file_input_name>state_te_cur</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="column_integrated_total_water_of_initial_state">
+  <entry stdname="vertically_integrated_total_water_of_initial_state">
     <ic_file_input_names>
       <ic_file_input_name>tw_ini</ic_file_input_name>
       <ic_file_input_name>state_tw_ini</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="column_integrated_total_water_of_current_state">
+  <entry stdname="vertically_integrated_total_water_of_current_state">
     <ic_file_input_names>
       <ic_file_input_name>tw_cur</ic_file_input_name>
       <ic_file_input_name>state_tw_cur</ic_file_input_name>
@@ -196,13 +196,13 @@
       <ic_file_input_name>tend_dtdt</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="tendency_of_x_wind_due_to_model_physics">
+  <entry stdname="tendency_of_eastward_wind_due_to_model_physics">
     <ic_file_input_names>
       <ic_file_input_name>dudt</ic_file_input_name>
       <ic_file_input_name>tend_dudt</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="tendency_of_y_wind_due_to_model_physics">
+  <entry stdname="tendency_of_northward_wind_due_to_model_physics">
     <ic_file_input_names>
       <ic_file_input_name>dvdt</ic_file_input_name>
       <ic_file_input_name>tend_dvdt</ic_file_input_name>
@@ -226,13 +226,13 @@
       <ic_file_input_name>cnst_CLDICE</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="rain_water_mixing_ratio_wrt_moist_air">
+  <entry stdname="rain_mixing_ratio_wrt_moist_air_and_condensed_water">
     <ic_file_input_names>
       <ic_file_input_name>RAINQM</ic_file_input_name>
       <ic_file_input_name>cnst_RAINQM</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="snow_water_mixing_ratio_wrt_moist_air">
+  <entry stdname="snow_mixing_ratio_wrt_moist_air_and_condensed_water">
     <ic_file_input_names>
       <ic_file_input_name>SNOWQM</ic_file_input_name>
       <ic_file_input_name>cnst_SNOWQM</ic_file_input_name>

--- a/src/data/stdnames_to_inputnames_dictionary.xml
+++ b/src/data/stdnames_to_inputnames_dictionary.xml
@@ -208,19 +208,19 @@
       <ic_file_input_name>tend_dvdt</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="specific_humidity">
+  <entry stdname="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water">
     <ic_file_input_names>
       <ic_file_input_name>Q</ic_file_input_name>
       <ic_file_input_name>cnst_Q</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="cloud_liquid_water_mixing_ratio_wrt_moist_air">
+  <entry stdname="cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water">
     <ic_file_input_names>
       <ic_file_input_name>CLDLIQ</ic_file_input_name>
       <ic_file_input_name>cnst_CLDLIQ</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="cloud_ice_mixing_ratio_wrt_moist_air">
+  <entry stdname="cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water">
     <ic_file_input_names>
       <ic_file_input_name>CLDICE</ic_file_input_name>
       <ic_file_input_name>cnst_CLDICE</ic_file_input_name>

--- a/src/data/write_init_files.py
+++ b/src/data/write_init_files.py
@@ -36,6 +36,10 @@ _PHYS_VARS_PREAMBLE_INCS = ["cam_var_init_marks_decl.inc"]
 # Include files to insert in the module body
 _PHYS_VARS_BODY_INCS = ["cam_var_init_marks.inc"]
 
+# Increase allowed line lengths needed to fit extra-long CCPP standard names:
+_LINE_FILL_LEN = 150
+_MAX_LINE_LEN = 200
+
 ##############
 #Main function
 ##############
@@ -150,7 +154,8 @@ def write_init_files(cap_database, ic_names, outdir,
     # Open file using CCPP's FortranWriter:
     file_desc = "Initialization-checking source file"
     with FortranWriter(ofilename, "w", file_desc,
-                       phys_check_fname_str, indent=indent) as outfile:
+                       phys_check_fname_str,
+                       indent=indent) as outfile:
 
         # Add boilerplate code:
         outfile.write_preamble()
@@ -202,8 +207,11 @@ def write_init_files(cap_database, ic_names, outdir,
 
     # Open file using CCPP's FortranWriter:
     file_desc = f"Initial conditions source file, {phys_input_filename}"
-    with FortranWriter(ofilename, "w", file_desc, phys_input_fname_str,
-                       indent=indent) as outfile:
+    with FortranWriter(ofilename, "w", file_desc,
+                       phys_input_fname_str,
+                       indent=indent,
+                       line_fill=_LINE_FILL_LEN,
+                       line_max=_MAX_LINE_LEN) as outfile:
 
         # Add boilerplate code:
         outfile.write_preamble()

--- a/src/data/write_init_files.py
+++ b/src/data/write_init_files.py
@@ -20,11 +20,11 @@ from var_props import is_horizontal_dimension, is_vertical_dimension
 # Some are from the CCPP framework (e.g., ccpp_num_constituents)
 # Some are for efficiency and to avoid dependency loops (e.g., log_output_unit)
 _EXCLUDED_STDNAMES = {'suite_name', 'suite_part',
-                          'ccpp_num_constituents',
-                          'ccpp_num_advected_constituents',
-                          'ccpp_constituent_array',
-                          'ccpp_constituent_properties_array',
-                          'ccpp_constituent_array_minimum_values',
+                          'number_of_ccpp_constituents',
+                          'number_of_ccpp_advected_constituents',
+                          'ccpp_constituents',
+                          'ccpp_constituent_properties',
+                          'ccpp_constituent_minimum_values',
                           'log_output_unit', 'do_log_output',
                           'mpi_communicator', 'mpi_root', 'mpi_rank',
                           'number_of_mpi_tasks'}
@@ -155,6 +155,8 @@ def write_init_files(cap_database, ic_names, outdir,
     file_desc = "Initialization-checking source file"
     with FortranWriter(ofilename, "w", file_desc,
                        phys_check_fname_str,
+                       line_fill=_LINE_FILL_LEN,
+                       line_max=_MAX_LINE_LEN,
                        indent=indent) as outfile:
 
         # Add boilerplate code:

--- a/src/data/write_init_files.py
+++ b/src/data/write_init_files.py
@@ -825,6 +825,7 @@ def write_phys_read_subroutine(outfile, host_dict, host_vars, host_imports,
     # Add use statements:
     use_stmts = [["pio", ["file_desc_t"]],
                  ["cam_abortutils", ["endrun"]],
+                 ["spmd_utils", ["masterproc"]],
                  ["shr_kind_mod", ["SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX"]],
                  ["physics_data", ["read_field", "find_input_name_idx",
                                    "no_exist_idx", "init_mark_idx",

--- a/src/dynamics/none/dyn_grid.F90
+++ b/src/dynamics/none/dyn_grid.F90
@@ -213,8 +213,10 @@ CONTAINS
               '(a,i4,i9,2i7)', (/ num_local_columns, col_start, col_end/))
       end if
       ! Find a 3D variable and get its dimensions
-      call cam_pio_find_var(fh_ini, (/ 'U      ', 'state_u', 'eastward_wind ' /),         &
-           fieldname, vardesc, var_found)
+      call cam_pio_find_var(fh_ini, (/ 'U            ',                       &
+                                       'state_u      ',                       &
+                                       'eastward_wind' /),                    &
+                            fieldname, vardesc, var_found)
       if (var_found) then
          ! Find the variable dimension info
          dimnames = ''

--- a/src/dynamics/none/dyn_grid.F90
+++ b/src/dynamics/none/dyn_grid.F90
@@ -213,7 +213,7 @@ CONTAINS
               '(a,i4,i9,2i7)', (/ num_local_columns, col_start, col_end/))
       end if
       ! Find a 3D variable and get its dimensions
-      call cam_pio_find_var(fh_ini, (/ 'U      ', 'state_u', 'x_wind ' /),         &
+      call cam_pio_find_var(fh_ini, (/ 'U      ', 'state_u', 'eastward_wind ' /),         &
            fieldname, vardesc, var_found)
       if (var_found) then
          ! Find the variable dimension info

--- a/src/dynamics/se/dp_coupling.F90
+++ b/src/dynamics/se/dp_coupling.F90
@@ -559,7 +559,6 @@ subroutine derived_phys_dry(cam_runtime_opts, phys_state, phys_tend)
    use cam_thermo,        only: cam_thermo_update
    use physics_types,     only: cpairv, rairv, zvirv
    use physics_grid,      only: columns_on_task
-   use shr_const_mod,     only: shr_const_rwv
    use geopotential_temp, only: geopotential_temp_run
    use static_energy,     only: update_dry_static_energy_run
 !   use qneg,              only: qneg_run

--- a/src/dynamics/se/dp_coupling.F90
+++ b/src/dynamics/se/dp_coupling.F90
@@ -589,7 +589,7 @@ subroutine derived_phys_dry(cam_runtime_opts, phys_state, phys_tend)
    ! Set constituent indices
    call const_get_index('specific_humidity', ix_q)
    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air', ix_cld_liq)
-   call const_get_index('rain_water_mixing_ratio_wrt_moist_air', ix_rain)
+   call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix_rain)
 
    ! Grab pointer to constituent array
    const_data_ptr => cam_constituents_array()

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -911,10 +911,10 @@ subroutine dyn_init(cam_runtime_opts, dyn_in, dyn_out)
    end if
    call phys_getopts(history_budget_out=history_budget, history_budget_histfile_num_out=budget_hfile_num)
    if ( history_budget ) then
-      call const_get_index('specific_humidity', ixq)
-      call const_get_index('cloud_liquid_water_mixing_ratio_wrt_total_mass',  &
+      call const_get_index('water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water', ixq)
+      call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water',  &
            ixcldliq)
-      call const_get_index('cloud_ice_water_mixing_ratio_wrt_total_mass', ixcldice)
+      call const_get_index('cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water', ixcldice)
       call add_default(tottnam(     ixq), budget_hfile_num, ' ')
       call add_default(tottnam(ixcldliq), budget_hfile_num, ' ')
       call add_default(tottnam(ixcldice), budget_hfile_num, ' ')

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -1812,9 +1812,9 @@ subroutine read_inidat(dyn_in)
    !Finally, mark variables as initialized so that physics doesn't try to set
    !the initial values itself:
    call mark_as_initialized("surface_air_pressure")
-   call mark_as_initialized("pressure_thickness")
-   call mark_as_initialized("x_wind") !eastward wind
-   call mark_as_initialized("y_wind") !northward wind
+   call mark_as_initialized("air_pressure_thickness")
+   call mark_as_initialized("eastward_wind")  !eastward wind
+   call mark_as_initialized("northward_wind") !northward wind
    call mark_as_initialized("air_temperature")
 
    !Mark all constituents as initialized
@@ -1824,28 +1824,28 @@ subroutine read_inidat(dyn_in)
 
    !These calls may be removed if geopotential_t is only allowed to run
    !in a CCPP physics suite:
-   call mark_as_initialized("geopotential_height")
-   call mark_as_initialized("geopotential_height_at_interface")
+   call mark_as_initialized("geopotential_height_wrt_surface")
+   call mark_as_initialized("geopotential_height_wrt_surface_at_interface")
    call mark_as_initialized("dry_static_energy")
 
    !These variables are calculated in d_p_coupling, but need to be marked here:
    call mark_as_initialized("air_pressure")
-   call mark_as_initialized("ln_of_air_pressure")
+   call mark_as_initialized("ln_air_pressure")
    call mark_as_initialized("air_pressure_at_interface")
-   call mark_as_initialized("ln_of_air_pressure_at_interface")
-   call mark_as_initialized("pressure_thickness_of_dry_air")
+   call mark_as_initialized("ln_air_pressure_at_interface")
+   call mark_as_initialized("air_pressure_thickness_of_dry_air")
    call mark_as_initialized("surface_pressure_of_dry_air")
    call mark_as_initialized("air_pressure_of_dry_air")
    call mark_as_initialized("air_pressure_of_dry_air_at_interface")
-   call mark_as_initialized("ln_of_air_pressure_of_dry_air_at_interface")
-   call mark_as_initialized("ln_of_air_pressure_of_dry_air")
-   call mark_as_initialized("reciprocal_of_pressure_thickness_of_dry_air")
-   call mark_as_initialized("reciprocal_of_pressure_thickness")
+   call mark_as_initialized("ln_air_pressure_of_dry_air_at_interface")
+   call mark_as_initialized("ln_air_pressure_of_dry_air")
+   call mark_as_initialized("reciprocal_of_air_pressure_thickness_of_dry_air")
+   call mark_as_initialized("reciprocal_of_air_pressure_thickness")
    call mark_as_initialized("inverse_exner_function_wrt_surface_pressure")
    call mark_as_initialized("lagrangian_tendency_of_air_pressure")
    call mark_as_initialized("tendency_of_air_temperature_due_to_model_physics")
-   call mark_as_initialized("tendency_of_x_wind_due_to_model_physics")
-   call mark_as_initialized("tendency_of_y_wind_due_to_model_physics")
+   call mark_as_initialized("tendency_of_eastward_wind_due_to_model_physics")
+   call mark_as_initialized("tendency_of_northward_wind_due_to_model_physics")
 
 end subroutine read_inidat
 
@@ -2112,7 +2112,7 @@ subroutine set_phis(dyn_in)
 
    !Mark phis as initialized so that physics doesn't try to set
    !the initial values itself:
-   call mark_as_initialized("geopotential_at_surface")
+   call mark_as_initialized("surface_geopotential")
 
 end subroutine set_phis
 

--- a/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
+++ b/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
@@ -118,7 +118,7 @@ contains
 
     !set constituent indices
     call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air', ix_cld_liq)
-    call const_get_index('rain_water_mixing_ratio_wrt_moist_air', ix_rain)
+    call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix_rain)
 
     ncol = size(latvals, 1)
     nlev = -1

--- a/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
+++ b/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
@@ -117,7 +117,7 @@ contains
     end if
 
     !set constituent indices
-    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air', ix_cld_liq)
+    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water', ix_cld_liq)
     call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix_rain)
 
     ncol = size(latvals, 1)

--- a/src/dynamics/tests/initial_conditions/ic_baroclinic.F90
+++ b/src/dynamics/tests/initial_conditions/ic_baroclinic.F90
@@ -160,7 +160,7 @@ contains
     end if
 
     call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air', ix_cld_liq)
-    call const_get_index('rain_water_mixing_ratio_wrt_moist_air', ix_rain)
+    call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix_rain)
 
     if (present(verbose)) then
       verbose_use = verbose

--- a/src/dynamics/tests/initial_conditions/ic_baroclinic.F90
+++ b/src/dynamics/tests/initial_conditions/ic_baroclinic.F90
@@ -159,7 +159,7 @@ contains
       mask_use = .true.
     end if
 
-    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air', ix_cld_liq)
+    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water', ix_cld_liq)
     call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix_rain)
 
     if (present(verbose)) then

--- a/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
+++ b/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
@@ -77,7 +77,7 @@ CONTAINS
     end if
 
     !set constituent indices
-    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air', ix_cld_liq)
+    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water', ix_cld_liq)
     call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix_rain)
 
     ncol = size(latvals, 1)

--- a/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
+++ b/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
@@ -78,7 +78,7 @@ CONTAINS
 
     !set constituent indices
     call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air', ix_cld_liq)
-    call const_get_index('rain_water_mixing_ratio_wrt_moist_air', ix_rain)
+    call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix_rain)
 
     ncol = size(latvals, 1)
     nlev = -1

--- a/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
+++ b/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
@@ -77,8 +77,10 @@ CONTAINS
     end if
 
     !set constituent indices
-    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water', ix_cld_liq)
-    call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix_rain)
+    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water', &
+                         ix_cld_liq, abort=.false.)
+    call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', &
+                         ix_rain, abort=.false.)
 
     ncol = size(latvals, 1)
     nlev = -1

--- a/src/dynamics/utils/hycoef.F90
+++ b/src/dynamics/utils/hycoef.F90
@@ -98,7 +98,7 @@ subroutine hycoef_init(file, psdry)
 
    !-----------------------------------------------------------------------
 
-   ! Initalize reference pressures:
+   ! Initalize reference pressure:
    ps0 = real(pref, r8)  ! Reference pressure (pascals)
 
    ! Allocate public variables:

--- a/src/dynamics/utils/hycoef.F90
+++ b/src/dynamics/utils/hycoef.F90
@@ -36,7 +36,6 @@ real(r8), public, allocatable :: hypm(:)    ! reference pressures at midpoints
 real(r8), public, allocatable :: hypd(:)    ! reference pressure layer thickness
 
 real(r8), public, protected :: ps0    ! Base state surface pressure (pascals)
-real(r8), public, protected :: psr    ! Reference surface pressure (pascals)
 
 real(r8), allocatable, target :: alev(:)   ! level values (pascals) for 'lev' coord
 real(r8), allocatable, target :: ailev(:)  ! interface level values for 'ilev' coord
@@ -55,7 +54,7 @@ contains
 subroutine hycoef_init(file, psdry)
 
 !   use cam_history_support, only: add_hist_coord, add_vert_coord, formula_terms_t
-   use physconst,    only: ps_base, ps_ref
+   use physconst,    only: pref
    use string_utils, only: to_str
 
    !-----------------------------------------------------------------------
@@ -100,8 +99,7 @@ subroutine hycoef_init(file, psdry)
    !-----------------------------------------------------------------------
 
    ! Initalize reference pressures:
-   ps0 = real(ps_base, r8) ! Base state surface pressure (pascals)
-   psr = real(ps_ref, r8)  ! Reference surface pressure (pascals)
+   ps0 = real(pref, r8)  ! Reference pressure (pascals)
 
    ! Allocate public variables:
 
@@ -191,13 +189,13 @@ subroutine hycoef_init(file, psdry)
    ! pressures
    do k=1,pver
       hybd(k) = hybi(k+1) - hybi(k)
-      hypm(k) = hyam(k)*ps0 + hybm(k)*psr
+      hypm(k) = hyam(k)*ps0 + hybm(k)*ps0
       etamid(k) = hyam(k) + hybm(k)
    end do
 
    ! Reference state interface pressures
    do k=1,pverp
-      hypi(k) = hyai(k)*ps0 + hybi(k)*psr
+      hypi(k) = hyai(k)*ps0 + hybi(k)*ps0
    end do
 
    ! Reference state layer thicknesses
@@ -437,12 +435,9 @@ subroutine hycoef_read(File)
       if (ierr /= PIO_NOERR) then
          call endrun(routine//': reading P0.')
       end if
-      psr = ps0
-
       if (masterproc) then
          write(iulog,*) routine//': read P0 value: ', ps0
       end if
-
    end if
 
    ! Put the error handling back the way it was

--- a/src/dynamics/utils/vert_coord.meta
+++ b/src/dynamics/utils/vert_coord.meta
@@ -19,28 +19,28 @@
   type = integer
   protected = True
 [ index_top_layer ]
-  standard_name = index_of_top_vertical_layer
+  standard_name = vertical_index_at_top_adjacent_layer
   long_name = Vertical coordinate index for uppermost layer
   units = index
   dimensions = ()
   type = integer
   protected = True
 [ index_bottom_layer ]
-  standard_name = index_of_bottom_vertical_layer
+  standard_name = vertical_index_at_surface_adjacent_layer
   long_name = Vertical coordinate index for lowest layer
   units = index
   dimensions = ()
   type = integer
   protected = True
 [ index_top_interface ]
-  standard_name = index_of_top_vertical_interface
+  standard_name = vertical_index_at_top_interface
   long_name = Vertical coordinate index for uppermost interface
   units = index
   dimensions = ()
   type = integer
   protected = True
 [ index_bottom_interface ]
-  standard_name = index_of_bottom_vertical_interface
+  standard_name = vertical_index_at_surface_interface
   long_name = Vertical coordinate index for lowest interface
   units = index
   dimensions = ()

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -18,7 +18,9 @@ module cam_constituents
    public :: const_is_moist
    public :: const_is_wet
    public :: const_is_thermo_active
+   public :: const_is_water_species
    public :: const_set_thermo_active
+   public :: const_set_water_species
    public :: const_qmin
    public :: const_set_qmin
 
@@ -60,10 +62,20 @@ module cam_constituents
       module procedure const_is_thermo_active_index
    end interface const_is_thermo_active
 
+   interface const_is_water_species
+      module procedure const_is_water_species_obj
+      module procedure const_is_water_species_index
+   end interface const_is_water_species
+
    interface const_set_thermo_active
       module procedure const_set_thermo_active_obj
       module procedure const_set_thermo_active_index
    end interface const_set_thermo_active
+
+   interface const_set_water_species
+      module procedure const_set_water_species_obj
+      module procedure const_set_water_species_index
+   end interface const_set_water_species
 
    interface const_qmin
       module procedure const_qmin_obj
@@ -483,7 +495,8 @@ CONTAINS
 
    logical function const_is_thermo_active_index(const_ind)
 
-      ! Return .true. if the constituent at <index> is wet
+      ! Return .true. if the constituent at <index> is
+      ! thermodynamically-active
       ! Dummy argument
       integer, intent(in) :: const_ind
       ! Local variable
@@ -494,6 +507,46 @@ CONTAINS
       end if
 
    end function const_is_thermo_active_index
+
+   !#######################################################################
+
+   logical function const_is_water_species_obj(const_obj)
+      use cam_abortutils, only: endrun
+      use string_utils,   only: to_str
+
+      ! Return .true. if the constituent object, <const_obj>, is
+      ! a type (species) of water
+      ! Dummy argument
+      type(ccpp_constituent_prop_ptr_t), intent(in) :: const_obj
+      ! Local variables
+      integer                     :: err_code
+      character(len=256)          :: err_msg
+      character(len=*), parameter :: subname = 'const_is_water_species_obj: '
+
+      call const_obj%is_water_species(const_is_water_species_obj, err_code, err_msg)
+      if (err_code /= 0) then
+         call endrun(subname//"Error "//to_str(err_code)//": "//           &
+              trim(err_msg), file=__FILE__, line=__LINE__)
+      end if
+
+   end function const_is_water_species_obj
+
+   !#######################################################################
+
+   logical function const_is_water_species_index(const_ind)
+
+      ! Return .true. if the constituent at <index> is
+      ! a type (species) of water
+      ! Dummy argument
+      integer, intent(in) :: const_ind
+      ! Local variable
+      character(len=*), parameter :: subname = 'const_is_water_species_index: '
+
+      if (check_index_bounds(const_ind, subname)) then
+         const_is_water_species_index = const_is_water_species(const_props(const_ind))
+      end if
+
+   end function const_is_water_species_index
 
    !#######################################################################
 
@@ -539,6 +592,48 @@ CONTAINS
 
    !#######################################################################
 
+   subroutine const_set_water_species_obj(const_obj, water_species)
+      use cam_abortutils, only: endrun
+      use string_utils,   only: to_str
+
+      ! Set the value for the 'water_species' property for the constituent
+      !object, <const_obj>.
+      ! Dummy argument
+      type(ccpp_constituent_prop_ptr_t), intent(inout) :: const_obj
+      logical, intent(in)                              :: water_species
+      ! Local variables
+      integer                     :: err_code
+      character(len=256)          :: err_msg
+      character(len=*), parameter :: subname = 'const_set_water_species_obj: '
+
+      call const_obj%set_water_species(water_species, err_code, err_msg)
+      if (err_code /= 0) then
+         call endrun(subname//"Error "//to_str(err_code)//": "//           &
+              trim(err_msg), file=__FILE__, line=__LINE__)
+      end if
+
+   end subroutine const_set_water_species_obj
+
+   !#######################################################################
+
+   subroutine const_set_water_species_index(const_ind, water_species)
+
+      ! Set the value for the 'water_species' property for the constituent
+      !object index, <const_ind>.
+      ! Dummy argument
+      integer, intent(in) :: const_ind
+      logical, intent(in) :: water_species
+      ! Local variable
+      character(len=*), parameter :: subname = 'const_set_water_species_index: '
+
+      if (check_index_bounds(const_ind, subname)) then
+         call const_set_water_species(const_props(const_ind), water_species)
+      end if
+
+   end subroutine const_set_water_species_index
+
+   !#######################################################################
+
    real(kind_phys) function const_qmin_obj(const_obj)
       use cam_abortutils, only: endrun
       use string_utils,   only: to_str
@@ -581,7 +676,7 @@ CONTAINS
       use cam_abortutils, only: endrun
       use string_utils,   only: to_str
 
-      ! Set the 'minimum value' property for the constituent
+      ! Set the minimum value property for the constituent
       !object, <const_obj>.
       ! Dummy argument
       type(ccpp_constituent_prop_ptr_t), intent(inout) :: const_obj
@@ -603,7 +698,7 @@ CONTAINS
 
    subroutine const_set_qmin_index(const_ind, qmin_val)
 
-      ! Set the value for the 'thermo_active' property for the constituent
+      ! Set the value for the minimu value property for the constituent
       !object index, <const_ind>.
       ! Dummy argument
       integer, intent(in)         :: const_ind

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -498,8 +498,8 @@ CONTAINS
       ! Set the value for the 'thermo_active' property for the constituent
       !object, <const_obj>.
       ! Dummy argument
-      type(ccpp_constituent_prop_ptr_t), intent(in) :: const_obj
-      logical, intent(in)                           :: thermo_active
+      type(ccpp_constituent_prop_ptr_t), intent(inout) :: const_obj
+      logical, intent(in)                              :: thermo_active
       ! Local variables
       integer                     :: err_code
       character(len=256)          :: err_msg
@@ -526,7 +526,7 @@ CONTAINS
       character(len=*), parameter :: subname = 'const_set_thermo_active_index: '
 
       if (check_index_bounds(const_ind, subname)) then
-         const_is_thermo_active_index = const_set_thermo_active(const_props(const_ind))
+         call const_set_thermo_active(const_props(const_ind), thermo_active)
       end if
 
    end subroutine const_set_thermo_active_index

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -20,6 +20,7 @@ module cam_constituents
    public :: const_is_thermo_active
    public :: const_set_thermo_active
    public :: const_qmin
+   public :: const_set_qmin
 
    ! Private array of constituent properties (for property interface functions)
    type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:) => NULL()
@@ -68,6 +69,11 @@ module cam_constituents
       module procedure const_qmin_obj
       module procedure const_qmin_index
    end interface const_qmin
+
+   interface const_set_qmin
+      module procedure const_set_qmin_obj
+      module procedure const_set_qmin_index
+   end interface
 
    ! Private interfaces
    private :: check_index_bounds
@@ -568,6 +574,48 @@ CONTAINS
       end if
 
    end function const_qmin_index
+
+   !#######################################################################
+
+   subroutine const_set_qmin_obj(const_obj, qmin_val)
+      use cam_abortutils, only: endrun
+      use string_utils,   only: to_str
+
+      ! Set the 'minimum value' property for the constituent
+      !object, <const_obj>.
+      ! Dummy argument
+      type(ccpp_constituent_prop_ptr_t), intent(inout) :: const_obj
+      real(kind_phys),                   intent(in)    :: qmin_val
+      ! Local variables
+      integer                     :: err_code
+      character(len=256)          :: err_msg
+      character(len=*), parameter :: subname = 'const_set_qmin_obj: '
+
+      call const_obj%set_minimum(qmin_val, err_code, err_msg)
+      if (err_code /= 0) then
+         call endrun(subname//"Error "//to_str(err_code)//": "//           &
+              trim(err_msg), file=__FILE__, line=__LINE__)
+      end if
+
+   end subroutine const_set_qmin_obj
+
+   !#######################################################################
+
+   subroutine const_set_qmin_index(const_ind, qmin_val)
+
+      ! Set the value for the 'thermo_active' property for the constituent
+      !object index, <const_ind>.
+      ! Dummy argument
+      integer, intent(in)         :: const_ind
+      real(kind_phys), intent(in) :: qmin_val
+      ! Local variable
+      character(len=*), parameter :: subname = 'const_set_qmin_index: '
+
+      if (check_index_bounds(const_ind, subname)) then
+         call const_set_qmin(const_props(const_ind), qmin_val)
+      end if
+
+   end subroutine const_set_qmin_index
 
    !#######################################################################
 

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -17,6 +17,8 @@ module cam_constituents
    public :: const_is_dry
    public :: const_is_moist
    public :: const_is_wet
+   public :: const_is_thermo_active
+   public :: const_set_thermo_active
    public :: const_qmin
 
    ! Private array of constituent properties (for property interface functions)
@@ -51,6 +53,16 @@ module cam_constituents
       module procedure const_is_wet_obj
       module procedure const_is_wet_index
    end interface const_is_wet
+
+   interface const_is_thermo_active
+      module procedure const_is_thermo_active_obj
+      module procedure const_is_thermo_active_index
+   end interface const_is_thermo_active
+
+   interface const_set_thermo_active
+      module procedure const_set_thermo_active_obj
+      module procedure const_set_thermo_active_index
+   end interface const_set_thermo_active
 
    interface const_qmin
       module procedure const_qmin_obj
@@ -437,6 +449,87 @@ CONTAINS
       end if
 
    end function const_is_wet_index
+
+   !#######################################################################
+
+   logical function const_is_thermo_active_obj(const_obj)
+      use cam_abortutils, only: endrun
+      use string_utils,   only: to_str
+
+      ! Return .true. if the constituent object, <const_obj>, is
+      ! thermodynamically-active
+      ! Dummy argument
+      type(ccpp_constituent_prop_ptr_t), intent(in) :: const_obj
+      ! Local variables
+      integer                     :: err_code
+      character(len=256)          :: err_msg
+      character(len=*), parameter :: subname = 'const_is_thermo_active_obj: '
+
+      call const_obj%is_thermo_active(const_is_thermo_active_obj, err_code, err_msg)
+      if (err_code /= 0) then
+         call endrun(subname//"Error "//to_str(err_code)//": "//           &
+              trim(err_msg), file=__FILE__, line=__LINE__)
+      end if
+
+   end function const_is_thermo_active_obj
+
+   !#######################################################################
+
+   logical function const_is_thermo_active_index(const_ind)
+
+      ! Return .true. if the constituent at <index> is wet
+      ! Dummy argument
+      integer, intent(in) :: const_ind
+      ! Local variable
+      character(len=*), parameter :: subname = 'const_is_thermo_active_index: '
+
+      if (check_index_bounds(const_ind, subname)) then
+         const_is_thermo_active_index = const_is_thermo_active(const_props(const_ind))
+      end if
+
+   end function const_is_thermo_active_index
+
+   !#######################################################################
+
+   subroutine const_set_thermo_active_obj(const_obj, thermo_active)
+      use cam_abortutils, only: endrun
+      use string_utils,   only: to_str
+
+      ! Set the value for the 'thermo_active' property for the constituent
+      !object, <const_obj>.
+      ! Dummy argument
+      type(ccpp_constituent_prop_ptr_t), intent(in) :: const_obj
+      logical, intent(in)                           :: thermo_active
+      ! Local variables
+      integer                     :: err_code
+      character(len=256)          :: err_msg
+      character(len=*), parameter :: subname = 'const_set_thermo_active_obj: '
+
+      call const_obj%set_thermo_active(thermo_active, err_code, err_msg)
+      if (err_code /= 0) then
+         call endrun(subname//"Error "//to_str(err_code)//": "//           &
+              trim(err_msg), file=__FILE__, line=__LINE__)
+      end if
+
+   end subroutine const_set_thermo_active_obj
+
+   !#######################################################################
+
+   subroutine const_set_thermo_active_index(const_ind, thermo_active)
+
+      ! Set the value for the 'thermo_active' property for the constituent
+      !object index, <const_ind>.
+      ! Dummy argument
+      integer, intent(in) :: const_ind
+      logical, intent(in) :: thermo_active
+      ! Local variable
+      character(len=*), parameter :: subname = 'const_set_thermo_active_index: '
+
+      if (check_index_bounds(const_ind, subname)) then
+         const_is_thermo_active_index = const_set_thermo_active(const_props(const_ind))
+      end if
+
+   end subroutine const_set_thermo_active_index
 
    !#######################################################################
 

--- a/src/physics/utils/physics_data.F90
+++ b/src/physics/utils/physics_data.F90
@@ -352,9 +352,9 @@ CONTAINS
       integer                          :: mpi_stat(mpi_status_size) !For MPI
       real(kind_phys), allocatable     :: buffer(:)
       integer                          :: diff_count
-      real(kind_phys)                  :: max_diff(2,1)    !Stores the local max diff and its MPI rank
+      real(kind_phys)                  :: max_diff(2)    !Stores the local max diff and its MPI rank
       integer                          :: max_diff_col
-      real(kind_phys)                  :: max_diff_gl(2,1) !Stores the global max diff and its MPI rank
+      real(kind_phys)                  :: max_diff_gl(2) !Stores the global max diff and its MPI rank
       integer                          :: max_diff_gl_col
       integer                          :: diff_count_gl
 
@@ -365,8 +365,8 @@ CONTAINS
       max_diff_col  = 0
       diff_count    = 0
       diff          = 0._kind_phys
-      max_diff(1,1) = 0._kind_phys
-      max_diff(2,1) = real(iam, kind_phys) !MPI rank for this task
+      max_diff(1) = 0._kind_phys
+      max_diff(2) = real(iam, kind_phys) !MPI rank for this task
 
       call cam_pio_find_var(file, var_names, found_name, vardesc, var_found)
       if (var_found) then
@@ -382,8 +382,8 @@ CONTAINS
                   diff = abs(current_value(col) - buffer(col)) /              &
                      abs(current_value(col))
                end if
-               if (diff > max_diff(1,1)) then
-                  max_diff(1,1)  = diff
+               if (diff > max_diff(1)) then
+                  max_diff(1)  = diff
                   max_diff_col = col
                end if
                if (diff > min_difference) then
@@ -398,19 +398,19 @@ CONTAINS
                                MPI_2DOUBLE_PRECISION,                         &
                                mpi_maxloc, mpicom, ierr)
 
-            if (iam == int(max_diff_gl(2,1)) .and. .not. masterproc) then
+            if (iam == int(max_diff_gl(2)) .and. .not. masterproc) then
                !The largest diff happened on this task, so the local max is
                !is the global max. So send the local max value's dimension
                !index (usually column index) to the root task:
                call mpi_send(max_diff_col, 1, mpi_integer, masterprocid, 0,   &
                              mpicom, ierr)
-            else if (iam /= int(max_diff_gl(2,1)) .and. masterproc) then
+            else if (iam /= int(max_diff_gl(2)) .and. masterproc) then
                !The root task needs to receive the relevant max diff index
                !from a different task:
                call mpi_recv(max_diff_gl_col, 1, mpi_integer,                 &
-                             int(max_diff_gl(2,1)), 0, mpicom,                &
+                             int(max_diff_gl(2)), 0, mpicom,                &
                              mpi_stat, ierr)
-            else if (masterprocid == int(max_diff_gl(2,1))) then
+            else if (masterprocid == int(max_diff_gl(2))) then
                !The biggest difference is on the root MPI task already,
                !so just set directly:
                max_diff_gl_col = max_diff_col
@@ -420,8 +420,8 @@ CONTAINS
             if (masterproc) then
                if (diff_count_gl > 0) then
                   call write_check_field_entry(stdname, diff_count_gl,        &
-                                               max_diff_gl(1,1),              &
-                                               int(max_diff_gl(2,1)),         &
+                                               max_diff_gl(1),              &
+                                               int(max_diff_gl(2)),         &
                                                max_diff_gl_col, is_first)
                   is_first = .false.
                end if
@@ -471,10 +471,10 @@ CONTAINS
       integer                          :: lev
       real(kind_phys), allocatable     :: buffer(:,:)
       integer                          :: diff_count
-      real(kind_phys)                  :: max_diff(2,1)    !Stores the local max diff and its MPI rank
+      real(kind_phys)                  :: max_diff(2)    !Stores the local max diff and its MPI rank
       integer                          :: max_diff_col
       integer                          :: max_diff_lev
-      real(kind_phys)                  :: max_diff_gl(2,1) !Stores the global max diff and its MPI rank
+      real(kind_phys)                  :: max_diff_gl(2) !Stores the global max diff and its MPI rank
       integer                          :: max_diff_gl_col
       integer                          :: max_diff_gl_lev
       integer                          :: diff_count_gl
@@ -488,8 +488,8 @@ CONTAINS
       max_diff_lev  = 0
       diff_count    = 0
       diff          = 0._kind_phys
-      max_diff(1,1) = 0._kind_phys
-      max_diff(2,1) = real(iam, kind_phys) !MPI rank for this task
+      max_diff(1)   = 0._kind_phys
+      max_diff(2)   = real(iam, kind_phys) !MPI rank for this task
 
       call cam_pio_find_var(file, var_names, found_name, vardesc, var_found)
 
@@ -515,8 +515,8 @@ CONTAINS
                      diff = abs(current_value(col, lev) - buffer(col, lev)) / &
                         abs(current_value(col, lev))
                   end if
-                  if (diff > max_diff(1,1)) then
-                     max_diff(1,1) = diff
+                  if (diff > max_diff(1)) then
+                     max_diff(1) = diff
                      max_diff_col = col
                      max_diff_lev = lev
                   end if
@@ -535,7 +535,7 @@ CONTAINS
                                MPI_2DOUBLE_PRECISION,                         &
                                mpi_maxloc, mpicom, ierr)
 
-            if (iam == int(max_diff_gl(2,1)) .and. .not. masterproc) then
+            if (iam == int(max_diff_gl(2)) .and. .not. masterproc) then
                !The largest diff happened on this task, so the local max is
                !is the global max. So send the local max value's dimension
                !indices (usually column and level index) to the root task:
@@ -543,16 +543,16 @@ CONTAINS
                              mpicom, ierr)
                call mpi_send(max_diff_lev, 1, mpi_integer, masterprocid, 0,   &
                              mpicom, ierr)
-            else if (iam /= int(max_diff_gl(2,1)) .and. masterproc) then
+            else if (iam /= int(max_diff_gl(2)) .and. masterproc) then
                !The root task needs to receive the relevant max diff indices
                !from a different task:
                call mpi_recv(max_diff_gl_col, 1, mpi_integer,                 &
-                             int(max_diff_gl(2,1)), 0, mpicom,                &
+                             int(max_diff_gl(2)), 0, mpicom,                &
                              mpi_stat, ierr)
                call mpi_recv(max_diff_gl_lev, 1, mpi_integer,                 &
-                             int(max_diff_gl(2,1)), 0, mpicom,                &
+                             int(max_diff_gl(2)), 0, mpicom,                &
                              mpi_stat, ierr)
-            else if (masterprocid == int(max_diff_gl(2,1))) then
+            else if (masterprocid == int(max_diff_gl(2))) then
                !The biggest difference is on the root MPI task already, so just
                !set directly:
                max_diff_gl_col = max_diff_col
@@ -563,8 +563,8 @@ CONTAINS
             if (masterproc) then
                if (diff_count_gl > 0) then
                   call write_check_field_entry(stdname, diff_count_gl,        &
-                                               max_diff_gl(1,1),              &
-                                               int(max_diff_gl(2,1)),         &
+                                               max_diff_gl(1),              &
+                                               int(max_diff_gl(2)),         &
                                                max_diff_gl_col,               &
                                                is_first,                      &
                                                max_diff_lev=max_diff_gl_lev)
@@ -619,9 +619,9 @@ CONTAINS
 
       !Write out difference and index valuesa:
       if (present(max_diff_lev)) then
-         write(index_str, '(a,i0,a,i0,a,i0,a)') "(",max_diff_rank,",",max_diff_col,",",max_diff_lev,"}"
+         write(index_str, '(a,i0,a,i0,a,i0,a)') "(",max_diff_rank,",",max_diff_col,",",max_diff_lev,")"
       else
-         write(index_str, '(a,i0,a,i0,a)') "(",max_diff_rank,",",max_diff_col,"}"
+         write(index_str, '(a,i0,a,i0,a)') "(",max_diff_rank,",",max_diff_col,")"
       end if
       write(fmt_str, '(a,i0,a)') "(1x,a,t",indent_level+1,",1x,i7,2x,e8.2,3x,a)"
       write(iulog, fmt_str) stdname(1:slen), diff_count, max_diff, index_str

--- a/src/physics/utils/physics_data.F90
+++ b/src/physics/utils/physics_data.F90
@@ -321,11 +321,12 @@ CONTAINS
       stdname, min_difference, min_relative_value, is_first)
       use pio,            only: file_desc_t, var_desc_t
       use spmd_utils,     only: masterproc, masterprocid
+      use spmd_utils,     only: mpicom, iam
       use cam_pio_utils,  only: cam_pio_find_var
       use cam_abortutils, only: endrun, check_allocate
       use cam_field_read, only: cam_read_field
-      use mpi,            only: mpi_max, mpi_sum, mpi_real8, mpi_integer
-      use spmd_utils,     only: mpicom
+      use mpi,            only: mpi_maxloc, mpi_sum, mpi_status_size
+      use mpi,            only: mpi_2double_precision, mpi_integer
 
       !Max possible length of variable name in file:
       use phys_vars_init_check, only: std_name_len
@@ -348,19 +349,24 @@ CONTAINS
       real(kind_phys)                  :: diff
       integer                          :: col
       integer                          :: ierr      !For MPI
+      integer                          :: mpi_stat(mpi_status_size) !For MPI
       real(kind_phys), allocatable     :: buffer(:)
       integer                          :: diff_count
-      real(kind_phys)                  :: max_diff
-      real(kind_phys)                  :: max_diff_gl
+      real(kind_phys)                  :: max_diff(2,1)    !Stores the local max diff and its MPI rank
+      integer                          :: max_diff_col
+      real(kind_phys)                  :: max_diff_gl(2,1) !Stores the global max diff and its MPI rank
+      integer                          :: max_diff_gl_col
       integer                          :: diff_count_gl
 
       !Initialize output variables
       ierr = 0
       allocate(buffer(size(current_value)), stat=ierr)
       call check_allocate(ierr, subname, 'buffer')
-      diff_count = 0
-      diff = 0._kind_phys
-      max_diff = 0._kind_phys
+      max_diff_col  = 0
+      diff_count    = 0
+      diff          = 0._kind_phys
+      max_diff(1,1) = 0._kind_phys
+      max_diff(2,1) = real(iam, kind_phys) !MPI rank for this task
 
       call cam_pio_find_var(file, var_names, found_name, vardesc, var_found)
       if (var_found) then
@@ -376,22 +382,47 @@ CONTAINS
                   diff = abs(current_value(col) - buffer(col)) /              &
                      abs(current_value(col))
                end if
-               if (diff > max_diff) then
-                  max_diff = diff
+               if (diff > max_diff(1,1)) then
+                  max_diff(1,1)  = diff
+                  max_diff_col = col
                end if
                if (diff > min_difference) then
                   diff_count = diff_count + 1
                end if
             end do
             !Gather results across all nodes to get global values
-            call mpi_reduce(diff_count, diff_count_gl, 1, mpi_integer,     &
-                 mpi_sum, masterprocid,  mpicom, ierr)
-            call mpi_reduce(max_diff, max_diff_gl, 1, mpi_real8, mpi_max,  &
-                 masterprocid, mpicom, ierr)
+            call mpi_reduce(diff_count, diff_count_gl, 1, mpi_integer,        &
+                            mpi_sum, masterprocid,  mpicom, ierr)
+
+            call mpi_allreduce(max_diff, max_diff_gl, 1,                      &
+                               MPI_2DOUBLE_PRECISION,                         &
+                               mpi_maxloc, mpicom, ierr)
+
+            if (iam == int(max_diff_gl(2,1)) .and. .not. masterproc) then
+               !The largest diff happened on this task, so the local max is
+               !is the global max. So send the local max value's dimension
+               !index (usually column index) to the root task:
+               call mpi_send(max_diff_col, 1, mpi_integer, masterprocid, 0,   &
+                             mpicom, ierr)
+            else if (iam /= int(max_diff_gl(2,1)) .and. masterproc) then
+               !The root task needs to receive the relevant max diff index
+               !from a different task:
+               call mpi_recv(max_diff_gl_col, 1, mpi_integer,                 &
+                             int(max_diff_gl(2,1)), 0, mpicom,                &
+                             mpi_stat, ierr)
+            else if (masterprocid == int(max_diff_gl(2,1))) then
+               !The biggest difference is on the root MPI task already,
+               !so just set directly:
+               max_diff_gl_col = max_diff_col
+            end if
+
+            !Print difference stats to log file
             if (masterproc) then
                if (diff_count_gl > 0) then
                   call write_check_field_entry(stdname, diff_count_gl,        &
-                     max_diff_gl, is_first)
+                                               max_diff_gl(1,1),              &
+                                               int(max_diff_gl(2,1)),         &
+                                               max_diff_gl_col, is_first)
                   is_first = .false.
                end if
             end if
@@ -405,11 +436,12 @@ CONTAINS
       use shr_sys_mod,    only: shr_sys_flush
       use pio,            only: file_desc_t, var_desc_t
       use spmd_utils,     only: masterproc, masterprocid
+      use spmd_utils,     only: mpicom, iam
       use cam_pio_utils,  only: cam_pio_find_var
       use cam_abortutils, only: endrun, check_allocate
       use cam_field_read, only: cam_read_field
-      use mpi,            only: mpi_max, mpi_sum, mpi_real8, mpi_integer
-      use spmd_utils,     only: mpicom
+      use mpi,            only: mpi_maxloc, mpi_sum, mpi_status_size
+      use mpi,            only: mpi_2double_precision, mpi_integer
       use vert_coord,     only: pver, pverp
 
       !Max possible length of variable name in file:
@@ -432,14 +464,19 @@ CONTAINS
       type(var_desc_t)                 :: vardesc
       character(len=*),  parameter     :: subname = 'check_field_3d'
       real(kind_phys)                  :: diff
-      integer                          :: ierr      !For MPI
+      integer                          :: ierr                      !For MPI
+      integer                          :: mpi_stat(mpi_status_size) !For MPI
       integer                          :: num_levs
       integer                          :: col
       integer                          :: lev
       real(kind_phys), allocatable     :: buffer(:,:)
       integer                          :: diff_count
-      real(kind_phys)                  :: max_diff
-      real(kind_phys)                  :: max_diff_gl
+      real(kind_phys)                  :: max_diff(2,1)    !Stores the local max diff and its MPI rank
+      integer                          :: max_diff_col
+      integer                          :: max_diff_lev
+      real(kind_phys)                  :: max_diff_gl(2,1) !Stores the global max diff and its MPI rank
+      integer                          :: max_diff_gl_col
+      integer                          :: max_diff_gl_lev
       integer                          :: diff_count_gl
 
       !Initialize output variables
@@ -447,9 +484,12 @@ CONTAINS
       allocate(buffer(size(current_value, 1), size(current_value, 2)),        &
         stat=ierr)
       call check_allocate(ierr, subname, 'buffer')
-      diff = 0._kind_phys
-      diff_count = 0
-      max_diff = 0._kind_phys
+      max_diff_col  = 0
+      max_diff_lev  = 0
+      diff_count    = 0
+      diff          = 0._kind_phys
+      max_diff(1,1) = 0._kind_phys
+      max_diff(2,1) = real(iam, kind_phys) !MPI rank for this task
 
       call cam_pio_find_var(file, var_names, found_name, vardesc, var_found)
 
@@ -475,8 +515,10 @@ CONTAINS
                      diff = abs(current_value(col, lev) - buffer(col, lev)) / &
                         abs(current_value(col, lev))
                   end if
-                  if (diff > max_diff) then
-                     max_diff = diff
+                  if (diff > max_diff(1,1)) then
+                     max_diff(1,1) = diff
+                     max_diff_col = col
+                     max_diff_lev = lev
                   end if
                   !Determine if diff is large enough to be considered a "hit"
                   if (diff > min_difference) then
@@ -484,14 +526,48 @@ CONTAINS
                   end if
                end do
             end do
-            call mpi_reduce(diff_count, diff_count_gl, 1, mpi_integer,     &
+
+            !Make relevant MPI calls to get global values:
+            call mpi_reduce(diff_count, diff_count_gl, 1, mpi_integer,        &
                  mpi_sum, masterprocid, mpicom, ierr)
-            call mpi_reduce(max_diff, max_diff_gl, 1, mpi_real8, mpi_max,  &
-                 masterprocid, mpicom, ierr)
+
+            call mpi_allreduce(max_diff, max_diff_gl, 1,                      &
+                               MPI_2DOUBLE_PRECISION,                         &
+                               mpi_maxloc, mpicom, ierr)
+
+            if (iam == int(max_diff_gl(2,1)) .and. .not. masterproc) then
+               !The largest diff happened on this task, so the local max is
+               !is the global max. So send the local max value's dimension
+               !indices (usually column and level index) to the root task:
+               call mpi_send(max_diff_col, 1, mpi_integer, masterprocid, 0,   &
+                             mpicom, ierr)
+               call mpi_send(max_diff_lev, 1, mpi_integer, masterprocid, 0,   &
+                             mpicom, ierr)
+            else if (iam /= int(max_diff_gl(2,1)) .and. masterproc) then
+               !The root task needs to receive the relevant max diff indices
+               !from a different task:
+               call mpi_recv(max_diff_gl_col, 1, mpi_integer,                 &
+                             int(max_diff_gl(2,1)), 0, mpicom,                &
+                             mpi_stat, ierr)
+               call mpi_recv(max_diff_gl_lev, 1, mpi_integer,                 &
+                             int(max_diff_gl(2,1)), 0, mpicom,                &
+                             mpi_stat, ierr)
+            else if (masterprocid == int(max_diff_gl(2,1))) then
+               !The biggest difference is on the root MPI task already, so just
+               !set directly:
+               max_diff_gl_col = max_diff_col
+               max_diff_gl_lev = max_diff_lev
+            end if
+
+            !Print difference stats to log file
             if (masterproc) then
                if (diff_count_gl > 0) then
                   call write_check_field_entry(stdname, diff_count_gl,        &
-                     max_diff_gl, is_first)
+                                               max_diff_gl(1,1),              &
+                                               int(max_diff_gl(2,1)),         &
+                                               max_diff_gl_col,               &
+                                               is_first,                      &
+                                               max_diff_lev=max_diff_gl_lev)
                   is_first = .false.
                end if
             end if
@@ -501,36 +577,54 @@ CONTAINS
 
    end subroutine check_field_3d
 
-   subroutine write_check_field_entry(stdname, diff_count, max_diff, is_first)
+   subroutine write_check_field_entry(stdname,      diff_count,               &
+                                      max_diff,     max_diff_rank,            &
+                                      max_diff_col, is_first,                 &
+                                      max_diff_lev)
 
       use cam_logfile, only: iulog
+      use shr_kind_mod, only: cs=>shr_kind_cs
 
       !Dummy variables:
-      character(len=*), intent(in) :: stdname
-      integer,          intent(in) :: diff_count
-      real(kind_phys),  intent(in) :: max_diff
-      logical,          intent(in) :: is_first
+      character(len=*),  intent(in) :: stdname
+      integer,           intent(in) :: diff_count
+      real(kind_phys),   intent(in) :: max_diff
+      integer,           intent(in) :: max_diff_rank !MPI rank max diff occurred on
+      integer,           intent(in) :: max_diff_col  !max diff column (1st) dimension value
+      integer, optional, intent(in) :: max_diff_lev  !max diff level (2nd) dimension value
+      logical,           intent(in) :: is_first
 
       !Local variables:
-      character(len=24)            :: fmt_str
+      character(len=cs)            :: fmt_str
+      character(len=cs)            :: index_str
       integer                      :: slen
       integer, parameter           :: indent_level = 50
 
       slen = len_trim(stdname)
 
+      !Write check_field log header:
       if (is_first) then
          write(iulog, *) ''
-         write(fmt_str, '(a,i0,a)') "(1x,a,t",indent_level+1,",1x,a,2x,a)"
-         write(iulog, fmt_str) 'Variable', '# Diffs', 'Max Diff'
-         write(iulog, fmt_str) '--------', '-------', '--------'
+         write(fmt_str, '(a,i0,a)') "(1x,a,t",indent_level+1,",1x,a,2x,a,3x,a)"
+         write(iulog, fmt_str) 'Variable', '# Diffs', 'Max Diff', 'Max Diff loc (rank, col, lev)'
+         write(iulog, fmt_str) '--------', '-------', '--------', '-----------------------------'
       end if
 
+      !Write standard name separately if longer
+      !than the indent level:
       if (slen > indent_level) then
          write(iulog, '(a)') trim(stdname)
          slen = 0
       end if
-      write(fmt_str, '(a,i0,a)') "(1x,a,t",indent_level+1,",1x,i7,2x,e8.2)"
-      write(iulog, fmt_str) stdname(1:slen), diff_count, max_diff
+
+      !Write out difference and index valuesa:
+      if (present(max_diff_lev)) then
+         write(index_str, '(a,i0,a,i0,a,i0,a)') "(",max_diff_rank,",",max_diff_col,",",max_diff_lev,"}"
+      else
+         write(index_str, '(a,i0,a,i0,a)') "(",max_diff_rank,",",max_diff_col,"}"
+      end if
+      write(fmt_str, '(a,i0,a)') "(1x,a,t",indent_level+1,",1x,i7,2x,e8.2,3x,a)"
+      write(iulog, fmt_str) stdname(1:slen), diff_count, max_diff, index_str
 
    end subroutine write_check_field_entry
 

--- a/src/utils/cam_abortutils.F90
+++ b/src/utils/cam_abortutils.F90
@@ -1,7 +1,7 @@
 module cam_abortutils
 
    use shr_sys_mod,  only: shr_sys_abort, shr_sys_flush
-   use shr_kind_mod, only: max_chars=>shr_kind_cl, msg_len=>SHR_KIND_CS
+   use shr_kind_mod, only: max_chars=>shr_kind_cx, msg_len=>SHR_KIND_CS
    use shr_kind_mod, only: r8 => shr_kind_r8
    use shr_mem_mod,  only: shr_mem_getusage
    use pio,          only: file_desc_t

--- a/src/utils/spmd_utils.meta
+++ b/src/utils/spmd_utils.meta
@@ -18,7 +18,7 @@
   dimensions = ()
   protected = True
 [ masterproc ]
-  standard_name = is_mpi_root
+  standard_name = flag_for_mpi_root
   units = flag
   type = logical
   dimensions = ()

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_4D.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_4D.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_4D
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_bvd.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_bvd.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_bvd
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_ddt.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_ddt.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_ddt
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_ddt2.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_ddt2.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_ddt2
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_ddt_array.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_ddt_array.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_ddt_array
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=39), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'T(:, :, index_of_potential_temperature)', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_host_var.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_host_var.F90
@@ -46,20 +46,20 @@ module phys_vars_init_check_host_var
    character(len=25), public, protected :: phys_var_stdnames(phys_var_num) = (/ &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=3), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'slp' /), (/1, phys_var_num/))

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_mf.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_mf.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_mf
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_no_horiz.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_no_horiz.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_no_horiz
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_noreq.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_noreq.F90
@@ -45,20 +45,20 @@ module phys_vars_init_check_noreq
    ! Physics-related input variable standard names:
    character(len=0), public, protected :: phys_var_stdnames(phys_var_num)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=0), public, protected :: input_var_names(0, phys_var_num)
 

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_param.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_param.F90
@@ -48,20 +48,20 @@ module phys_vars_init_check_param
       'air_pressure_at_sea_level ', &
       'gravitational_acceleration' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_protect.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_protect.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_protect
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_scalar.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_scalar.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_scalar
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/phys_vars_init_check_simple.F90
+++ b/test/unit/sample_files/write_init_files/phys_vars_init_check_simple.F90
@@ -47,20 +47,20 @@ module phys_vars_init_check_simple
       'potential_temperature    ', &
       'air_pressure_at_sea_level' /)
 
-   character(len=37), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
-      "ccpp_constituent_array               ", &
-      "ccpp_constituent_array_minimum_values", &
-      "ccpp_constituent_properties_array    ", &
-      "ccpp_num_advected_constituents       ", &
-      "ccpp_num_constituents                ", &
-      "do_log_output                        ", &
-      "log_output_unit                      ", &
-      "mpi_communicator                     ", &
-      "mpi_rank                             ", &
-      "mpi_root                             ", &
-      "number_of_mpi_tasks                  ", &
-      "suite_name                           ", &
-      "suite_part                           " /)
+   character(len=36), public, protected :: phys_const_stdnames(phys_const_num) = (/ &
+      "ccpp_constituent_minimum_values     ", &
+      "ccpp_constituent_properties         ", &
+      "ccpp_constituents                   ", &
+      "do_log_output                       ", &
+      "log_output_unit                     ", &
+      "mpi_communicator                    ", &
+      "mpi_rank                            ", &
+      "mpi_root                            ", &
+      "number_of_ccpp_advected_constituents", &
+      "number_of_ccpp_constituents         ", &
+      "number_of_mpi_tasks                 ", &
+      "suite_name                          ", &
+      "suite_part                          " /)
    !Array storing all registered IC file input names for each variable:
    character(len=5), public, protected :: input_var_names(1, phys_var_num) = reshape((/ &
       'theta', &

--- a/test/unit/sample_files/write_init_files/physics_inputs_4D.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_4D.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                       only: file_desc_t
       use cam_abortutils,            only: endrun
+      use spmd_utils,                only: masterproc
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,              only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,              only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array
-      use cam_ccpp_cap,              only: cam_model_const_properties
+      use physics_data,              only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                only: kind_phys
       use phys_vars_init_check_4D,   only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
@@ -67,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -97,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -118,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -183,13 +167,10 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call read_field(file, 'potential_temperature',                            &
-                             input_var_names(:,name_idx), 'lev', timestep, theta)
+                        call read_field(file, 'potential_temperature', input_var_names(:,name_idx), 'lev', timestep, theta)
 
                      case ('air_pressure_at_sea_level')
-                        call                                                                      &
-                             endrun('Cannot read slp from file'//                                 &
-                             ', slp has unsupported dimension, timestep_for_physics.')
+                        call endrun('Cannot read slp from file'//', slp has unsupported dimension, timestep_for_physics.')
 
                   end select !read variables
                end select !special indices
@@ -215,15 +196,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                     only: file_desc_t, pio_nowrite
       use cam_abortutils,          only: endrun
       use shr_kind_mod,            only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,            only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,            only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,            only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,            only: cam_advected_constituents_array
+      use physics_data,            only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,            only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,        only: const_get_index
       use ccpp_kinds,              only: kind_phys
       use cam_logfile,             only: iulog
@@ -278,16 +256,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -295,30 +270,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -326,13 +294,11 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta,     &
-                       'potential_temperature', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta, 'potential_temperature', min_difference,                 &
+                       min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
-                  call                                                                            &
-                       endrun('Cannot check status of slp'//                                      &
-                       ', slp has unsupported dimension, timestep_for_physics.')
+                  call endrun('Cannot check status of slp'//', slp has unsupported dimension, timestep_for_physics.')
 
                end select !check variables
             end if !check if constituent

--- a/test/unit/sample_files/write_init_files/physics_inputs_ddt.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_ddt.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                       only: file_desc_t
       use cam_abortutils,            only: endrun
+      use spmd_utils,                only: masterproc
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,              only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,              only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array
-      use cam_ccpp_cap,              only: cam_model_const_properties
+      use physics_data,              only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                only: kind_phys
       use phys_vars_init_check_ddt,  only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
@@ -67,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -97,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -118,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -183,12 +167,10 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call read_field(file, 'potential_temperature',                            &
-                             input_var_names(:,name_idx), 'lev', timestep, phys_state%theta)
+                        call read_field(file, 'potential_temperature', input_var_names(:,name_idx), 'lev', timestep, phys_state%theta)
 
                      case ('air_pressure_at_sea_level')
-                        call read_field(file, 'air_pressure_at_sea_level',                        &
-                             input_var_names(:,name_idx), timestep, slp)
+                        call read_field(file, 'air_pressure_at_sea_level', input_var_names(:,name_idx), timestep, slp)
 
                   end select !read variables
                end select !special indices
@@ -214,15 +196,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                      only: file_desc_t, pio_nowrite
       use cam_abortutils,           only: endrun
       use shr_kind_mod,             only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,             only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,             only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,             only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,             only: cam_advected_constituents_array
+      use physics_data,             only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,             only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,         only: const_get_index
       use ccpp_kinds,               only: kind_phys
       use cam_logfile,              only: iulog
@@ -277,16 +256,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -294,30 +270,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -325,13 +294,12 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep,            &
-                       phys_state%theta, 'potential_temperature', min_difference,                 &
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, phys_state%theta, 'potential_temperature', min_difference,      &
                        min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
-                  call check_field(file, input_var_names(:,name_idx), timestep, slp,              &
-                       'air_pressure_at_sea_level', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), timestep, slp, 'air_pressure_at_sea_level', min_difference, min_relative_value,  &
+                       is_first)
 
                end select !check variables
             end if !check if constituent

--- a/test/unit/sample_files/write_init_files/physics_inputs_ddt2.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_ddt2.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                       only: file_desc_t
       use cam_abortutils,            only: endrun
+      use spmd_utils,                only: masterproc
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,              only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,              only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array
-      use cam_ccpp_cap,              only: cam_model_const_properties
+      use physics_data,              only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                only: kind_phys
       use phys_vars_init_check_ddt2, only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
@@ -67,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -97,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -118,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -183,12 +167,10 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call read_field(file, 'potential_temperature',                            &
-                             input_var_names(:,name_idx), 'lev', timestep, phys_state%theta)
+                        call read_field(file, 'potential_temperature', input_var_names(:,name_idx), 'lev', timestep, phys_state%theta)
 
                      case ('air_pressure_at_sea_level')
-                        call read_field(file, 'air_pressure_at_sea_level',                        &
-                             input_var_names(:,name_idx), timestep, phys_state%slp)
+                        call read_field(file, 'air_pressure_at_sea_level', input_var_names(:,name_idx), timestep, phys_state%slp)
 
                   end select !read variables
                end select !special indices
@@ -214,15 +196,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                       only: file_desc_t, pio_nowrite
       use cam_abortutils,            only: endrun
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,              only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,              only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,              only: cam_advected_constituents_array
+      use physics_data,              only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,          only: const_get_index
       use ccpp_kinds,                only: kind_phys
       use cam_logfile,               only: iulog
@@ -277,16 +256,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -294,30 +270,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -325,13 +294,12 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep,            &
-                       phys_state%theta, 'potential_temperature', min_difference,                 &
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, phys_state%theta, 'potential_temperature', min_difference,      &
                        min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
-                  call check_field(file, input_var_names(:,name_idx), timestep, phys_state%slp,   &
-                       'air_pressure_at_sea_level', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), timestep, phys_state%slp, 'air_pressure_at_sea_level', min_difference,           &
+                       min_relative_value, is_first)
 
                end select !check variables
             end if !check if constituent

--- a/test/unit/sample_files/write_init_files/physics_inputs_ddt_array.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_ddt_array.F90
@@ -31,12 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                            only: file_desc_t
       use cam_abortutils,                 only: endrun
+      use spmd_utils,                     only: masterproc
       use shr_kind_mod,                   only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                   only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,                   only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                   only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                   only: cam_constituents_array
-      use cam_ccpp_cap,                   only: cam_model_const_properties
+      use physics_data,                   only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                   only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                     only: kind_phys
       use phys_vars_init_check_ddt_array, only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod,      only: ccpp_constituent_prop_ptr_t
@@ -68,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -98,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -119,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -184,13 +167,10 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call read_field(file, 'potential_temperature',                            &
-                             input_var_names(:,name_idx), 'lev', timestep, phys_state%T(:, :,     &
-                             ix_theta))
+                        call read_field(file, 'potential_temperature', input_var_names(:,name_idx), 'lev', timestep, phys_state%T(:, :, ix_theta))
 
                      case ('air_pressure_at_sea_level')
-                        call read_field(file, 'air_pressure_at_sea_level',                        &
-                             input_var_names(:,name_idx), timestep, phys_state%slp)
+                        call read_field(file, 'air_pressure_at_sea_level', input_var_names(:,name_idx), timestep, phys_state%slp)
 
                   end select !read variables
                end select !special indices
@@ -216,15 +196,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                            only: file_desc_t, pio_nowrite
       use cam_abortutils,                 only: endrun
       use shr_kind_mod,                   only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                   only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,                   only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                   only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                   only: cam_advected_constituents_array
+      use physics_data,                   only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                   only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,               only: const_get_index
       use ccpp_kinds,                     only: kind_phys
       use cam_logfile,                    only: iulog
@@ -279,16 +256,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -296,30 +270,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -327,13 +294,12 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep,            &
-                       phys_state%T(:, :, ix_theta), 'potential_temperature', min_difference,     &
-                       min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, phys_state%T(:, :, ix_theta), 'potential_temperature',          &
+                       min_difference, min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
-                  call check_field(file, input_var_names(:,name_idx), timestep, phys_state%slp,   &
-                       'air_pressure_at_sea_level', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), timestep, phys_state%slp, 'air_pressure_at_sea_level', min_difference,           &
+                       min_relative_value, is_first)
 
                end select !check variables
             end if !check if constituent

--- a/test/unit/sample_files/write_init_files/physics_inputs_host_var.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_host_var.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                           only: file_desc_t
       use cam_abortutils,                only: endrun
+      use spmd_utils,                    only: masterproc
       use shr_kind_mod,                  only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                  only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,                  only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                  only: cam_constituents_array, cam_model_const_properties
+      use physics_data,                  only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                    only: kind_phys
       use phys_vars_init_check_host_var, only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod,     only: ccpp_constituent_prop_ptr_t
@@ -67,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -97,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -118,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -183,8 +167,7 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('air_pressure_at_sea_level')
-                        call read_field(file, 'air_pressure_at_sea_level',                        &
-                             input_var_names(:,name_idx), timestep, slp)
+                        call read_field(file, 'air_pressure_at_sea_level', input_var_names(:,name_idx), timestep, slp)
 
                   end select !read variables
                end select !special indices
@@ -210,15 +193,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                           only: file_desc_t, pio_nowrite
       use cam_abortutils,                only: endrun
       use shr_kind_mod,                  only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                  only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,                  only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                  only: cam_advected_constituents_array
+      use physics_data,                  only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,              only: const_get_index
       use ccpp_kinds,                    only: kind_phys
       use cam_logfile,                   only: iulog
@@ -273,16 +253,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -290,30 +267,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -321,8 +291,8 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('air_pressure_at_sea_level')
-                  call check_field(file, input_var_names(:,name_idx), timestep, slp,              &
-                       'air_pressure_at_sea_level', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), timestep, slp, 'air_pressure_at_sea_level', min_difference, min_relative_value,  &
+                       is_first)
 
                end select !check variables
             end if !check if constituent

--- a/test/unit/sample_files/write_init_files/physics_inputs_mf.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_mf.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                       only: file_desc_t
       use cam_abortutils,            only: endrun
+      use spmd_utils,                only: masterproc
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,              only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,              only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array
-      use cam_ccpp_cap,              only: cam_model_const_properties
+      use physics_data,              only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                only: kind_phys
       use phys_vars_init_check_mf,   only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
@@ -68,8 +67,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -98,17 +96,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -119,61 +114,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -184,12 +168,10 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call read_field(file, 'potential_temperature',                            &
-                             input_var_names(:,name_idx), 'lev', timestep, theta)
+                        call read_field(file, 'potential_temperature', input_var_names(:,name_idx), 'lev', timestep, theta)
 
                      case ('air_pressure_at_sea_level')
-                        call read_field(file, 'air_pressure_at_sea_level',                        &
-                             input_var_names(:,name_idx), timestep, slp)
+                        call read_field(file, 'air_pressure_at_sea_level', input_var_names(:,name_idx), timestep, slp)
 
                   end select !read variables
                end select !special indices
@@ -215,15 +197,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                     only: file_desc_t, pio_nowrite
       use cam_abortutils,          only: endrun
       use shr_kind_mod,            only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,            only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,            only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,            only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,            only: cam_advected_constituents_array
+      use physics_data,            only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,            only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,        only: const_get_index
       use ccpp_kinds,              only: kind_phys
       use cam_logfile,             only: iulog
@@ -279,16 +258,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -296,30 +272,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -327,12 +296,12 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta,     &
-                       'potential_temperature', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta, 'potential_temperature', min_difference,                 &
+                       min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
-                  call check_field(file, input_var_names(:,name_idx), timestep, slp,              &
-                       'air_pressure_at_sea_level', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), timestep, slp, 'air_pressure_at_sea_level', min_difference, min_relative_value,  &
+                       is_first)
 
                end select !check variables
             end if !check if constituent

--- a/test/unit/sample_files/write_init_files/physics_inputs_no_horiz.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_no_horiz.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                           only: file_desc_t
       use cam_abortutils,                only: endrun
+      use spmd_utils,                    only: masterproc
       use shr_kind_mod,                  only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                  only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,                  only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                  only: cam_constituents_array, cam_model_const_properties
+      use physics_data,                  only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                    only: kind_phys
       use phys_vars_init_check_no_horiz, only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod,     only: ccpp_constituent_prop_ptr_t
@@ -67,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -97,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -118,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -183,13 +167,10 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call read_field(file, 'potential_temperature',                            &
-                             input_var_names(:,name_idx), 'lev', timestep, theta)
+                        call read_field(file, 'potential_temperature', input_var_names(:,name_idx), 'lev', timestep, theta)
 
                      case ('air_pressure_at_sea_level')
-                        call                                                                      &
-                             endrun('Cannot read slp from file'//                                 &
-                             ', slp has no horizontal dimension')
+                        call endrun('Cannot read slp from file'//', slp has no horizontal dimension')
 
                   end select !read variables
                end select !special indices
@@ -215,15 +196,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                           only: file_desc_t, pio_nowrite
       use cam_abortutils,                only: endrun
       use shr_kind_mod,                  only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                  only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,                  only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                  only: cam_advected_constituents_array
+      use physics_data,                  only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,              only: const_get_index
       use ccpp_kinds,                    only: kind_phys
       use cam_logfile,                   only: iulog
@@ -278,16 +256,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -295,30 +270,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -326,8 +294,8 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta,     &
-                       'potential_temperature', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta, 'potential_temperature', min_difference,                 &
+                       min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
                   call endrun('Cannot check status of slp'//', slp has no horizontal dimension')

--- a/test/unit/sample_files/write_init_files/physics_inputs_noreq.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_noreq.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                        only: file_desc_t
       use cam_abortutils,             only: endrun
+      use spmd_utils,                 only: masterproc
       use shr_kind_mod,               only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,               only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,               only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_constituents_array
-      use cam_ccpp_cap,               only: cam_model_const_properties
+      use physics_data,               only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                 only: kind_phys
       use phys_vars_init_check_noreq, only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod,  only: ccpp_constituent_prop_ptr_t
@@ -66,8 +65,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -96,17 +94,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -117,61 +112,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -205,15 +189,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                        only: file_desc_t, pio_nowrite
       use cam_abortutils,             only: endrun
       use shr_kind_mod,               only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,               only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,               only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,               only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,               only: cam_advected_constituents_array
+      use physics_data,               only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,           only: const_get_index
       use ccpp_kinds,                 only: kind_phys
       use cam_logfile,                only: iulog
@@ -267,16 +248,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -284,30 +262,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if

--- a/test/unit/sample_files/write_init_files/physics_inputs_param.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_param.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                        only: file_desc_t
       use cam_abortutils,             only: endrun
+      use spmd_utils,                 only: masterproc
       use shr_kind_mod,               only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,               only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,               only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_constituents_array
-      use cam_ccpp_cap,               only: cam_model_const_properties
+      use physics_data,               only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                 only: kind_phys
       use phys_vars_init_check_param, only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod,  only: ccpp_constituent_prop_ptr_t
@@ -67,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -97,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -118,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -183,17 +167,13 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call read_field(file, 'potential_temperature',                            &
-                             input_var_names(:,name_idx), 'lev', timestep, theta)
+                        call read_field(file, 'potential_temperature', input_var_names(:,name_idx), 'lev', timestep, theta)
 
                      case ('air_pressure_at_sea_level')
-                        call read_field(file, 'air_pressure_at_sea_level',                        &
-                             input_var_names(:,name_idx), timestep, slp)
+                        call read_field(file, 'air_pressure_at_sea_level', input_var_names(:,name_idx), timestep, slp)
 
                      case ('gravitational_acceleration')
-                        call                                                                      &
-                             endrun('Cannot read g from file'//                                   &
-                             ', g has no horizontal dimension; g is a protected variable')
+                        call endrun('Cannot read g from file'//', g has no horizontal dimension; g is a protected variable')
 
                   end select !read variables
                end select !special indices
@@ -219,15 +199,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                        only: file_desc_t, pio_nowrite
       use cam_abortutils,             only: endrun
       use shr_kind_mod,               only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,               only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,               only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,               only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,               only: cam_advected_constituents_array
+      use physics_data,               only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,           only: const_get_index
       use ccpp_kinds,                 only: kind_phys
       use cam_logfile,                only: iulog
@@ -282,16 +259,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -299,30 +273,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -330,12 +297,12 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta,     &
-                       'potential_temperature', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta, 'potential_temperature', min_difference,                 &
+                       min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
-                  call check_field(file, input_var_names(:,name_idx), timestep, slp,              &
-                       'air_pressure_at_sea_level', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), timestep, slp, 'air_pressure_at_sea_level', min_difference, min_relative_value,  &
+                       is_first)
 
                case ('gravitational_acceleration')
                   call endrun('Cannot check status of g'//', g has no horizontal dimension')

--- a/test/unit/sample_files/write_init_files/physics_inputs_protect.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_protect.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                          only: file_desc_t
       use cam_abortutils,               only: endrun
+      use spmd_utils,                   only: masterproc
       use shr_kind_mod,                 only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                 only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,                 only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                 only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                 only: cam_constituents_array, cam_model_const_properties
+      use physics_data,                 only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                 only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                   only: kind_phys
       use phys_vars_init_check_protect, only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod,    only: ccpp_constituent_prop_ptr_t
@@ -67,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -97,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -118,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -183,13 +167,10 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call                                                                      &
-                             endrun('Cannot read theta from file'//                               &
-                             ', theta is a protected variable')
+                        call endrun('Cannot read theta from file'//', theta is a protected variable')
 
                      case ('air_pressure_at_sea_level')
-                        call read_field(file, 'air_pressure_at_sea_level',                        &
-                             input_var_names(:,name_idx), timestep, slp)
+                        call read_field(file, 'air_pressure_at_sea_level', input_var_names(:,name_idx), timestep, slp)
 
                   end select !read variables
                end select !special indices
@@ -215,15 +196,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                          only: file_desc_t, pio_nowrite
       use cam_abortutils,               only: endrun
       use shr_kind_mod,                 only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                 only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,                 only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                 only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                 only: cam_advected_constituents_array
+      use physics_data,                 only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                 only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,             only: const_get_index
       use ccpp_kinds,                   only: kind_phys
       use cam_logfile,                  only: iulog
@@ -278,16 +256,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -295,30 +270,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -326,12 +294,12 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta,     &
-                       'potential_temperature', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta, 'potential_temperature', min_difference,                 &
+                       min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
-                  call check_field(file, input_var_names(:,name_idx), timestep, slp,              &
-                       'air_pressure_at_sea_level', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), timestep, slp, 'air_pressure_at_sea_level', min_difference, min_relative_value,  &
+                       is_first)
 
                end select !check variables
             end if !check if constituent

--- a/test/unit/sample_files/write_init_files/physics_inputs_scalar.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_scalar.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                         only: file_desc_t
       use cam_abortutils,              only: endrun
+      use spmd_utils,                  only: masterproc
       use shr_kind_mod,                only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,                only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_constituents_array
-      use cam_ccpp_cap,                only: cam_model_const_properties
+      use physics_data,                only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                  only: kind_phys
       use phys_vars_init_check_scalar, only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod,   only: ccpp_constituent_prop_ptr_t
@@ -67,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -97,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -118,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -183,13 +167,10 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call read_field(file, 'potential_temperature',                            &
-                             input_var_names(:,name_idx), 'lev', timestep, theta)
+                        call read_field(file, 'potential_temperature', input_var_names(:,name_idx), 'lev', timestep, theta)
 
                      case ('air_pressure_at_sea_level')
-                        call                                                                      &
-                             endrun('Cannot read slp from file'//                                 &
-                             ', slp has no horizontal dimension')
+                        call endrun('Cannot read slp from file'//', slp has no horizontal dimension')
 
                   end select !read variables
                end select !special indices
@@ -215,15 +196,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                         only: file_desc_t, pio_nowrite
       use cam_abortutils,              only: endrun
       use shr_kind_mod,                only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,                only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                only: cam_advected_constituents_array
+      use physics_data,                only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,            only: const_get_index
       use ccpp_kinds,                  only: kind_phys
       use cam_logfile,                 only: iulog
@@ -278,16 +256,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -295,30 +270,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -326,8 +294,8 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta,     &
-                       'potential_temperature', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta, 'potential_temperature', min_difference,                 &
+                       min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
                   call endrun('Cannot check status of slp'//', slp has no horizontal dimension')

--- a/test/unit/sample_files/write_init_files/physics_inputs_simple.F90
+++ b/test/unit/sample_files/write_init_files/physics_inputs_simple.F90
@@ -31,11 +31,10 @@ CONTAINS
    subroutine physics_read_data(file, suite_names, timestep, read_initialized_variables)
       use pio,                         only: file_desc_t
       use cam_abortutils,              only: endrun
+      use spmd_utils,                  only: masterproc
       use shr_kind_mod,                only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                only: read_field, find_input_name_idx, no_exist_idx
-      use physics_data,                only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_constituents_array
-      use cam_ccpp_cap,                only: cam_model_const_properties
+      use physics_data,                only: read_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use ccpp_kinds,                  only: kind_phys
       use phys_vars_init_check_simple, only: phys_var_stdnames, input_var_names, std_name_len
       use ccpp_constituent_prop_mod,   only: ccpp_constituent_prop_ptr_t
@@ -67,8 +66,7 @@ CONTAINS
       character(len=2)           :: sep2            !String separator used to print err messages
       character(len=2)           :: sep3            !String separator used to print err messages
       real(kind=kind_phys), pointer :: field_data_ptr(:,:,:)
-      logical                    :: var_found       !Bool to determine if consituent found in
-      ! data files
+      logical                    :: var_found       !Bool to determine if consituent found in data files
 
       ! Fields needed for getting default data value for constituents
       type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
@@ -97,17 +95,14 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables and read from file if uninitialized:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! Find IC file input name array index for required variable:
-            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables,       &
-                 constituent_idx)
+            name_idx = find_input_name_idx(ccpp_required_data(req_idx), use_init_variables, constituent_idx)
 
             ! Check for special index values:
             select case (name_idx)
@@ -118,61 +113,50 @@ CONTAINS
 
                case (no_exist_idx)
 
-                  ! If an index was never found, then save variable name and check the rest of
-                  ! the variables, after which the model simulation will end:
-                     missing_required_vars(len_trim(missing_required_vars)+1:) =                  &
-                          trim(sep)//trim(ccpp_required_data(req_idx))
+                  ! If an index was never found, then save variable name and check the rest of the variables, after which the model simulation will
+                  ! end:
+                     missing_required_vars(len_trim(missing_required_vars)+1:) = trim(sep)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep = ', '
 
                case (prot_no_init_idx)
 
-                  ! If an index was found for a protected variable, but that variable was never
-                  ! marked as initialized, then save the variable name and check the rest of the
-                  ! variables, after which the model simulation will end:
-                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) =              &
-                          trim(sep2)//trim(ccpp_required_data(req_idx))
+                  ! If an index was found for a protected variable, but that variable was never marked as initialized, then save the variable name
+                  ! and check the rest of the variables, after which the model simulation will end:
+                     protected_non_init_vars(len_trim(protected_non_init_vars)+1:) = trim(sep2)//trim(ccpp_required_data(req_idx))
 
                   ! Update character separator to now include comma:
                   sep2 = ', '
 
                case (const_idx)
 
-                  ! If an index was found in the constituent hash table, then read in the data
-                  ! to that index of the constituent array
+                  ! If an index was found in the constituent hash table, then read in the data to that index of the constituent array
 
                   var_found = .false.
                   field_data_ptr => cam_constituents_array()
-                  call read_field(file, ccpp_required_data(req_idx),                              &
-                       [ccpp_required_data(req_idx)], 'lev', timestep,                            &
-                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false.,                 &
-                       error_on_not_found=.false., var_found=var_found)
+                  call read_field(file, ccpp_required_data(req_idx), [ccpp_required_data(req_idx)], 'lev', timestep,                                   &
+                       field_data_ptr(:,:,constituent_idx), mark_as_read=.false., error_on_not_found=.false., var_found=var_found)
                   if(.not. var_found) then
                      const_props => cam_model_const_properties()
                      constituent_has_default = .false.
-                     call const_props(constituent_idx)%has_default(constituent_has_default,       &
-                          constituent_errflg, constituent_errmsg)
+                     call const_props(constituent_idx)%has_default(constituent_has_default, constituent_errflg, constituent_errmsg)
                      if (constituent_errflg /= 0) then
                         call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                      end if
                      if (constituent_has_default) then
-                        call                                                                      &
-                             const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg,&
-                             constituent_errmsg)
+                        call const_props(constituent_idx)%default_value(constituent_default_value, constituent_errflg, constituent_errmsg)
                         if (constituent_errflg /= 0) then
                            call endrun(constituent_errmsg, file=__FILE__, line=__LINE__)
                         end if
                         field_data_ptr(:,:,constituent_idx) = constituent_default_value
                         if (masterproc) then
-                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx),           &
-                                ' initialized to default value: ', constituent_default_value
+                           write(iulog,*) 'Consitituent ', ccpp_required_data(req_idx), ' initialized to default value: ', constituent_default_value
                         end if
                      else
                         field_data_ptr(:,:,constituent_idx) = 0._kind_phys
                         if (masterproc) then
-                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx),            &
-                                ' default value not configured.  Setting to 0.'
+                           write(iulog,*) 'Constituent ', ccpp_required_data(req_idx), ' default value not configured.  Setting to 0.'
                         end if
                      end if
                   end if
@@ -183,12 +167,10 @@ CONTAINS
 
                   select case (trim(phys_var_stdnames(name_idx)))
                      case ('potential_temperature')
-                        call read_field(file, 'potential_temperature',                            &
-                             input_var_names(:,name_idx), 'lev', timestep, theta)
+                        call read_field(file, 'potential_temperature', input_var_names(:,name_idx), 'lev', timestep, theta)
 
                      case ('air_pressure_at_sea_level')
-                        call read_field(file, 'air_pressure_at_sea_level',                        &
-                             input_var_names(:,name_idx), timestep, slp)
+                        call read_field(file, 'air_pressure_at_sea_level', input_var_names(:,name_idx), timestep, slp)
 
                   end select !read variables
                end select !special indices
@@ -214,15 +196,12 @@ CONTAINS
 
    end subroutine physics_read_data
 
-   subroutine physics_check_data(file_name, suite_names, timestep, min_difference,                &
-        min_relative_value)
+   subroutine physics_check_data(file_name, suite_names, timestep, min_difference, min_relative_value)
       use pio,                         only: file_desc_t, pio_nowrite
       use cam_abortutils,              only: endrun
       use shr_kind_mod,                only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
-      use physics_data,                only: check_field, find_input_name_idx, no_exist_idx
-      use physics_data,                only: init_mark_idx, prot_no_init_idx, const_idx
-      use cam_ccpp_cap,                only: ccpp_physics_suite_variables
-      use cam_ccpp_cap,                only: cam_advected_constituents_array
+      use physics_data,                only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
+      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_advected_constituents_array
       use cam_constituents,            only: const_get_index
       use ccpp_kinds,                  only: kind_phys
       use cam_logfile,                 only: iulog
@@ -277,16 +256,13 @@ CONTAINS
          write(iulog,*) 'TIMESTEP: ', timestep
       end if
       if (file_name == 'UNSET') then
-         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.',                      &
-              ' Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Namelist variable ncdata_check is UNSET.', ' Model will run, but physics check data will not be printed'
          return
       end if
       ! Open check file:
-      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found,        &
-           log_info=.false.)
+      call cam_get_file(file_name, ncdata_check_loc, allow_fail=.true., lexist=file_found, log_info=.false.)
       if (.not. file_found) then
-         write(iulog,*) 'WARNING: Check file ', trim(file_name),                                  &
-              ' not found. Model will run, but physics check data will not be printed'
+         write(iulog,*) 'WARNING: Check file ', trim(file_name), ' not found. Model will run, but physics check data will not be printed'
          return
       end if
       allocate(file)
@@ -294,30 +270,23 @@ CONTAINS
       ! Loop over CCPP physics/chemistry suites:
       do suite_idx = 1, size(suite_names, 1)
 
-         ! Search for all needed CCPP input variables, so that they can be read from input file
-         ! if need be:
-            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data,         &
-                 errmsg, errflg, input_vars=.true., output_vars=.false.)
+         ! Search for all needed CCPP input variables, so that they can be read from input file if need be:
+            call ccpp_physics_suite_variables(suite_names(suite_idx), ccpp_required_data, errmsg, errflg, input_vars=.true., output_vars=.false.)
 
          ! Loop over all required variables as specified by CCPP suite:
          do req_idx = 1, size(ccpp_required_data, 1)
 
             ! First check if the required variable is a constituent:
-            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false.,     &
-                 warning=.false.)
+            call const_get_index(ccpp_required_data(req_idx), constituent_idx, abort=.false., warning=.false.)
             if (constituent_idx > -1) then
-               ! The required variable is a constituent. Call check variable routine on the
-               ! relevant index of the constituent array
+               ! The required variable is a constituent. Call check variable routine on the relevant index of the constituent array
                field_data_ptr => cam_advected_constituents_array()
-               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep,             &
-                    field_data_ptr(:,:,constituent_idx), ccpp_required_data(req_idx),             &
-                    min_difference, min_relative_value, is_first)
+               call check_field(file, [ccpp_required_data(req_idx)], 'lev', timestep, field_data_ptr(:,:,constituent_idx),                             &
+                    ccpp_required_data(req_idx), min_difference, min_relative_value, is_first)
             else
-               ! The required variable is not a constituent. Check if the variable was read from
-               ! a file
+               ! The required variable is not a constituent. Check if the variable was read from a file
                ! Find IC file input name array index for required variable:
-               call is_read_from_file(ccpp_required_data(req_idx), is_read,                       &
-                    stdnam_idx_out=name_idx)
+               call is_read_from_file(ccpp_required_data(req_idx), is_read, stdnam_idx_out=name_idx)
                if (.not. is_read) then
                   cycle
                end if
@@ -325,12 +294,12 @@ CONTAINS
 
                select case (trim(phys_var_stdnames(name_idx)))
                case ('potential_temperature')
-                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta,     &
-                       'potential_temperature', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), 'lev', timestep, theta, 'potential_temperature', min_difference,                 &
+                       min_relative_value, is_first)
 
                case ('air_pressure_at_sea_level')
-                  call check_field(file, input_var_names(:,name_idx), timestep, slp,              &
-                       'air_pressure_at_sea_level', min_difference, min_relative_value, is_first)
+                  call check_field(file, input_var_names(:,name_idx), timestep, slp, 'air_pressure_at_sea_level', min_difference, min_relative_value,  &
+                       is_first)
 
                end select !check variables
             end if !check if constituent


### PR DESCRIPTION
This PR introduces a large number of standard name and other changes to allow one to run the new Kessler and Held-Suarez physics suites with CAM snapshots, and to ensure that they are bit-for-bit with CAM's results.

This PR also ensures that the SE dycore still runs with both Held-Suarez and Kessler physics suites (but it's values can't be formally checked yet due to the dycore being out-of-sync with CAM).

This PR also performs some code clean-up, and adds the ability for `check_field` to print the location (as an MPI rank, array column, and vertical level) of the maximum difference for each variable, which should help with debugging.

closes #210

## Tests run

Ran single timestep `FPHYStest` runs with CAM snapshots for Held-Suarez and Kessler with GNU on Derecho with the ne3pg3 grid, and got bit-for-bit results.  Also ran `FHS94` and `FKESSLER` compsets with the `ne5pg2` grid and the GNU compiler for five timesteps each, and both ran successfully.