### PR TITLE
Stub interface for MPAS dynamical core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,10 @@ ccpp_framework
 ccs_config
 chem_proc
 cime
-share
-libraries
 components
+libraries
 manage_externals.log
+share
 src/dynamics/mpas/dycore
 src/physics/carma/base
 src/physics/clubb
@@ -15,18 +15,17 @@ src/physics/ncar_ccpp
 src/physics/silhs
 src/utils/history_output
 
-
 # Ignore compiled python
-buildnmlc
 *.pyc
+buildnmlc
 
 # Ignore test output
-test/unit/tmp
 test/include/*.mod
 test/include/*.o
+test/unit/tmp
 
 # Ignore editor temporaries and backups
+*.swp
 *~
 .#*
 \#*#
-*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ share
 libraries
 components
 manage_externals.log
+src/dynamics/mpas/dycore
 src/physics/carma/base
 src/physics/clubb
 src/physics/cosp2/src

--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -5,6 +5,14 @@ repo_url = https://github.com/peverwhee/ccpp-framework
 tag = CPF_0.2.050
 required = True
 
+[mpas]
+local_path = src/dynamics/mpas/dycore
+protocol = git
+repo_url = https://github.com/MPAS-Dev/MPAS-Model.git
+sparse = ../.mpas_sparse_checkout
+tag = v8.0.1
+required = True
+
 [ncar-physics]
 local_path = src/physics/ncar_ccpp
 protocol = git

--- a/cime_config/cam_config.py
+++ b/cime_config/cam_config.py
@@ -310,7 +310,7 @@ class ConfigCAM:
                          "src/dynamics, with a slash ('/') indicating directory hierarchy."]
 
 
-        #Determine dynmaical core and grid-matching regex to use for validation:
+        #Determine dynamical core and grid-matching regex to use for validation:
         dycore, grid_regex = get_atm_hgrid(atm_grid)
 
         #Add dynamical core to config object:
@@ -370,6 +370,11 @@ class ConfigCAM:
             self.create_config("trm", trm_desc, 1, (1, None))
             self.create_config("trn", trn_desc, 1, (1, None))
             self.create_config("trk", trk_desc, 1, (1, None))
+        elif dycore == "mpas":
+            # This only includes the driver and interface code between CAM-SIMA and MPAS dynamical core.
+            # MPAS dynamical core relies on its upstream build infrastructure for compilation instead of CIME to take advantage of future upstream changes automatically.
+            self.create_config("dyn_src_dirs", dyn_dirs_desc, ["mpas"],
+                               valid_list_type="str")
         elif dycore == "none":
             # Source code directories
             self.create_config("dyn_src_dirs", dyn_dirs_desc, ["none"],
@@ -865,7 +870,7 @@ class ConfigCAM:
                                           capgen_db, ic_names)
 
         #Add registry path to config object:
-        init_dir_desc = "Location of auto-generated physics initilazation code."
+        init_dir_desc = "Location of auto-generated physics initialization code."
         self.create_config("init_dir", init_dir_desc, init_dir)
 
         #--------------------------------------------------------------

--- a/src/dynamics/mpas/.mpas_sparse_checkout
+++ b/src/dynamics/mpas/.mpas_sparse_checkout
@@ -1,0 +1,7 @@
+/src/core_atmosphere
+/src/driver
+/src/external
+/src/framework
+/src/operators
+/src/tools
+/src/Makefile

--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -1,0 +1,42 @@
+module dyn_comp
+    use runtime_obj, only: runtime_options
+
+    implicit none
+
+    private
+    ! Provide APIs required by CAM Control.
+    public :: dyn_import_t
+    public :: dyn_export_t
+    public :: dyn_readnl
+    public :: dyn_init
+    ! public :: dyn_run
+    ! public :: dyn_final
+
+    type dyn_import_t
+    end type dyn_import_t
+
+    type dyn_export_t
+    end type dyn_export_t
+contains
+
+! Called by `read_namelist` in `src/control/runtime_opts.F90`.
+subroutine dyn_readnl(namelist_path)
+    character(*), intent(in) :: namelist_path
+end subroutine dyn_readnl
+
+! Called by `cam_init` in `src/control/cam_comp.F90`.
+subroutine dyn_init(cam_runtime_opts, dyn_in, dyn_out)
+    type(runtime_options), intent(in)  :: cam_runtime_opts
+    type(dyn_import_t),    intent(out) :: dyn_in
+    type(dyn_export_t),    intent(out) :: dyn_out
+end subroutine dyn_init
+
+! Not used for now. Intended to be called by `stepon_run*` in `src/dynamics/mpas/stepon.F90`.
+! subroutine dyn_run()
+! end subroutine dyn_run
+
+! Not used for now. Intended to be called by `stepon_final` in `src/dynamics/mpas/stepon.F90`.
+! subroutine dyn_final()
+! end subroutine dyn_final
+
+end module dyn_comp

--- a/src/dynamics/mpas/dyn_grid.F90
+++ b/src/dynamics/mpas/dyn_grid.F90
@@ -1,0 +1,13 @@
+module dyn_grid
+    implicit none
+
+    private
+    ! Provide APIs required by CAM Control.
+    public :: model_grid_init
+contains
+
+! Called by `cam_init` in `src/control/cam_comp.F90`.
+subroutine model_grid_init()
+end subroutine model_grid_init
+
+end module dyn_grid

--- a/src/dynamics/mpas/stepon.F90
+++ b/src/dynamics/mpas/stepon.F90
@@ -1,0 +1,62 @@
+module stepon
+    use camsrfexch,    only: cam_out_t
+    use dyn_comp,      only: dyn_import_t, dyn_export_t
+    use physics_types, only: physics_state, physics_tend
+    use runtime_obj,   only: runtime_options
+    use shr_kind_mod,  only: r8 => shr_kind_r8
+
+    implicit none
+
+    private
+    ! Provide APIs required by CAM Control.
+    public :: stepon_init
+    public :: stepon_run1
+    public :: stepon_run2
+    public :: stepon_run3
+    public :: stepon_final
+contains
+
+! Called by `cam_init` in `src/control/cam_comp.F90`.
+subroutine stepon_init(cam_runtime_opts, dyn_in, dyn_out)
+    type(runtime_options), intent(in) :: cam_runtime_opts
+    type(dyn_import_t),    intent(in) :: dyn_in
+    type(dyn_export_t),    intent(in) :: dyn_out
+end subroutine stepon_init
+
+! Called by `cam_run1` in `src/control/cam_comp.F90`.
+subroutine stepon_run1(dtime_phys, cam_runtime_opts, phys_state, phys_tend, dyn_in, dyn_out)
+    real(r8),              intent(out)   :: dtime_phys
+    type(runtime_options), intent(in)    :: cam_runtime_opts
+    type(physics_state),   intent(inout) :: phys_state
+    type(physics_tend),    intent(inout) :: phys_tend
+    type(dyn_import_t),    intent(inout) :: dyn_in
+    type(dyn_export_t),    intent(inout) :: dyn_out
+end subroutine stepon_run1
+
+! Called by `cam_run2` in `src/control/cam_comp.F90`.
+subroutine stepon_run2(cam_runtime_opts, phys_state, phys_tend, dyn_in, dyn_out)
+    type(runtime_options), intent(in)    :: cam_runtime_opts
+    type(physics_state),   intent(inout) :: phys_state
+    type(physics_tend),    intent(inout) :: phys_tend
+    type(dyn_import_t),    intent(inout) :: dyn_in
+    type(dyn_export_t),    intent(inout) :: dyn_out
+end subroutine stepon_run2
+
+! Called by `cam_run3` in `src/control/cam_comp.F90`.
+subroutine stepon_run3(dtime_phys, cam_runtime_opts, cam_out, phys_state, dyn_in, dyn_out)
+    real(r8),              intent(in)    :: dtime_phys
+    type(runtime_options), intent(in)    :: cam_runtime_opts
+    type(cam_out_t),       intent(inout) :: cam_out
+    type(physics_state),   intent(inout) :: phys_state
+    type(dyn_import_t),    intent(inout) :: dyn_in
+    type(dyn_export_t),    intent(inout) :: dyn_out
+end subroutine stepon_run3
+
+! Called by `cam_final` in `src/control/cam_comp.F90`.
+subroutine stepon_final(cam_runtime_opts, dyn_in, dyn_out)
+    type(runtime_options), intent(in)    :: cam_runtime_opts
+    type(dyn_import_t),    intent(inout) :: dyn_in
+    type(dyn_export_t),    intent(inout) :: dyn_out
+end subroutine stepon_final
+
+end module stepon


### PR DESCRIPTION
This PR introduces stub interface for MPAS dynamical core. This stub interface currently does nothing (i.e., can compile; cannot run), but it provides a fresh start from scratch for actual functionalities to be incrementally implemented later.