### PR TITLE
Integrate MPAS build infrastructure with CIME

### DIFF
--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -141,6 +141,11 @@ def _build_cam():
         #-------------------------------------------------------
         # build the library
         #-------------------------------------------------------
+
+        # If dynamical core is MPAS, setup its build infrastructure so it can be built along with CAM below.
+        if dycore == "mpas":
+            _setup_mpas(case)
+
         complib = os.path.join(libroot, "libatm.a")
         makefile = os.path.join(casetools, "Makefile")
 
@@ -156,22 +161,13 @@ def _build_cam():
         _LOGGER.info("%s: \n\n output:\n %s \n\n err:\n\n%s\n", cmd, out, err)
         expect(retcode == 0, f"Command {cmd} failed with rc={retcode}")
 
-        # If dynamical core is MPAS, build it after CAM due to dependencies.
-        if dycore == "mpas":
-            _build_mpas(case)
-
-def _build_mpas(case: Case) -> None:
+def _setup_mpas(case: Case) -> None:
     """
-    Build MPAS by invoking its build infrastructure.
+    Setup MPAS build infrastructure.
     """
 
-    case_root    = os.path.normpath(case.get_value("CASEROOT"))
     atm_src_root = os.path.normpath(case.get_value("COMP_ROOT_DIR_ATM"))
     atm_bld_root = os.path.normpath(os.path.join(case.get_value("EXEROOT"), "atm", "obj"))
-    lib_root     = os.path.normpath(os.path.join(case.get_value("EXEROOT"), "lib"))
-
-    gmake   = case.get_value("GMAKE")
-    gmake_j = case.get_value("GMAKE_J")
 
     mpas_dycore_src_root = os.path.join(atm_src_root, "src", "dynamics", "mpas", "dycore", "src")
     mpas_dycore_bld_root = os.path.join(atm_bld_root, "mpas")
@@ -188,23 +184,9 @@ def _build_mpas(case: Case) -> None:
         raise FileExistsError(1, "Unexpected file", mpas_dycore_bld_root)
 
     shutil.copytree(mpas_dycore_src_root, mpas_dycore_bld_root, copy_function=_copy2_as_needed, dirs_exist_ok=True)
-    _copy2_as_needed(os.path.normpath(os.path.join(mpas_dycore_src_root, "../../Makefile.in.CESM")), os.path.join(mpas_dycore_bld_root, "Makefile.in.CESM"))
-
-    # Invoke makefile target `libmpas-prepare`.
-    mpas_dycore_make_command  = f'{gmake} -C {mpas_dycore_bld_root} libmpas-prepare ESM="CESM" CASEROOT="{case_root}" LIBROOT="{lib_root}" '
-    mpas_dycore_make_command += f'FCINCLUDES="-I{atm_bld_root}"'
-
-    (sta, out, err) = run_cmd(mpas_dycore_make_command, from_dir=mpas_dycore_bld_root)
-    _LOGGER.info("* Command %s:\n\n  Output:\n%s\n\n  Error:\n%s\n\n", mpas_dycore_make_command, out, err)
-    expect(sta == 0, f"Command {mpas_dycore_make_command} failed with status {sta}")
-
-    # Invoke makefile target `libmpas-build`.
-    mpas_dycore_make_command  = f'{gmake} -C {mpas_dycore_bld_root} -j {gmake_j} libmpas-build ESM="CESM" CASEROOT="{case_root}" LIBROOT="{lib_root}" '
-    mpas_dycore_make_command += f'FCINCLUDES="-I{atm_bld_root}"'
-
-    (sta, out, err) = run_cmd(mpas_dycore_make_command, from_dir=mpas_dycore_bld_root)
-    _LOGGER.info("* Command %s:\n\n  Output:\n%s\n\n  Error:\n%s\n\n", mpas_dycore_make_command, out, err)
-    expect(sta == 0, f"Command {mpas_dycore_make_command} failed with status {sta}")
+    shutil.move(os.path.join(mpas_dycore_bld_root, "Makefile"), os.path.join(mpas_dycore_bld_root, "Makefile.CESM"))
+    _copy2_as_needed(os.path.normpath(os.path.join(mpas_dycore_src_root, os.pardir, os.pardir, "Makefile")), os.path.join(mpas_dycore_bld_root, "Makefile"))
+    _copy2_as_needed(os.path.normpath(os.path.join(mpas_dycore_src_root, os.pardir, os.pardir, "Makefile.in.CESM")), os.path.join(mpas_dycore_bld_root, "Makefile.in.CESM"))
 
 def _copy2_as_needed(src: str, dst: str) -> None:
     """

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -187,9 +187,8 @@ def _build_mpas(case: Case) -> None:
     if os.path.isfile(mpas_dycore_bld_root):
         raise FileExistsError(1, "Unexpected file", mpas_dycore_bld_root)
 
-    if not os.path.isdir(mpas_dycore_bld_root):
-        shutil.copytree(mpas_dycore_src_root, mpas_dycore_bld_root)
-        shutil.copy2(os.path.normpath(os.path.join(mpas_dycore_src_root, "../../Makefile.in.CESM")), os.path.join(mpas_dycore_bld_root, "Makefile.in.CESM"))
+    shutil.copytree(mpas_dycore_src_root, mpas_dycore_bld_root, copy_function=_copy2_as_needed, dirs_exist_ok=True)
+    _copy2_as_needed(os.path.normpath(os.path.join(mpas_dycore_src_root, "../../Makefile.in.CESM")), os.path.join(mpas_dycore_bld_root, "Makefile.in.CESM"))
 
     # Invoke makefile target `libmpas-prepare`.
     mpas_dycore_make_command  = f'{gmake} -C {mpas_dycore_bld_root} libmpas-prepare ESM="CESM" CASEROOT="{case_root}" LIBROOT="{lib_root}" '
@@ -206,6 +205,27 @@ def _build_mpas(case: Case) -> None:
     (sta, out, err) = run_cmd(mpas_dycore_make_command, from_dir=mpas_dycore_bld_root)
     _LOGGER.info("* Command %s:\n\n  Output:\n%s\n\n  Error:\n%s\n\n", mpas_dycore_make_command, out, err)
     expect(sta == 0, f"Command {mpas_dycore_make_command} failed with status {sta}")
+
+def _copy2_as_needed(src: str, dst: str) -> None:
+    """
+    Wrapper around `shutil.copy2`. Copy the file `src` to the file or directory `dst` as needed.
+    """
+
+    if os.path.isfile(src):
+        if os.path.isfile(dst):
+            if int(os.path.getmtime(src)) != int(os.path.getmtime(dst)) or os.path.getsize(src) != os.path.getsize(dst):
+                # `src` and `dst` are both files but their modification time or size differ.
+                # Example scenario: User modified some existing source code files.
+                print("1. Copy from", src, "to", dst)
+                print(os.path.getmtime(src), os.path.getmtime(dst))
+                print(os.path.getsize(src), os.path.getsize(dst))
+                shutil.copy2(src, dst)
+        else:
+            if os.path.isdir(dst) or os.path.isdir(os.path.dirname(dst)):
+                # `src` is a new file that does not exist at `dst`.
+                # Example scenario: User added some new source code files.
+                print("2. Copy from", src, "to", dst)
+                shutil.copy2(src, dst)
 
 ###############################################################################
 

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -216,15 +216,11 @@ def _copy2_as_needed(src: str, dst: str) -> None:
             if int(os.path.getmtime(src)) != int(os.path.getmtime(dst)) or os.path.getsize(src) != os.path.getsize(dst):
                 # `src` and `dst` are both files but their modification time or size differ.
                 # Example scenario: User modified some existing source code files.
-                print("1. Copy from", src, "to", dst)
-                print(os.path.getmtime(src), os.path.getmtime(dst))
-                print(os.path.getsize(src), os.path.getsize(dst))
                 shutil.copy2(src, dst)
         else:
             if os.path.isdir(dst) or os.path.isdir(os.path.dirname(dst)):
                 # `src` is a new file that does not exist at `dst`.
                 # Example scenario: User added some new source code files.
-                print("2. Copy from", src, "to", dst)
                 shutil.copy2(src, dst)
 
 ###############################################################################

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -156,6 +156,57 @@ def _build_cam():
         _LOGGER.info("%s: \n\n output:\n %s \n\n err:\n\n%s\n", cmd, out, err)
         expect(retcode == 0, f"Command {cmd} failed with rc={retcode}")
 
+        # If dynamical core is MPAS, build it after CAM due to dependencies.
+        if dycore == "mpas":
+            _build_mpas(case)
+
+def _build_mpas(case: Case) -> None:
+    """
+    Build MPAS by invoking its build infrastructure.
+    """
+
+    case_root    = os.path.normpath(case.get_value("CASEROOT"))
+    atm_src_root = os.path.normpath(case.get_value("COMP_ROOT_DIR_ATM"))
+    atm_bld_root = os.path.normpath(os.path.join(case.get_value("EXEROOT"), "atm", "obj"))
+    lib_root     = os.path.normpath(os.path.join(case.get_value("EXEROOT"), "lib"))
+
+    gmake   = case.get_value("GMAKE")
+    gmake_j = case.get_value("GMAKE_J")
+
+    mpas_dycore_src_root = os.path.join(atm_src_root, "src", "dynamics", "mpas", "dycore", "src")
+    mpas_dycore_bld_root = os.path.join(atm_bld_root, "mpas")
+
+    # Make sure `mpas_dycore_src_root` exists. If not, it is likely that `./manage_externals/checkout_externals` did not succeed.
+    if os.path.isfile(mpas_dycore_src_root):
+        raise FileExistsError(1, "Unexpected file", mpas_dycore_src_root)
+
+    if not os.path.isdir(mpas_dycore_src_root):
+        raise FileNotFoundError(1, "No such directory", mpas_dycore_src_root)
+
+    # MPAS supports "in-source" build only. Copy source code to `mpas_dycore_bld_root` to avoid polluting `mpas_dycore_src_root`.
+    if os.path.isfile(mpas_dycore_bld_root):
+        raise FileExistsError(1, "Unexpected file", mpas_dycore_bld_root)
+
+    if not os.path.isdir(mpas_dycore_bld_root):
+        shutil.copytree(mpas_dycore_src_root, mpas_dycore_bld_root)
+        shutil.copy2(os.path.normpath(os.path.join(mpas_dycore_src_root, "../../Makefile.in.CESM")), os.path.join(mpas_dycore_bld_root, "Makefile.in.CESM"))
+
+    # Invoke makefile target `libmpas-prepare`.
+    mpas_dycore_make_command  = f'{gmake} -C {mpas_dycore_bld_root} libmpas-prepare ESM="CESM" CASEROOT="{case_root}" LIBROOT="{lib_root}" '
+    mpas_dycore_make_command += f'FCINCLUDES="-I{atm_bld_root}"'
+
+    (sta, out, err) = run_cmd(mpas_dycore_make_command, from_dir=mpas_dycore_bld_root)
+    _LOGGER.info("* Command %s:\n\n  Output:\n%s\n\n  Error:\n%s\n\n", mpas_dycore_make_command, out, err)
+    expect(sta == 0, f"Command {mpas_dycore_make_command} failed with status {sta}")
+
+    # Invoke makefile target `libmpas-build`.
+    mpas_dycore_make_command  = f'{gmake} -C {mpas_dycore_bld_root} -j {gmake_j} libmpas-build ESM="CESM" CASEROOT="{case_root}" LIBROOT="{lib_root}" '
+    mpas_dycore_make_command += f'FCINCLUDES="-I{atm_bld_root}"'
+
+    (sta, out, err) = run_cmd(mpas_dycore_make_command, from_dir=mpas_dycore_bld_root)
+    _LOGGER.info("* Command %s:\n\n  Output:\n%s\n\n  Error:\n%s\n\n", mpas_dycore_make_command, out, err)
+    expect(sta == 0, f"Command {mpas_dycore_make_command} failed with status {sta}")
+
 ###############################################################################
 
 if __name__ == "__main__":

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -103,11 +103,11 @@
 
   <entry id="CAM_DYCORE">
     <type>char</type>
-    <valid_values>eul,fv,mpasa,se,none</valid_values>
+    <valid_values>eul,fv,mpas,se,none</valid_values>
     <default_value>fv</default_value>
     <values match="last">
       <value grid="a%T[1-9]">eul</value>
-      <value grid="a%mpasa[0-9]+">mpasa</value>
+      <value grid="a%mpasa[0-9]+">mpas</value>
       <value grid="a%ne[0-9]">se</value>
     </values>
     <group>build_component_cam</group>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -103,10 +103,11 @@
 
   <entry id="CAM_DYCORE">
     <type>char</type>
-    <valid_values>eul,fv,se,none</valid_values>
+    <valid_values>eul,fv,mpas,se,none</valid_values>
     <default_value>fv</default_value>
     <values match="last">
-      <value grid="a%T[1-9]" >eul</value>
+      <value grid="a%T[1-9]">eul</value>
+      <value grid="a%mpasa[0-9]+">mpas</value>
       <value grid="a%ne[0-9]">se</value>
     </values>
     <group>build_component_cam</group>
@@ -303,11 +304,12 @@
 
   <entry id="CAM_LINKED_LIBS">
     <type>char</type>
-    <valid_values></valid_values>
+    <valid_values>-lmpas</valid_values>
     <default_value>-lmusica -ljsonfortran</default_value>
     <values match="last">
-      <!--Turn off for physics testbed -->
-      <value compset="_CAM%PHYSTEST"> </value>
+      <!-- Turn off for physics testbed -->
+      <value compset="_CAM%PHYSTEST"></value>
+      <value grid="a%mpasa[0-9]+">-lmpas</value>
     </values>
     <group>build_component_cam</group>
     <file>env_build.xml</file>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -304,9 +304,9 @@
 
   <entry id="CAM_LINKED_LIBS">
     <type>char</type>
-    <valid_values>-lmpas</valid_values>
+    <valid_values></valid_values>
     <default_value>-lmusica -ljsonfortran</default_value>
-    <values match="last">
+    <values match="last" modifier="additive">
       <!-- Turn off for physics testbed -->
       <value compset="_CAM%PHYSTEST"></value>
       <value grid="a%mpasa[0-9]+">-lmpas</value>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -103,11 +103,11 @@
 
   <entry id="CAM_DYCORE">
     <type>char</type>
-    <valid_values>eul,fv,mpas,se,none</valid_values>
+    <valid_values>eul,fv,mpasa,se,none</valid_values>
     <default_value>fv</default_value>
     <values match="last">
       <value grid="a%T[1-9]">eul</value>
-      <value grid="a%mpasa[0-9]+">mpas</value>
+      <value grid="a%mpasa[0-9]+">mpasa</value>
       <value grid="a%ne[0-9]">se</value>
     </values>
     <group>build_component_cam</group>

--- a/src/dynamics/mpas/Makefile
+++ b/src/dynamics/mpas/Makefile
@@ -1,0 +1,9 @@
+# This Makefile is invoked by CIME Makefile (i.e., `cime/CIME/Tools/Makefile`).
+
+# Some targets in MPAS build infrastructure are sensitive to this environment variable. Override it to avoid build issues.
+override PWD = $(CURDIR)
+export PWD
+
+all:
+	$(MAKE) -f Makefile.CESM libmpas-prepare ESM="CESM"
+	$(MAKE) -f Makefile.CESM libmpas-build ESM="CESM"

--- a/src/dynamics/mpas/Makefile.in.CESM
+++ b/src/dynamics/mpas/Makefile.in.CESM
@@ -1,0 +1,110 @@
+ifeq ($(strip $(CASEROOT)),)
+    $(warning `CASEROOT` should not be empty. Defaulting to `.`)
+
+    CASEROOT = .
+endif
+
+ifeq ($(strip $(LIBROOT)),)
+    $(warning `LIBROOT` should not be empty. Defaulting to `..`)
+
+    LIBROOT = ..
+endif
+
+#
+# Define and export variables used by MPAS build infrastructure.
+#
+
+export CP = cp -afv
+export RM = rm -frv
+
+# Constants.
+export AUTOCLEAN       = false
+export BUILD_TARGET    = N/A
+export CORE            = atmosphere
+export EXE_NAME        = atmosphere_model
+export GEN_F90         = false
+export GIT_VERSION     = N/A
+export NAMELIST_SUFFIX = atmosphere
+
+# Read variables (e.g., build options) from `Macros.make`.
+include $(CASEROOT)/Macros.make
+
+# Translate variables (e.g., build options) from `Macros.make` to their equivalent ones used by MPAS build infrastructure.
+export AR             := ar
+export ARFLAGS        := -M
+export CC             := $(strip $(MPICC))
+export CFLAGS         := $(strip $(CFLAGS))
+export CPP            := cpp -P -traditional
+export CPPFLAGS       := -D_MPI \
+                         -DMPAS_BUILD_TARGET="$(BUILD_TARGET)" \
+                         -DMPAS_CAM_DYCORE \
+                         -DMPAS_EXE_NAME="$(EXE_NAME)" \
+                         -DMPAS_EXTERNAL_ESMF_LIB \
+                         -DMPAS_GIT_VERSION="$(GIT_VERSION)" \
+                         -DMPAS_NAMELIST_SUFFIX="$(NAMELIST_SUFFIX)" \
+                         -DMPAS_NATIVE_TIMERS \
+                         -DMPAS_NO_ESMF_INIT \
+                         -DMPAS_PIO_SUPPORT \
+                         -DUSE_PIO2
+export CPPINCLUDES    := $(strip $(CPPINCLUDES))
+export CXX            := $(strip $(MPICXX))
+export CXXFLAGS       := $(strip $(CXXFLAGS))
+export FC             := $(strip $(MPIFC))
+export FCINCLUDES     := $(strip $(FCINCLUDES))
+export FFLAGS         := $(strip $(FC_AUTO_R8) $(FFLAGS) $(FREEFLAGS))
+export LDFLAGS        := $(strip $(LDFLAGS))
+export LIBS           := $(strip $(LIBS))
+export LINKER         := $(strip $(MPIFC))
+export SCC            := $(strip $(SCC))
+export SCXX           := $(strip $(SCXX))
+export SFC            := $(strip $(SFC))
+
+#
+# Targets.
+#
+
+.PHONY: all
+all:
+	@echo 'Supplemental Makefile for MPAS Dynamical Core in CESM'
+	@echo ''
+	@echo 'Variables (e.g., build options) will be read from `$${CASEROOT}/Macros.make`.'
+	@echo 'MPAS will be built as a static library located at `$${LIBROOT}/libmpas.a`.'
+	@echo ''
+	@echo 'Usage hints:'
+	@echo '    `make libmpas-prepare ESM="CESM" CASEROOT="..." LIBROOT="..."`'
+	@echo '    `make libmpas-build ESM="CESM" CASEROOT="..." LIBROOT="..."`'
+	@echo '    `make libmpas-clean ESM="CESM" CASEROOT="..." LIBROOT="..."`'
+
+.PHONY: libmpas-prepare
+libmpas-prepare: libmpas-archiver-script.txt libmpas-no-physics
+
+# Combine multiple static libraries into `libmpas.a` via archiver/MRI script. This requires GNU or GNU-like archiver (`ar`) program.
+libmpas-archiver-script.txt:
+	@echo "create libmpas.a"       > $(@)
+	@echo "addlib libdycore.a"    >> $(@)
+	@echo "addlib libframework.a" >> $(@)
+	@echo "addlib libops.a"       >> $(@)
+	@echo "save"                  >> $(@)
+	@echo "end"                   >> $(@)
+
+# Do not use built-in MPAS/WRF physics.
+.PHONY: libmpas-no-physics
+libmpas-no-physics:
+	@sed -E -i -e "s/^ *PHYSICS=.+$$/PHYSICS=/g" core_atmosphere/Makefile
+
+.PHONY: libmpas-build
+libmpas-build: $(LIBROOT)/libmpas.a
+
+$(LIBROOT)/libmpas.a: libmpas.a
+	$(CP) $(<) $(@)
+
+libmpas.a: $(AUTOCLEAN_DEPS) dycore externals frame ops
+	$(AR) $(ARFLAGS) < libmpas-archiver-script.txt
+
+.PHONY: libmpas-clean
+libmpas-clean: clean
+	$(RM) $(LIBROOT)/libmpas.a libmpas.a
+
+.PHONY: externals
+externals: $(AUTOCLEAN_DEPS)
+	( cd external; $(MAKE) FC="$(FC)" SFC="$(SFC)" CC="$(CC)" SCC="$(SCC)" FFLAGS="$(FFLAGS)" CFLAGS="$(CFLAGS)" CPP="$(CPP)" NETCDF="$(NETCDF)" CORE="$(CORE)" ezxml-lib )

--- a/src/dynamics/mpas/Makefile.in.CESM
+++ b/src/dynamics/mpas/Makefile.in.CESM
@@ -1,9 +1,3 @@
-ifeq ($(strip $(CASEROOT)),)
-    $(warning `CASEROOT` should not be empty. Defaulting to `.`)
-
-    CASEROOT = .
-endif
-
 ifeq ($(strip $(LIBROOT)),)
     $(warning `LIBROOT` should not be empty. Defaulting to `..`)
 
@@ -27,14 +21,9 @@ export GEN_F90         = false
 export GIT_VERSION     = N/A
 export NAMELIST_SUFFIX = atmosphere
 
-# Read variables (e.g., build options) from `Macros.make`.
-include $(CASEROOT)/Macros.make
-
-# Translate variables (e.g., build options) from `Macros.make` to their equivalent ones used by MPAS build infrastructure.
+# Customize variables (e.g., build options) for use with CESM.
 export AR             := ar
 export ARFLAGS        := -M
-export CC             := $(strip $(MPICC))
-export CFLAGS         := $(strip $(CFLAGS))
 export CPP            := cpp -P -traditional
 export CPPFLAGS       := -D_MPI \
                          -DMPAS_BUILD_TARGET="$(BUILD_TARGET)" \
@@ -45,20 +34,15 @@ export CPPFLAGS       := -D_MPI \
                          -DMPAS_NAMELIST_SUFFIX="$(NAMELIST_SUFFIX)" \
                          -DMPAS_NATIVE_TIMERS \
                          -DMPAS_NO_ESMF_INIT \
-                         -DMPAS_PIO_SUPPORT \
-                         -DUSE_PIO2
-export CPPINCLUDES    := $(strip $(CPPINCLUDES))
-export CXX            := $(strip $(MPICXX))
-export CXXFLAGS       := $(strip $(CXXFLAGS))
-export FC             := $(strip $(MPIFC))
-export FCINCLUDES     := $(strip $(FCINCLUDES))
-export FFLAGS         := $(strip $(FC_AUTO_R8) $(FFLAGS) $(FREEFLAGS))
-export LDFLAGS        := $(strip $(LDFLAGS))
-export LIBS           := $(strip $(LIBS))
-export LINKER         := $(strip $(MPIFC))
-export SCC            := $(strip $(SCC))
-export SCXX           := $(strip $(SCXX))
-export SFC            := $(strip $(SFC))
+                         -DMPAS_PIO_SUPPORT
+# `PIODEF` is defined by CIME Makefile (i.e., `cime/CIME/Tools/Makefile`). Its value can be empty or `-DUSE_PIO2`.
+ifneq ($(strip $(PIODEF)),)
+    export CPPFLAGS   += $(strip $(PIODEF))
+endif
+export LINKER         := $(strip $(FC))
+export SCC            := $(strip $(CC))
+export SCXX           := $(strip $(CXX))
+export SFC            := $(strip $(FC))
 
 #
 # Targets.
@@ -68,16 +52,16 @@ export SFC            := $(strip $(SFC))
 all:
 	@echo 'Supplemental Makefile for MPAS Dynamical Core in CESM'
 	@echo ''
-	@echo 'Variables (e.g., build options) will be read from `$${CASEROOT}/Macros.make`.'
 	@echo 'MPAS will be built as a static library located at `$${LIBROOT}/libmpas.a`.'
+	@echo 'Users are responsible to provide all necessary build options via environment variables or command line arguments.'
 	@echo ''
 	@echo 'Usage hints:'
-	@echo '    `make libmpas-prepare ESM="CESM" CASEROOT="..." LIBROOT="..."`'
-	@echo '    `make libmpas-build ESM="CESM" CASEROOT="..." LIBROOT="..."`'
-	@echo '    `make libmpas-clean ESM="CESM" CASEROOT="..." LIBROOT="..."`'
+	@echo '    `make libmpas-prepare ESM="CESM" LIBROOT="..."`'
+	@echo '    `make libmpas-build ESM="CESM" LIBROOT="..."`'
+	@echo '    `make libmpas-clean ESM="CESM" LIBROOT="..."`'
 
 .PHONY: libmpas-prepare
-libmpas-prepare: libmpas-archiver-script.txt libmpas-no-physics
+libmpas-prepare: libmpas-archiver-script.txt libmpas-no-physics libmpas-preview
 
 # Combine multiple static libraries into `libmpas.a` via archiver/MRI script. This requires GNU or GNU-like archiver (`ar`) program.
 libmpas-archiver-script.txt:
@@ -92,6 +76,28 @@ libmpas-archiver-script.txt:
 .PHONY: libmpas-no-physics
 libmpas-no-physics:
 	@sed -E -i -e "s/^ *PHYSICS=.+$$/PHYSICS=/g" core_atmosphere/Makefile
+
+.PHONY: libmpas-preview
+libmpas-preview:
+	@echo "Previewing build options for $(LIBROOT)/libmpas.a:"
+	@echo "AR = $(AR)"
+	@echo "ARFLAGS = $(ARFLAGS)"
+	@echo "CC = $(CC)"
+	@echo "CFLAGS = $(CFLAGS)"
+	@echo "CPP = $(CPP)"
+	@echo "CPPFLAGS = $(CPPFLAGS)"
+	@echo "CPPINCLUDES = $(CPPINCLUDES)"
+	@echo "CXX = $(CXX)"
+	@echo "CXXFLAGS = $(CXXFLAGS)"
+	@echo "FC = $(FC)"
+	@echo "FCINCLUDES = $(FCINCLUDES)"
+	@echo "FFLAGS = $(FFLAGS)"
+	@echo "LDFLAGS = $(LDFLAGS)"
+	@echo "LIBS = $(LIBS)"
+	@echo "LINKER = $(LINKER)"
+	@echo "SCC = $(SCC)"
+	@echo "SCXX = $(SCXX)"
+	@echo "SFC = $(SFC)"
 
 .PHONY: libmpas-build
 libmpas-build: $(LIBROOT)/libmpas.a

--- a/src/dynamics/mpas/Makefile.in.CESM
+++ b/src/dynamics/mpas/Makefile.in.CESM
@@ -15,6 +15,7 @@ endif
 #
 
 export CP = cp -afv
+export MKDIR = mkdir -pv
 export RM = rm -frv
 
 # Constants.
@@ -96,6 +97,7 @@ libmpas-no-physics:
 libmpas-build: $(LIBROOT)/libmpas.a
 
 $(LIBROOT)/libmpas.a: libmpas.a
+	$(MKDIR) $(LIBROOT)
 	$(CP) $(<) $(@)
 
 libmpas.a: $(AUTOCLEAN_DEPS) dycore externals frame ops


### PR DESCRIPTION
This PR brings integration of MPAS build infrastructure with CIME. If MPAS dynamical core is selected (determined from model grid specifications), it will be built as a part of the usual CIME build process (i.e., `case.build`).

The approach taken here is to reuse upstream MPAS build infrastructure as much as possible. This way, it would be easier to keep in sync with future upstream changes. However, by default, MPAS is built as a standalone executable. A supplemental `Makefile` is therefore needed to enable MPAS to be built as a static library, which is then linked into the host model executable.

This PR should be considered *after* #244.