### PR TITLE
Comment out linked libs for FPHYStest compset

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -308,7 +308,7 @@
     <default_value>-lmusica -ljsonfortran</default_value>
     <values match="last" modifier="additive">
       <!-- Turn off for physics testbed -->
-      <value compset="_CAM%PHYSTEST"></value>
+      <!-- <value compset="_CAM%PHYSTEST"></value> -->
       <value grid="a%mpasa[0-9]+">-lmpas</value>
     </values>
     <group>build_component_cam</group>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -305,11 +305,12 @@
   <entry id="CAM_LINKED_LIBS">
     <type>char</type>
     <valid_values></valid_values>
-    <default_value>-lmusica -ljsonfortran</default_value>
+    <default_value> </default_value>
     <values match="last" modifier="additive">
-      <!-- Turn off for physics testbed -->
-      <!-- <value compset="_CAM%PHYSTEST"></value> -->
-      <value grid="a%mpasa[0-9]+">-lmpas</value>
+      <!-- Turn on chemistry if not using physics testbed -->
+      <value compset="^((?!_CAM%PHYSTEST).)*$">-lmusica -ljsonfortran</value>
+      <!-- Add MPAS if using mpas grid and not using physics testbed -->
+      <value compset="^((?!_CAM%PHYSTEST).)*$" grid="a%mpasa[0-9]+">-lmpas</value>
     </values>
     <group>build_component_cam</group>
     <file>env_build.xml</file>


### PR DESCRIPTION
Temporary fix; this means we'll have to do ./xmlchange CAM_LINKED_LIBS="" before trying to build an FPHYStest case.