### PR TITLE
Implement model grid initialization for MPAS dynamical core

### DIFF
--- a/Externals_CAM.cfg
+++ b/Externals_CAM.cfg
@@ -10,7 +10,7 @@ local_path = src/dynamics/mpas/dycore
 protocol = git
 repo_url = https://github.com/MPAS-Dev/MPAS-Model.git
 sparse = ../.mpas_sparse_checkout
-tag = v8.0.1
+hash = ed6f8e39ec0a811b6d079ca0fc6f9fb6e30bad23
 required = True
 
 [ncar-physics]

--- a/cime_config/namelist_definition_cam.xml
+++ b/cime_config/namelist_definition_cam.xml
@@ -140,6 +140,8 @@
       <value dyn="se" hgrid="ne30np4" nlev="70" sim_year="1850">${DIN_LOC_ROOT}/atm/waccm/ic/waccm5_1850_ne30np4_L70_0001-01-11-00000_c151217.nc</value>
       <value dyn="se" hgrid="ne30np4" nlev="70">${DIN_LOC_ROOT}/atm/waccm/ic/fw2000_ne30np4_L70_c181221.nc</value>
       <value hgrid="64x128" nlev="30" scam="1">${DIN_LOC_ROOT}/atm/cam/inic/gaus/cami_0000-09-01_64x128_L30_c031210.nc</value>
+      <value dyn="mpas" hgrid="mpasa120" nlev="32" analytic_ic="1">${DIN_LOC_ROOT}/atm/cam/inic/mpas/mpasa120_L32_notopo_coords_c201216.nc</value>
+      <value dyn="mpas" hgrid="mpasa480" nlev="32" analytic_ic="1">${DIN_LOC_ROOT}/atm/cam/inic/mpas/mpasa480_L32_notopo_coords_c201125.nc</value>
     </values>
   </entry>
   <entry id="pertlim">
@@ -350,6 +352,7 @@
       <value phys_suite="cam4">26</value>
       <value phys_suite="cam5">30</value>
       <value phys_suite="cam6">32</value>
+      <value dyn="mpas" analytic_ic="1">32</value>
     </values>
   </entry>
 

--- a/src/dynamics/mpas/.mpas_sparse_checkout
+++ b/src/dynamics/mpas/.mpas_sparse_checkout
@@ -5,3 +5,4 @@
 /src/operators
 /src/tools
 /src/Makefile
+/README.md

--- a/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
@@ -561,50 +561,71 @@ contains
         end select
 
         call mpas_pool_get_config(self % domain_ptr % configs, 'config_calendar_type', config_pointer_c)
+
+        if (.not. associated(config_pointer_c)) then
+            call self % model_error('Failed to find config', subname, __LINE__)
+        end if
+
         config_pointer_c = trim(adjustl(mpas_calendar))
-
         call self % debug_print('config_calendar_type = ', [config_pointer_c])
-
         nullify(config_pointer_c)
 
         ! MPAS represents date and time in ISO 8601 format. However, the separator between date and time is `_`
         ! instead of standard `T`.
         ! Format in `YYYY-MM-DD_hh:mm:ss` is acceptable.
         call mpas_pool_get_config(self % domain_ptr % configs, 'config_start_time', config_pointer_c)
+
+        if (.not. associated(config_pointer_c)) then
+            call self % model_error('Failed to find config', subname, __LINE__)
+        end if
+
         config_pointer_c = stringify(start_date_time(1:3), '-') // '_' // stringify(start_date_time(4:6), ':')
-
         call self % debug_print('config_start_time = ', [config_pointer_c])
-
         nullify(config_pointer_c)
 
         call mpas_pool_get_config(self % domain_ptr % configs, 'config_stop_time', config_pointer_c)
+
+        if (.not. associated(config_pointer_c)) then
+            call self % model_error('Failed to find config', subname, __LINE__)
+        end if
+
         config_pointer_c = stringify(stop_date_time(1:3), '-') // '_' // stringify(stop_date_time(4:6), ':')
-
         call self % debug_print('config_stop_time = ', [config_pointer_c])
-
         nullify(config_pointer_c)
 
         ! Format in `DD_hh:mm:ss` is acceptable.
         call mpas_pool_get_config(self % domain_ptr % configs, 'config_run_duration', config_pointer_c)
+
+        if (.not. associated(config_pointer_c)) then
+            call self % model_error('Failed to find config', subname, __LINE__)
+        end if
+
         config_pointer_c = stringify([run_duration(1)]) // '_' // stringify(run_duration(2:4), ':')
-
         call self % debug_print('config_run_duration = ', [config_pointer_c])
-
         nullify(config_pointer_c)
 
         ! Reflect current run type to MPAS.
         if (initial_run) then
             ! Run type is initial run.
             call mpas_pool_get_config(self % domain_ptr % configs, 'config_do_restart', config_pointer_l)
+
+            if (.not. associated(config_pointer_l)) then
+                call self % model_error('Failed to find config', subname, __LINE__)
+            end if
+
             config_pointer_l = .false.
         else
             ! Run type is branch or restart run.
             call mpas_pool_get_config(self % domain_ptr % configs, 'config_do_restart', config_pointer_l)
+
+            if (.not. associated(config_pointer_l)) then
+                call self % model_error('Failed to find config', subname, __LINE__)
+            end if
+
             config_pointer_l = .true.
         end if
 
         call self % debug_print('config_do_restart = ', [config_pointer_l])
-
         nullify(config_pointer_l)
 
         call self % debug_print(subname // ' completed')

--- a/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
@@ -518,9 +518,9 @@ contains
 
         character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_read_namelist'
         character(strkind) :: mpas_calendar
-        character(strkind), pointer :: config_value_c => null()
+        character(strkind), pointer :: config_pointer_c => null()
         integer :: ierr
-        logical, pointer :: config_value_l => null()
+        logical, pointer :: config_pointer_l => null()
 
         call self % debug_print(subname // ' entered')
 
@@ -560,52 +560,52 @@ contains
                     subname, __LINE__)
         end select
 
-        call mpas_pool_get_config(self % domain_ptr % configs, 'config_calendar_type', config_value_c)
-        config_value_c = trim(adjustl(mpas_calendar))
+        call mpas_pool_get_config(self % domain_ptr % configs, 'config_calendar_type', config_pointer_c)
+        config_pointer_c = trim(adjustl(mpas_calendar))
 
-        call self % debug_print('config_calendar_type = ', [config_value_c])
+        call self % debug_print('config_calendar_type = ', [config_pointer_c])
 
-        nullify(config_value_c)
+        nullify(config_pointer_c)
 
         ! MPAS represents date and time in ISO 8601 format. However, the separator between date and time is `_`
         ! instead of standard `T`.
         ! Format in `YYYY-MM-DD_hh:mm:ss` is acceptable.
-        call mpas_pool_get_config(self % domain_ptr % configs, 'config_start_time', config_value_c)
-        config_value_c = stringify(start_date_time(1:3), '-') // '_' // stringify(start_date_time(4:6), ':')
+        call mpas_pool_get_config(self % domain_ptr % configs, 'config_start_time', config_pointer_c)
+        config_pointer_c = stringify(start_date_time(1:3), '-') // '_' // stringify(start_date_time(4:6), ':')
 
-        call self % debug_print('config_start_time = ', [config_value_c])
+        call self % debug_print('config_start_time = ', [config_pointer_c])
 
-        nullify(config_value_c)
+        nullify(config_pointer_c)
 
-        call mpas_pool_get_config(self % domain_ptr % configs, 'config_stop_time', config_value_c)
-        config_value_c = stringify(stop_date_time(1:3), '-') // '_' // stringify(stop_date_time(4:6), ':')
+        call mpas_pool_get_config(self % domain_ptr % configs, 'config_stop_time', config_pointer_c)
+        config_pointer_c = stringify(stop_date_time(1:3), '-') // '_' // stringify(stop_date_time(4:6), ':')
 
-        call self % debug_print('config_stop_time = ', [config_value_c])
+        call self % debug_print('config_stop_time = ', [config_pointer_c])
 
-        nullify(config_value_c)
+        nullify(config_pointer_c)
 
         ! Format in `DD_hh:mm:ss` is acceptable.
-        call mpas_pool_get_config(self % domain_ptr % configs, 'config_run_duration', config_value_c)
-        config_value_c = stringify([run_duration(1)]) // '_' // stringify(run_duration(2:4), ':')
+        call mpas_pool_get_config(self % domain_ptr % configs, 'config_run_duration', config_pointer_c)
+        config_pointer_c = stringify([run_duration(1)]) // '_' // stringify(run_duration(2:4), ':')
 
-        call self % debug_print('config_run_duration = ', [config_value_c])
+        call self % debug_print('config_run_duration = ', [config_pointer_c])
 
-        nullify(config_value_c)
+        nullify(config_pointer_c)
 
         ! Reflect current run type to MPAS.
         if (initial_run) then
             ! Run type is initial run.
-            call mpas_pool_get_config(self % domain_ptr % configs, 'config_do_restart', config_value_l)
-            config_value_l = .false.
+            call mpas_pool_get_config(self % domain_ptr % configs, 'config_do_restart', config_pointer_l)
+            config_pointer_l = .false.
         else
             ! Run type is branch or restart run.
-            call mpas_pool_get_config(self % domain_ptr % configs, 'config_do_restart', config_value_l)
-            config_value_l = .true.
+            call mpas_pool_get_config(self % domain_ptr % configs, 'config_do_restart', config_pointer_l)
+            config_pointer_l = .true.
         end if
 
-        call self % debug_print('config_do_restart = ', [config_value_l])
+        call self % debug_print('config_do_restart = ', [config_pointer_l])
 
-        nullify(config_value_l)
+        nullify(config_pointer_l)
 
         call self % debug_print(subname // ' completed')
     end subroutine dyn_mpas_read_namelist

--- a/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
@@ -11,15 +11,33 @@ module dyn_mpas_subdriver
 
     ! Modules from external libraries.
     use mpi, only: mpi_comm_null, mpi_comm_rank, mpi_success
-    use pio, only: iosystem_desc_t, pio_iosystem_is_active
+    use pio, only: file_desc_t, iosystem_desc_t, pio_file_is_open, pio_iosystem_is_active, &
+                   pio_inq_varid, pio_inq_varndims, pio_noerr
 
     ! Modules from MPAS.
     use atm_core_interface, only: atm_setup_core, atm_setup_domain
-    use mpas_derived_types, only: core_type, domain_type
+    use mpas_bootstrapping, only: mpas_bootstrap_framework_phase1, mpas_bootstrap_framework_phase2
+    use mpas_derived_types, only: core_type, domain_type, &
+                                  mpas_pool_type, mpas_pool_field_info_type, &
+                                  mpas_pool_character, mpas_pool_real, mpas_pool_integer, &
+                                  mpas_stream_type, mpas_stream_noerr, &
+                                  mpas_io_native_precision, mpas_io_pnetcdf, mpas_io_read, mpas_io_write, &
+                                  field0dchar, field1dchar, &
+                                  field0dinteger, field1dinteger, field2dinteger, field3dinteger, &
+                                  field0dreal, field1dreal, field2dreal, field3dreal, field4dreal, field5dreal
+    use mpas_dmpar, only: mpas_dmpar_exch_halo_field, &
+                          mpas_dmpar_max_int, mpas_dmpar_sum_int
     use mpas_domain_routines, only: mpas_allocate_domain
     use mpas_framework, only: mpas_framework_init_phase1, mpas_framework_init_phase2
-    use mpas_kind_types, only: strkind
-    use mpas_pool_routines, only: mpas_pool_get_config
+    use mpas_io_streams, only: mpas_createstream, mpas_closestream, mpas_streamaddfield, &
+                               mpas_readstream, mpas_writestream, mpas_writestreamatt
+    use mpas_kind_types, only: rkind, strkind
+    use mpas_pool_routines, only: mpas_pool_create_pool, mpas_pool_destroy_pool, mpas_pool_get_subpool, &
+                                  mpas_pool_add_config, mpas_pool_get_config, &
+                                  mpas_pool_get_array, &
+                                  mpas_pool_get_dimension, &
+                                  mpas_pool_get_field, mpas_pool_get_field_info
+    use mpas_stream_manager, only: postread_reindex, prewrite_reindex, postwrite_reindex
 
     implicit none
 
@@ -60,7 +78,188 @@ module dyn_mpas_subdriver
         procedure, pass, public :: init_phase1 => dyn_mpas_init_phase1
         procedure, pass, public :: read_namelist => dyn_mpas_read_namelist
         procedure, pass, public :: init_phase2 => dyn_mpas_init_phase2
+        procedure, pass, public :: init_phase3 => dyn_mpas_init_phase3
+        procedure, pass, public :: read_write_stream => dyn_mpas_read_write_stream
+        procedure, pass :: init_stream_with_pool => dyn_mpas_init_stream_with_pool
+        procedure, pass, public :: exchange_halo => dyn_mpas_exchange_halo
+
+        ! Accessor subroutines for users to access internal states of MPAS dynamical core.
+
+        procedure, pass, public :: get_global_mesh_dimension => dyn_mpas_get_global_mesh_dimension
+
+        procedure, pass :: get_pool_pointer => dyn_mpas_get_pool_pointer
+
+        procedure, pass :: get_variable_pointer_c0 => dyn_mpas_get_variable_pointer_c0
+        procedure, pass :: get_variable_pointer_c1 => dyn_mpas_get_variable_pointer_c1
+        procedure, pass :: get_variable_pointer_i0 => dyn_mpas_get_variable_pointer_i0
+        procedure, pass :: get_variable_pointer_i1 => dyn_mpas_get_variable_pointer_i1
+        procedure, pass :: get_variable_pointer_i2 => dyn_mpas_get_variable_pointer_i2
+        procedure, pass :: get_variable_pointer_i3 => dyn_mpas_get_variable_pointer_i3
+        procedure, pass :: get_variable_pointer_l0 => dyn_mpas_get_variable_pointer_l0
+        procedure, pass :: get_variable_pointer_r0 => dyn_mpas_get_variable_pointer_r0
+        procedure, pass :: get_variable_pointer_r1 => dyn_mpas_get_variable_pointer_r1
+        procedure, pass :: get_variable_pointer_r2 => dyn_mpas_get_variable_pointer_r2
+        procedure, pass :: get_variable_pointer_r3 => dyn_mpas_get_variable_pointer_r3
+        procedure, pass :: get_variable_pointer_r4 => dyn_mpas_get_variable_pointer_r4
+        procedure, pass :: get_variable_pointer_r5 => dyn_mpas_get_variable_pointer_r5
+        generic, public :: get_variable_pointer => get_variable_pointer_c0, get_variable_pointer_c1, &
+                                                   get_variable_pointer_i0, get_variable_pointer_i1, &
+                                                   get_variable_pointer_i2, get_variable_pointer_i3, &
+                                                   get_variable_pointer_l0, &
+                                                   get_variable_pointer_r0, get_variable_pointer_r1, &
+                                                   get_variable_pointer_r2, get_variable_pointer_r3, &
+                                                   get_variable_pointer_r4, get_variable_pointer_r5
+        procedure, pass :: get_variable_value_c0 => dyn_mpas_get_variable_value_c0
+        procedure, pass :: get_variable_value_c1 => dyn_mpas_get_variable_value_c1
+        procedure, pass :: get_variable_value_i0 => dyn_mpas_get_variable_value_i0
+        procedure, pass :: get_variable_value_i1 => dyn_mpas_get_variable_value_i1
+        procedure, pass :: get_variable_value_i2 => dyn_mpas_get_variable_value_i2
+        procedure, pass :: get_variable_value_i3 => dyn_mpas_get_variable_value_i3
+        procedure, pass :: get_variable_value_l0 => dyn_mpas_get_variable_value_l0
+        procedure, pass :: get_variable_value_r0 => dyn_mpas_get_variable_value_r0
+        procedure, pass :: get_variable_value_r1 => dyn_mpas_get_variable_value_r1
+        procedure, pass :: get_variable_value_r2 => dyn_mpas_get_variable_value_r2
+        procedure, pass :: get_variable_value_r3 => dyn_mpas_get_variable_value_r3
+        procedure, pass :: get_variable_value_r4 => dyn_mpas_get_variable_value_r4
+        procedure, pass :: get_variable_value_r5 => dyn_mpas_get_variable_value_r5
+        generic, public :: get_variable_value => get_variable_value_c0, get_variable_value_c1, &
+                                                 get_variable_value_i0, get_variable_value_i1, &
+                                                 get_variable_value_i2, get_variable_value_i3, &
+                                                 get_variable_value_l0, &
+                                                 get_variable_value_r0, get_variable_value_r1, &
+                                                 get_variable_value_r2, get_variable_value_r3, &
+                                                 get_variable_value_r4, get_variable_value_r5
     end type mpas_dynamical_core_type
+
+    !> This derived type conveys information similar to the `var` and `var_array` elements in MPAS registry.
+    !> For example, in MPAS registry, the "xCell" variable is described as:
+    !>     <var name="xCell" type="real" dimensions="nCells" units="m" description="Cartesian x-coordinate of cells" />
+    !> Here, it is described as:
+    !>     var_info_type(name="xCell", type="real", rank=1)
+    type :: var_info_type
+        private
+
+        character(64) :: name = ''
+        character(10) :: type = ''
+        integer :: rank = 0
+    end type var_info_type
+
+    ! Developers/Maintainers should keep the following parameters up-to-date with MPAS registry.
+
+    !> This list corresponds to the "invariant" stream in MPAS registry.
+    !> It consists of variables that are members of the "mesh" struct.
+    type(var_info_type), parameter :: invariant_var_info_list(*) = [ &
+        var_info_type('angleEdge'                       , 'real'      , 1), &
+        var_info_type('areaCell'                        , 'real'      , 1), &
+        var_info_type('areaTriangle'                    , 'real'      , 1), &
+        var_info_type('bdyMaskCell'                     , 'integer'   , 1), &
+        var_info_type('bdyMaskEdge'                     , 'integer'   , 1), &
+        var_info_type('bdyMaskVertex'                   , 'integer'   , 1), &
+        var_info_type('cellTangentPlane'                , 'real'      , 3), &
+        var_info_type('cell_gradient_coef_x'            , 'real'      , 2), &
+        var_info_type('cell_gradient_coef_y'            , 'real'      , 2), &
+        var_info_type('cellsOnCell'                     , 'integer'   , 2), &
+        var_info_type('cellsOnEdge'                     , 'integer'   , 2), &
+        var_info_type('cellsOnVertex'                   , 'integer'   , 2), &
+        var_info_type('cf1'                             , 'real'      , 0), &
+        var_info_type('cf2'                             , 'real'      , 0), &
+        var_info_type('cf3'                             , 'real'      , 0), &
+        var_info_type('coeffs_reconstruct'              , 'real'      , 3), &
+        var_info_type('dcEdge'                          , 'real'      , 1), &
+        var_info_type('defc_a'                          , 'real'      , 2), &
+        var_info_type('defc_b'                          , 'real'      , 2), &
+        var_info_type('deriv_two'                       , 'real'      , 3), &
+        var_info_type('dss'                             , 'real'      , 2), &
+        var_info_type('dvEdge'                          , 'real'      , 1), &
+        var_info_type('dzu'                             , 'real'      , 1), &
+        var_info_type('edgeNormalVectors'               , 'real'      , 2), &
+        var_info_type('edgesOnCell'                     , 'integer'   , 2), &
+        var_info_type('edgesOnEdge'                     , 'integer'   , 2), &
+        var_info_type('edgesOnVertex'                   , 'integer'   , 2), &
+        var_info_type('fEdge'                           , 'real'      , 1), &
+        var_info_type('fVertex'                         , 'real'      , 1), &
+        var_info_type('fzm'                             , 'real'      , 1), &
+        var_info_type('fzp'                             , 'real'      , 1), &
+        var_info_type('indexToCellID'                   , 'integer'   , 1), &
+        var_info_type('indexToEdgeID'                   , 'integer'   , 1), &
+        var_info_type('indexToVertexID'                 , 'integer'   , 1), &
+        var_info_type('kiteAreasOnVertex'               , 'real'      , 2), &
+        var_info_type('latCell'                         , 'real'      , 1), &
+        var_info_type('latEdge'                         , 'real'      , 1), &
+        var_info_type('latVertex'                       , 'real'      , 1), &
+        var_info_type('localVerticalUnitVectors'        , 'real'      , 2), &
+        var_info_type('lonCell'                         , 'real'      , 1), &
+        var_info_type('lonEdge'                         , 'real'      , 1), &
+        var_info_type('lonVertex'                       , 'real'      , 1), &
+        var_info_type('meshDensity'                     , 'real'      , 1), &
+        var_info_type('nEdgesOnCell'                    , 'integer'   , 1), &
+        var_info_type('nEdgesOnEdge'                    , 'integer'   , 1), &
+        var_info_type('nominalMinDc'                    , 'real'      , 0), &
+        var_info_type('qv_init'                         , 'real'      , 1), &
+        var_info_type('rdzu'                            , 'real'      , 1), &
+        var_info_type('rdzw'                            , 'real'      , 1), &
+        var_info_type('t_init'                          , 'real'      , 2), &
+        var_info_type('u_init'                          , 'real'      , 1), &
+        var_info_type('v_init'                          , 'real'      , 1), &
+        var_info_type('verticesOnCell'                  , 'integer'   , 2), &
+        var_info_type('verticesOnEdge'                  , 'integer'   , 2), &
+        var_info_type('weightsOnEdge'                   , 'real'      , 2), &
+        var_info_type('xCell'                           , 'real'      , 1), &
+        var_info_type('xEdge'                           , 'real'      , 1), &
+        var_info_type('xVertex'                         , 'real'      , 1), &
+        var_info_type('yCell'                           , 'real'      , 1), &
+        var_info_type('yEdge'                           , 'real'      , 1), &
+        var_info_type('yVertex'                         , 'real'      , 1), &
+        var_info_type('zCell'                           , 'real'      , 1), &
+        var_info_type('zEdge'                           , 'real'      , 1), &
+        var_info_type('zVertex'                         , 'real'      , 1), &
+        var_info_type('zb'                              , 'real'      , 3), &
+        var_info_type('zb3'                             , 'real'      , 3), &
+        var_info_type('zgrid'                           , 'real'      , 2), &
+        var_info_type('zxu'                             , 'real'      , 2), &
+        var_info_type('zz'                              , 'real'      , 2)  &
+    ]
+
+    ! Whether a variable should be in input or restart can be determined by looking at
+    ! the `atm_init_coupled_diagnostics` subroutine in MPAS.
+    ! If a variable first appears on the LHS of an equation, it should be in restart.
+    ! If a variable first appears on the RHS of an equation, it should be in input.
+
+    !> This list corresponds to the "input" stream in MPAS registry.
+    !> It consists of variables that are members of the "diag" and "state" struct.
+    !> Only variables that are specific to the "input" stream are included.
+    type(var_info_type), parameter :: input_var_info_list(*) = [ &
+        var_info_type('Time'                            , 'real'      , 1), &
+        var_info_type('initial_time'                    , 'character' , 0), &
+        var_info_type('relhum'                          , 'real'      , 3), &
+        var_info_type('rho'                             , 'real'      , 3), &
+        var_info_type('rho_base'                        , 'real'      , 3), &
+        var_info_type('scalars'                         , 'real'      , 3), &
+        var_info_type('theta'                           , 'real'      , 3), &
+        var_info_type('theta_base'                      , 'real'      , 3), &
+        var_info_type('u'                               , 'real'      , 3), &
+        var_info_type('w'                               , 'real'      , 3), &
+        var_info_type('xtime'                           , 'character' , 1)  &
+    ]
+
+    !> This list corresponds to the "restart" stream in MPAS registry.
+    !> It consists of variables that are members of the "diag" and "state" struct.
+    !> Only variables that are specific to the "restart" stream are included.
+    type(var_info_type), parameter :: restart_var_info_list(*) = [ &
+        var_info_type('exner'                           , 'real'      , 1), &
+        var_info_type('exner_base'                      , 'real'      , 1), &
+        var_info_type('pressure_base'                   , 'real'      , 1), &
+        var_info_type('pressure_p'                      , 'real'      , 1), &
+        var_info_type('rho_p'                           , 'real'      , 1), &
+        var_info_type('rho_zz'                          , 'real'      , 1), &
+        var_info_type('rtheta_base'                     , 'real'      , 1), &
+        var_info_type('rtheta_p'                        , 'real'      , 1), &
+        var_info_type('ru'                              , 'real'      , 1), &
+        var_info_type('ru_p'                            , 'real'      , 1), &
+        var_info_type('rw'                              , 'real'      , 1), &
+        var_info_type('rw_p'                            , 'real'      , 1), &
+        var_info_type('theta_m'                         , 'real'      , 1)  &
+    ]
 contains
     !> Print a debug message with optionally the value(s) of a variable.
     !> If `printer` is not supplied, the MPI root rank will print. Otherwise, the designated MPI rank will print instead.
@@ -420,7 +619,7 @@ contains
     !> \details
     !>  This subroutine follows the stand-alone MPAS subdriver from the point
     !>  where we call the second phase of MPAS framework initialization up
-    !>  to the check on the existence of the streams.<core> file.
+    !>  to the check on the existence of the `streams.<core>` file.
     !> \addenda
     !>  Ported and refactored for CAM-SIMA. (KCW, 2024-02-07)
     !
@@ -485,4 +684,1520 @@ contains
         ! in `dyn_grid::model_grid_init`.
         call self % debug_print(subname // ' completed')
     end subroutine dyn_mpas_init_phase2
+
+    !-------------------------------------------------------------------------------
+    ! subroutine dyn_mpas_init_phase3
+    !
+    !> \brief  Tracks `mpas_init` up to the point of calling `core_init`
+    !> \author Michael Duda
+    !> \date   19 April 2019
+    !> \details
+    !>  This subroutine follows the stand-alone MPAS subdriver after the check on
+    !>  the existence of the `streams.<core>` file up to, but not including,
+    !>  the point where `core_init` is called. It completes MPAS framework
+    !>  initialization, including the allocation of all blocks and fields managed
+    !>  by MPAS.
+    !> \addenda
+    !>  Ported and refactored for CAM-SIMA. (KCW, 2024-03-06)
+    !
+    !-------------------------------------------------------------------------------
+    subroutine dyn_mpas_init_phase3(self, cam_pcnst, pio_file)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, intent(in) :: cam_pcnst
+        type(file_desc_t), pointer, intent(in) :: pio_file
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_init_phase3'
+        character(strkind) :: mesh_filename
+        integer :: mesh_format
+
+        call self % debug_print(subname // ' entered')
+
+        call self % debug_print('Number of constituents is ', [cam_pcnst])
+
+        ! Adding a config named `cam_pcnst` with the number of constituents will indicate to MPAS that
+        ! it is operating as a dynamical core, and therefore it needs to allocate scalars separately
+        ! from other Registry-defined fields. The special logic is located in `atm_setup_block`.
+        ! This must be done before calling `mpas_bootstrap_framework_phase1`.
+        call mpas_pool_add_config(self % domain_ptr % configs, 'cam_pcnst', cam_pcnst)
+
+        ! Not actually used because a PIO file descriptor is directly supplied.
+        mesh_filename = 'external mesh'
+        mesh_format = mpas_io_pnetcdf
+
+        call self % debug_print('Checking PIO file descriptor')
+
+        if (.not. associated(pio_file)) then
+            call self % model_error('Invalid PIO file descriptor', subname, __LINE__)
+        end if
+
+        if (.not. pio_file_is_open(pio_file)) then
+            call self % model_error('Invalid PIO file descriptor', subname, __LINE__)
+        end if
+
+        call self % debug_print('Calling mpas_bootstrap_framework_phase1')
+
+        ! Finish setting up blocks.
+        call mpas_bootstrap_framework_phase1(self % domain_ptr, mesh_filename, mesh_format, pio_file_desc=pio_file)
+
+        call self % debug_print('Calling mpas_bootstrap_framework_phase2')
+
+        ! Finish setting up fields.
+        call mpas_bootstrap_framework_phase2(self % domain_ptr, pio_file_desc=pio_file)
+
+        call self % debug_print(subname // ' completed')
+    end subroutine dyn_mpas_init_phase3
+
+    !-------------------------------------------------------------------------------
+    ! subroutine dyn_mpas_read_write_stream
+    !
+    !> \brief  Read or write an MPAS stream
+    !> \author Kuan-Chih Wang
+    !> \date   2024-03-15
+    !> \details
+    !>  In the context of MPAS, the concept of a "pool" resembles a group of
+    !>  (related) variables, while the concept of a "stream" resembles a file.
+    !>  This subroutine reads or writes an MPAS stream. It provides the mechanism
+    !>  for CAM-SIMA to input/output data to/from MPAS dynamical core.
+    !>  Analogous to the `{read,write}_stream` subroutines in MPAS stream manager.
+    !
+    !-------------------------------------------------------------------------------
+    subroutine dyn_mpas_read_write_stream(self, pio_file, stream_mode, stream_name)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        type(file_desc_t), pointer, intent(in) :: pio_file
+        character(*), intent(in) :: stream_mode
+        character(*), intent(in) :: stream_name
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_read_write_stream'
+        integer :: i, ierr
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+        type(mpas_stream_type), pointer :: mpas_stream => null()
+        type(var_info_type), allocatable :: var_info_list(:)
+
+        call self % debug_print(subname // ' entered')
+
+        call self % debug_print('Initializing stream')
+
+        call self % init_stream_with_pool(mpas_pool, mpas_stream, pio_file, stream_mode, stream_name)
+
+        if (.not. associated(mpas_pool)) then
+            call self % model_error('Failed to initialize stream', subname, __LINE__)
+        end if
+
+        if (.not. associated(mpas_stream)) then
+            call self % model_error('Failed to initialize stream', subname, __LINE__)
+        end if
+
+        select case (trim(adjustl(stream_mode)))
+            case ('r', 'read')
+                call self % debug_print('Reading stream')
+
+                call mpas_readstream(mpas_stream, 1, ierr=ierr)
+
+                if (ierr /= mpas_stream_noerr) then
+                    call self % model_error('Failed to read stream', subname, __LINE__)
+                end if
+
+                ! Exchange halo layers because new data have just been read.
+                var_info_list = parse_stream_name(stream_name)
+
+                do i = 1, size(var_info_list)
+                    call self % exchange_halo(var_info_list(i) % name)
+                end do
+
+                ! For any connectivity arrays in this stream, convert global indexes to local indexes.
+                call postread_reindex(self % domain_ptr % blocklist % allfields, self % domain_ptr % packages, &
+                    mpas_pool, mpas_pool)
+            case ('w', 'write')
+                call self % debug_print('Writing stream')
+
+                ! WARNING:
+                ! The `{pre,post}write_reindex` subroutines are STATEFUL because they store information inside their module
+                ! (i.e., module variables). They MUST be called in pairs, like below, to prevent undefined behaviors.
+
+                ! For any connectivity arrays in this stream, temporarily convert local indexes to global indexes.
+                call prewrite_reindex(self % domain_ptr % blocklist % allfields, self % domain_ptr % packages, &
+                    mpas_pool, mpas_pool)
+
+                call mpas_writestream(mpas_stream, 1, ierr=ierr)
+
+                if (ierr /= mpas_stream_noerr) then
+                    call self % model_error('Failed to write stream', subname, __LINE__)
+                end if
+
+                ! For any connectivity arrays in this stream, reset global indexes back to local indexes.
+                call postwrite_reindex(self % domain_ptr % blocklist % allfields, mpas_pool)
+            case default
+                call self % model_error('Unsupported stream mode "' // trim(adjustl(stream_mode)) // '"', subname, __LINE__)
+        end select
+
+        call self % debug_print('Closing stream')
+
+        call mpas_closestream(mpas_stream, ierr=ierr)
+
+        if (ierr /= mpas_stream_noerr) then
+            call self % model_error('Failed to close stream', subname, __LINE__)
+        end if
+
+        ! Deallocate temporary pointers to avoid memory leaks.
+        call mpas_pool_destroy_pool(mpas_pool)
+        nullify(mpas_pool)
+
+        deallocate(mpas_stream)
+        nullify(mpas_stream)
+
+        call self % debug_print(subname // ' completed')
+    end subroutine dyn_mpas_read_write_stream
+
+    !-------------------------------------------------------------------------------
+    ! subroutine dyn_mpas_init_stream_with_pool
+    !
+    !> \brief  Initialize an MPAS stream with an accompanying MPAS pool
+    !> \author Kuan-Chih Wang
+    !> \date   2024-03-14
+    !> \details
+    !>  In the context of MPAS, the concept of a "pool" resembles a group of
+    !>  (related) variables, while the concept of a "stream" resembles a file.
+    !>  This subroutine initializes an MPAS stream with an accompanying MPAS pool by
+    !>  adding variable and attribute information to them. After that, MPAS is ready
+    !>  to perform IO on them.
+    !>  Analogous to the `build_stream` and `mpas_stream_mgr_add_field`
+    !>  subroutines in MPAS stream manager.
+    !
+    !-------------------------------------------------------------------------------
+    subroutine dyn_mpas_init_stream_with_pool(self, mpas_pool, mpas_stream, pio_file, stream_mode, stream_name)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        type(mpas_pool_type), pointer, intent(out) :: mpas_pool
+        type(mpas_stream_type), pointer, intent(out) :: mpas_stream
+        type(file_desc_t), pointer, intent(in) :: pio_file
+        character(*), intent(in) :: stream_mode
+        character(*), intent(in) :: stream_name
+
+        interface add_stream_attribute
+            procedure :: add_stream_attribute_0d
+            procedure :: add_stream_attribute_1d
+        end interface add_stream_attribute
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_init_stream_with_pool'
+        character(strkind) :: stream_filename
+        integer :: i, ierr, ndims, stream_format, varid
+        type(field0dchar), pointer :: field_0d_char => null()
+        type(field1dchar), pointer :: field_1d_char => null()
+        type(field0dinteger), pointer :: field_0d_integer => null()
+        type(field1dinteger), pointer :: field_1d_integer => null()
+        type(field2dinteger), pointer :: field_2d_integer => null()
+        type(field3dinteger), pointer :: field_3d_integer => null()
+        type(field0dreal), pointer :: field_0d_real => null()
+        type(field1dreal), pointer :: field_1d_real => null()
+        type(field2dreal), pointer :: field_2d_real => null()
+        type(field3dreal), pointer :: field_3d_real => null()
+        type(field4dreal), pointer :: field_4d_real => null()
+        type(field5dreal), pointer :: field_5d_real => null()
+        type(var_info_type), allocatable :: var_info_list(:)
+
+        call self % debug_print(subname // ' entered')
+
+        call mpas_pool_create_pool(mpas_pool)
+
+        allocate(mpas_stream)
+
+        ! Not actually used because a PIO file descriptor is directly supplied.
+        stream_filename = 'external stream'
+        stream_format = mpas_io_pnetcdf
+
+        call self % debug_print('Checking PIO file descriptor')
+
+        if (.not. associated(pio_file)) then
+            call self % model_error('Invalid PIO file descriptor', subname, __LINE__)
+        end if
+
+        if (.not. pio_file_is_open(pio_file)) then
+            call self % model_error('Invalid PIO file descriptor', subname, __LINE__)
+        end if
+
+        select case (trim(adjustl(stream_mode)))
+            case ('r', 'read')
+                call self % debug_print('Creating "' // trim(adjustl(stream_name)) // '" stream for reading')
+
+                call mpas_createstream( &
+                    mpas_stream, self % domain_ptr % iocontext, stream_filename, stream_format, mpas_io_read,  &
+                    clobberrecords=.false., clobberfiles=.false., truncatefiles=.false., &
+                    precision=mpas_io_native_precision, pio_file_desc=pio_file, ierr=ierr)
+            case ('w', 'write')
+                call self % debug_print('Creating "' // trim(adjustl(stream_name)) // '" stream for writing')
+
+                call mpas_createstream( &
+                    mpas_stream, self % domain_ptr % iocontext, stream_filename, stream_format, mpas_io_write, &
+                    clobberrecords=.false., clobberfiles=.false., truncatefiles=.false., &
+                    precision=mpas_io_native_precision, pio_file_desc=pio_file, ierr=ierr)
+            case default
+                call self % model_error('Unsupported stream mode "' // trim(adjustl(stream_mode)) // '"', subname, __LINE__)
+        end select
+
+        if (ierr /= mpas_stream_noerr) then
+            call self % model_error('Failed to create stream', subname, __LINE__)
+        end if
+
+        var_info_list = parse_stream_name(stream_name)
+
+        ! Add variables to stream.
+        call self % debug_print('Adding variables to stream')
+
+        do i = 1, size(var_info_list)
+            call self % debug_print('var_info_list(' // stringify([i]) // ') % name = ' // &
+                stringify([var_info_list(i) % name]))
+            call self % debug_print('var_info_list(' // stringify([i]) // ') % type = ' // &
+                stringify([var_info_list(i) % type]))
+            call self % debug_print('var_info_list(' // stringify([i]) // ') % rank = ' // &
+                stringify([var_info_list(i) % rank]))
+
+            if (trim(adjustl(stream_mode)) == 'r' .or. trim(adjustl(stream_mode)) == 'read') then
+                ! Check if "<variable name>" is present.
+                ierr = pio_inq_varid(pio_file, trim(adjustl(var_info_list(i) % name)), varid)
+
+                ! Do not hard crash the model if a variable is missing and cannot be read.
+                ! This can happen if users attempt to initialize/restart the model with data generated by
+                ! older versions of MPAS. Print a debug message to let users decide if this is acceptable.
+                if (ierr /= pio_noerr) then
+                    call self % debug_print('Skipping variable "' // trim(adjustl(var_info_list(i) % name)) // '"')
+
+                    cycle
+                end if
+
+                ierr = pio_inq_varndims(pio_file, varid, ndims)
+
+                if (ierr /= pio_noerr) then
+                    call self % model_error('Failed to inquire variable rank', subname, __LINE__)
+                end if
+
+                if (ndims /= var_info_list(i) % rank) then
+                    call self % model_error('Variable rank mismatch', subname, __LINE__)
+                end if
+            end if
+
+            ! Add "<variable name>" to pool with the value of `1`.
+            ! The existence of "<variable name>" in pool causes it to be considered for IO in MPAS.
+            call mpas_pool_add_config(mpas_pool, trim(adjustl(var_info_list(i) % name)), 1)
+            ! Add "<variable name>:packages" to pool with the value of an empty character string.
+            ! This causes "<variable name>" to be always considered active for IO in MPAS.
+            call mpas_pool_add_config(mpas_pool, trim(adjustl(var_info_list(i) % name) // ':packages'), '')
+
+            ! Add "<variable name>" to stream.
+            select case (trim(adjustl(var_info_list(i) % type)))
+                case ('character')
+                    select case (var_info_list(i) % rank)
+                        case (0)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_0d_char, timelevel=1)
+
+                            if (.not. associated(field_0d_char)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_0d_char, ierr=ierr)
+
+                            nullify(field_0d_char)
+                        case (1)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_1d_char, timelevel=1)
+
+                            if (.not. associated(field_1d_char)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_1d_char, ierr=ierr)
+
+                            nullify(field_1d_char)
+                        case default
+                            call self % model_error('Unsupported variable rank', subname, __LINE__)
+                    end select
+                case ('integer')
+                    select case (var_info_list(i) % rank)
+                        case (0)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_0d_integer, timelevel=1)
+
+                            if (.not. associated(field_0d_integer)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_0d_integer, ierr=ierr)
+
+                            nullify(field_0d_integer)
+                        case (1)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_1d_integer, timelevel=1)
+
+                            if (.not. associated(field_1d_integer)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_1d_integer, ierr=ierr)
+
+                            nullify(field_1d_integer)
+                        case (2)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_2d_integer, timelevel=1)
+
+                            if (.not. associated(field_2d_integer)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_2d_integer, ierr=ierr)
+
+                            nullify(field_2d_integer)
+                        case (3)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_3d_integer, timelevel=1)
+
+                            if (.not. associated(field_3d_integer)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_3d_integer, ierr=ierr)
+
+                            nullify(field_3d_integer)
+                        case default
+                            call self % model_error('Unsupported variable rank', subname, __LINE__)
+                    end select
+                case ('real')
+                    select case (var_info_list(i) % rank)
+                        case (0)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_0d_real, timelevel=1)
+
+                            if (.not. associated(field_0d_real)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_0d_real, ierr=ierr)
+
+                            nullify(field_0d_real)
+                        case (1)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_1d_real, timelevel=1)
+
+                            if (.not. associated(field_1d_real)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_1d_real, ierr=ierr)
+
+                            nullify(field_1d_real)
+                        case (2)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_2d_real, timelevel=1)
+
+                            if (.not. associated(field_2d_real)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_2d_real, ierr=ierr)
+
+                            nullify(field_2d_real)
+                        case (3)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_3d_real, timelevel=1)
+
+                            if (.not. associated(field_3d_real)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_3d_real, ierr=ierr)
+
+                            nullify(field_3d_real)
+                        case (4)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_4d_real, timelevel=1)
+
+                            if (.not. associated(field_4d_real)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_4d_real, ierr=ierr)
+
+                            nullify(field_4d_real)
+                        case (5)
+                            call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                                trim(adjustl(var_info_list(i) % name)), field_5d_real, timelevel=1)
+
+                            if (.not. associated(field_5d_real)) then
+                                call self % model_error('Failed to find variable', subname, __LINE__)
+                            end if
+
+                            call mpas_streamaddfield(mpas_stream, field_5d_real, ierr=ierr)
+
+                            nullify(field_5d_real)
+                        case default
+                            call self % model_error('Unsupported variable rank', subname, __LINE__)
+                    end select
+                case default
+                    call self % model_error('Unsupported variable type', subname, __LINE__)
+            end select
+
+            if (ierr /= mpas_stream_noerr) then
+                call self % model_error('Failed to add variable to stream', subname, __LINE__)
+            end if
+        end do
+
+        deallocate(var_info_list)
+
+        if (trim(adjustl(stream_mode)) == 'w' .or. trim(adjustl(stream_mode)) == 'write') then
+            ! Add MPAS-specific attributes to stream.
+            call self % debug_print('Adding attributes to stream')
+
+            ! Attributes related to MPAS core (i.e., `core_type`).
+            call add_stream_attribute('conventions', self % domain_ptr % core % conventions)
+            call add_stream_attribute('core_name', self % domain_ptr % core % corename)
+            call add_stream_attribute('git_version', self % domain_ptr % core % git_version)
+            call add_stream_attribute('model_name', self % domain_ptr % core % modelname)
+            call add_stream_attribute('source', self % domain_ptr % core % source)
+
+            ! Attributes related to MPAS domain (i.e., `domain_type`).
+            call add_stream_attribute('is_periodic', self % domain_ptr % is_periodic)
+            call add_stream_attribute('mesh_spec', self % domain_ptr % mesh_spec)
+            call add_stream_attribute('on_a_sphere', self % domain_ptr % on_a_sphere)
+            call add_stream_attribute('parent_id', self % domain_ptr %  parent_id)
+            call add_stream_attribute('sphere_radius', self % domain_ptr % sphere_radius)
+            call add_stream_attribute('x_period', self % domain_ptr % x_period)
+            call add_stream_attribute('y_period', self % domain_ptr % y_period)
+        end if
+
+        call self % debug_print(subname // ' completed')
+    contains
+        !> Helper subroutine for adding a 0-d stream attribute by calling `mpas_writestreamatt` with error checking.
+        !> (KCW, 2024-03-14)
+        subroutine add_stream_attribute_0d(attribute_name, attribute_value)
+            character(*), intent(in) :: attribute_name
+            class(*), intent(in) :: attribute_value
+
+            select type (attribute_value)
+                type is (character(*))
+                    call mpas_writestreamatt(mpas_stream, &
+                        trim(adjustl(attribute_name)), trim(adjustl(attribute_value)), syncval=.false., ierr=ierr)
+                type is (integer)
+                    call mpas_writestreamatt(mpas_stream, &
+                        trim(adjustl(attribute_name)), attribute_value, syncval=.false., ierr=ierr)
+                type is (logical)
+                    if (attribute_value) then
+                        ! Logical `.true.` becomes character string `YES`.
+                        call mpas_writestreamatt(mpas_stream, &
+                            trim(adjustl(attribute_name)), 'YES', syncval=.false., ierr=ierr)
+                    else
+                        ! Logical `.false.` becomes character string `NO`.
+                        call mpas_writestreamatt(mpas_stream, &
+                            trim(adjustl(attribute_name)), 'NO', syncval=.false., ierr=ierr)
+                    end if
+                type is (real(rkind))
+                    call mpas_writestreamatt(mpas_stream, &
+                        trim(adjustl(attribute_name)), attribute_value, syncval=.false., ierr=ierr)
+                class default
+                    call self % model_error('Unsupported attribute type', subname, __LINE__)
+            end select
+
+            if (ierr /= mpas_stream_noerr) then
+                call self % model_error('Failed to add attribute to stream', subname, __LINE__)
+            end if
+        end subroutine add_stream_attribute_0d
+
+        !> Helper subroutine for adding a 1-d stream attribute by calling `mpas_writestreamatt` with error checking.
+        !> (KCW, 2024-03-14)
+        subroutine add_stream_attribute_1d(attribute_name, attribute_value)
+            character(*), intent(in) :: attribute_name
+            class(*), intent(in) :: attribute_value(:)
+
+            select type (attribute_value)
+                type is (integer)
+                    call mpas_writestreamatt(mpas_stream, &
+                        trim(adjustl(attribute_name)), attribute_value, syncval=.false., ierr=ierr)
+                type is (real(rkind))
+                    call mpas_writestreamatt(mpas_stream, &
+                        trim(adjustl(attribute_name)), attribute_value, syncval=.false., ierr=ierr)
+                class default
+                    call self % model_error('Unsupported attribute type', subname, __LINE__)
+            end select
+
+            if (ierr /= mpas_stream_noerr) then
+                call self % model_error('Failed to add attribute to stream', subname, __LINE__)
+            end if
+        end subroutine add_stream_attribute_1d
+    end subroutine dyn_mpas_init_stream_with_pool
+
+    !> Parse one or more stream names and return variable information contained in those streams as a list of `var_info_type`.
+    !> Multiple stream names should be separated by `+` (i.e., a plus).
+    !> Duplicate variable names in the resulting list are discarded.
+    !> (KCW, 2024-03-15)
+    pure recursive function parse_stream_name(stream_name) result(var_info_list)
+        character(*), intent(in) :: stream_name
+        type(var_info_type), allocatable :: var_info_list(:)
+
+        integer :: i, n, offset
+        type(var_info_type), allocatable :: var_info_list_append(:)
+
+        allocate(var_info_list(0))
+
+        n = len(stream_name)
+        offset = 0
+
+        if (offset + 1 > n) then
+            return
+        end if
+
+        i = index(stream_name(offset + 1:), '+')
+
+        do while (i > 0)
+            if (i > 1) then
+                var_info_list_append = parse_stream_name(stream_name(offset + 1:offset + i - 1))
+                var_info_list = [var_info_list, var_info_list_append]
+
+                deallocate(var_info_list_append)
+            end if
+
+            offset = offset + i
+
+            if (offset + 1 > n) then
+                exit
+            end if
+
+            i = index(stream_name(offset + 1:), '+')
+        end do
+
+        if (offset + 1 > n) then
+            return
+        end if
+
+        select case (trim(adjustl(stream_name(offset + 1:))))
+            case ('invariant')
+                allocate(var_info_list_append, source=invariant_var_info_list)
+            case ('input')
+                allocate(var_info_list_append, source=input_var_info_list)
+            case ('restart')
+                allocate(var_info_list_append, source=restart_var_info_list)
+            case default
+                allocate(var_info_list_append(0))
+        end select
+
+        var_info_list = [var_info_list, var_info_list_append]
+
+        ! Discard duplicate variable information by names.
+        var_info_list = var_info_list(index_unique(var_info_list(:) % name))
+
+        deallocate(var_info_list_append)
+    end function parse_stream_name
+
+    !> Return the index of unique elements in `array`, which can be any intrinsic data types, as an integer array.
+    !> If `array` contains zero element or is of unsupported data types, an empty integer array is produced.
+    !> (KCW, 2024-03-22)
+    pure function index_unique(array)
+        use, intrinsic :: iso_fortran_env, only: int32, int64, real32, real64
+
+        class(*), intent(in) :: array(:)
+        integer, allocatable :: index_unique(:)
+
+        integer :: i, n
+        logical :: mask_unique(size(array))
+
+        n = size(array)
+
+        if (n == 0) then
+            allocate(index_unique(0))
+
+            return
+        end if
+
+        mask_unique = .false.
+
+        select type (array)
+            type is (character(*))
+                do i = 1, n
+                    if (.not. any(array(i) == array .and. mask_unique)) then
+                        mask_unique(i) = .true.
+                    end if
+                end do
+            type is (integer(int32))
+                do i = 1, n
+                    if (.not. any(array(i) == array .and. mask_unique)) then
+                        mask_unique(i) = .true.
+                    end if
+                end do
+            type is (integer(int64))
+                do i = 1, n
+                    if (.not. any(array(i) == array .and. mask_unique)) then
+                        mask_unique(i) = .true.
+                    end if
+                end do
+            type is (logical)
+                do i = 1, n
+                    if (.not. any(array(i) == array .and. mask_unique)) then
+                        mask_unique(i) = .true.
+                    end if
+                end do
+            type is (real(real32))
+                do i = 1, n
+                    if (.not. any(array(i) == array .and. mask_unique)) then
+                        mask_unique(i) = .true.
+                    end if
+                end do
+            type is (real(real64))
+                do i = 1, n
+                    if (.not. any(array(i) == array .and. mask_unique)) then
+                        mask_unique(i) = .true.
+                    end if
+                end do
+            class default
+                allocate(index_unique(0))
+
+                return
+        end select
+
+        index_unique = pack([(i, i = 1, n)], mask_unique)
+    end function index_unique
+
+    !-------------------------------------------------------------------------------
+    ! subroutine dyn_mpas_exchange_halo
+    !
+    !> \brief  Updates the halo layers of the named field
+    !> \author Michael Duda
+    !> \date   16 January 2020
+    !> \details
+    !>  Given a field name that is defined in MPAS registry, this subroutine updates
+    !>  the halo layers for that field.
+    !> \addenda
+    !>  Ported and refactored for CAM-SIMA. (KCW, 2024-03-18)
+    !
+    !-------------------------------------------------------------------------------
+    subroutine dyn_mpas_exchange_halo(self, field_name)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        character(*), intent(in) :: field_name
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_exchange_halo'
+        type(field1dinteger), pointer :: field_1d_integer => null()
+        type(field2dinteger), pointer :: field_2d_integer => null()
+        type(field3dinteger), pointer :: field_3d_integer => null()
+        type(field1dreal), pointer :: field_1d_real => null()
+        type(field2dreal), pointer :: field_2d_real => null()
+        type(field3dreal), pointer :: field_3d_real => null()
+        type(field4dreal), pointer :: field_4d_real => null()
+        type(field5dreal), pointer :: field_5d_real => null()
+        type(mpas_pool_field_info_type) :: mpas_pool_field_info
+
+        call self % debug_print(subname // ' entered')
+
+        call self % debug_print('Inquiring field information for "' // trim(adjustl(field_name)) // '"')
+
+        call mpas_pool_get_field_info(self % domain_ptr % blocklist % allfields, &
+            trim(adjustl(field_name)), mpas_pool_field_info)
+
+        if (mpas_pool_field_info % fieldtype == -1 .or. &
+            mpas_pool_field_info % ndims == -1 .or. &
+            mpas_pool_field_info % nhalolayers == -1) then
+            call self % model_error('Invalid field information', subname, __LINE__)
+        end if
+
+        ! No halo layers to exchange. This field is not decomposed.
+        if (mpas_pool_field_info % nhalolayers == 0) then
+            call self % debug_print('Skipping field "' // trim(adjustl(field_name)) // '"')
+
+            return
+        end if
+
+        call self % debug_print('Exchanging halo layers for "' // trim(adjustl(field_name)) // '"')
+
+        select case (mpas_pool_field_info % fieldtype)
+            case (mpas_pool_integer)
+                select case (mpas_pool_field_info % ndims)
+                    case (1)
+                        call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                            trim(adjustl(field_name)), field_1d_integer, timelevel=1)
+
+                        if (.not. associated(field_1d_integer)) then
+                            call self % model_error('Failed to find field', subname, __LINE__)
+                        end if
+
+                        call mpas_dmpar_exch_halo_field(field_1d_integer)
+
+                        nullify(field_1d_integer)
+                    case (2)
+                        call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                            trim(adjustl(field_name)), field_2d_integer, timelevel=1)
+
+                        if (.not. associated(field_2d_integer)) then
+                            call self % model_error('Failed to find field', subname, __LINE__)
+                        end if
+
+                        call mpas_dmpar_exch_halo_field(field_2d_integer)
+
+                        nullify(field_2d_integer)
+                    case (3)
+                        call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                            trim(adjustl(field_name)), field_3d_integer, timelevel=1)
+
+                        if (.not. associated(field_3d_integer)) then
+                            call self % model_error('Failed to find field', subname, __LINE__)
+                        end if
+
+                        call mpas_dmpar_exch_halo_field(field_3d_integer)
+
+                        nullify(field_3d_integer)
+                    case default
+                        call self % model_error('Unsupported field rank', subname, __LINE__)
+                    end select
+            case (mpas_pool_real)
+                select case (mpas_pool_field_info % ndims)
+                    case (1)
+                        call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                            trim(adjustl(field_name)), field_1d_real, timelevel=1)
+
+                        if (.not. associated(field_1d_real)) then
+                            call self % model_error('Failed to find field', subname, __LINE__)
+                        end if
+
+                        call mpas_dmpar_exch_halo_field(field_1d_real)
+
+                        nullify(field_1d_real)
+                    case (2)
+                        call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                            trim(adjustl(field_name)), field_2d_real, timelevel=1)
+
+                        if (.not. associated(field_2d_real)) then
+                            call self % model_error('Failed to find field', subname, __LINE__)
+                        end if
+
+                        call mpas_dmpar_exch_halo_field(field_2d_real)
+
+                        nullify(field_2d_real)
+                    case (3)
+                        call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                            trim(adjustl(field_name)), field_3d_real, timelevel=1)
+
+                        if (.not. associated(field_3d_real)) then
+                            call self % model_error('Failed to find field', subname, __LINE__)
+                        end if
+
+                        call mpas_dmpar_exch_halo_field(field_3d_real)
+
+                        nullify(field_3d_real)
+                    case (4)
+                        call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                            trim(adjustl(field_name)), field_4d_real, timelevel=1)
+
+                        if (.not. associated(field_4d_real)) then
+                            call self % model_error('Failed to find field', subname, __LINE__)
+                        end if
+
+                        call mpas_dmpar_exch_halo_field(field_4d_real)
+
+                        nullify(field_4d_real)
+                    case (5)
+                        call mpas_pool_get_field(self % domain_ptr % blocklist % allfields, &
+                            trim(adjustl(field_name)), field_5d_real, timelevel=1)
+
+                        if (.not. associated(field_5d_real)) then
+                            call self % model_error('Failed to find field', subname, __LINE__)
+                        end if
+
+                        call mpas_dmpar_exch_halo_field(field_5d_real)
+
+                        nullify(field_5d_real)
+                    case default
+                        call self % model_error('Unsupported field rank', subname, __LINE__)
+                end select
+            case default
+                call self % model_error('Unsupported field type', subname, __LINE__)
+        end select
+
+        call self % debug_print(subname // ' completed')
+    end subroutine dyn_mpas_exchange_halo
+
+    !-------------------------------------------------------------------------------
+    ! subroutine dyn_mpas_get_global_mesh_dimension
+    !
+    !> \brief  Returns global mesh dimensions
+    !> \author Michael Duda
+    !> \date   22 August 2019
+    !> \details
+    !>  This subroutine returns global mesh dimensions, including:
+    !>  * Numbers of global mesh cells, edges, vertices and vertical levels
+    !>    across all tasks.
+    !>  * Maximum numbers of mesh cells and edges/vertices among all tasks.
+    !>  * Sphere radius.
+    !> \addenda
+    !>  Ported and refactored for CAM-SIMA. (KCW, 2024-03-25)
+    !
+    !-------------------------------------------------------------------------------
+    subroutine dyn_mpas_get_global_mesh_dimension(self, &
+            ncells_global, nedges_global, nvertices_global, nvertlevels, ncells_max, nedges_max, &
+            sphere_radius)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, intent(out) :: ncells_global, nedges_global, nvertices_global, nvertlevels, ncells_max, nedges_max
+        real(rkind), intent(out) :: sphere_radius
+
+        integer, allocatable :: maxedges_value
+        integer, allocatable :: ncellssolve_value
+        integer, allocatable :: nedgessolve_value
+        integer, allocatable :: nverticessolve_value
+        integer, allocatable :: nvertlevels_value
+
+        call self % get_variable_value(maxedges_value, 'dim', 'maxEdges')
+        call self % get_variable_value(ncellssolve_value, 'dim', 'nCellsSolve')
+        call self % get_variable_value(nedgessolve_value, 'dim', 'nEdgesSolve')
+        call self % get_variable_value(nverticessolve_value, 'dim', 'nVerticesSolve')
+        call self % get_variable_value(nvertlevels_value, 'dim', 'nVertLevels')
+
+        call mpas_dmpar_sum_int(self % domain_ptr % dminfo, ncellssolve_value, ncells_global)
+        call mpas_dmpar_sum_int(self % domain_ptr % dminfo, nedgessolve_value, nedges_global)
+        call mpas_dmpar_sum_int(self % domain_ptr % dminfo, nverticessolve_value, nvertices_global)
+
+        ! Vertical levels are not decomposed.
+        ! All tasks have the same number of vertical levels.
+        nvertlevels = nvertlevels_value
+
+        call mpas_dmpar_max_int(self % domain_ptr % dminfo, ncellssolve_value, ncells_max)
+
+        nedges_max = maxedges_value
+        sphere_radius = self % domain_ptr % sphere_radius
+
+        deallocate(maxedges_value)
+        deallocate(ncellssolve_value)
+        deallocate(nedgessolve_value)
+        deallocate(nverticessolve_value)
+        deallocate(nvertlevels_value)
+    end subroutine dyn_mpas_get_global_mesh_dimension
+
+    !> Helper subroutine for returning a pointer of `mpas_pool_type` to the named pool.
+    !> It is used by the `dyn_mpas_get_variable_{pointer,value}_*` subroutines to draw a variable from a pool.
+    !> (KCW, 2024-03-21)
+    subroutine dyn_mpas_get_pool_pointer(self, pool_pointer, pool_name)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        type(mpas_pool_type), pointer, intent(out) :: pool_pointer
+        character(*), intent(in) :: pool_name
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_pool_pointer'
+
+        nullify(pool_pointer)
+
+        select case (pool_name)
+            case ('all')
+                pool_pointer => self % domain_ptr % blocklist % allfields
+            case ('cfg')
+                pool_pointer => self % domain_ptr % configs
+            case ('dim')
+                pool_pointer => self % domain_ptr % blocklist % dimensions
+            case ('diag', 'mesh', 'state', 'tend')
+                call mpas_pool_get_subpool(self % domain_ptr % blocklist % allstructs, pool_name, pool_pointer)
+            case default
+                call self % model_error('Unsupported pool name', subname, __LINE__)
+        end select
+
+        if (.not. associated(pool_pointer)) then
+            call self % model_error('Failed to find pool', subname, __LINE__)
+        end if
+    end subroutine dyn_mpas_get_pool_pointer
+
+    !-------------------------------------------------------------------------------
+    ! subroutine dyn_mpas_get_variable_pointer_*
+    !
+    !> \brief  A family of accessor subroutines for MPAS dynamical core instance
+    !> \author Kuan-Chih Wang
+    !> \date   2024-03-21
+    !> \details
+    !>  The `dyn_mpas_get_variable_pointer_*` subroutines are a family of accessor
+    !>  subroutines for drawing the REFERENCE of an internal variable from
+    !>  MPAS dynamical core instance. The `get_variable_pointer` generic interface
+    !>  should be used instead of the specific ones.
+    !>  WARNING:
+    !>  USE OF THIS SUBROUTINE FAMILY IS HIGHLY DISCOURAGED BECAUSE INTERNAL
+    !>  STATES OF MPAS DYNAMICAL CORE INSTANCE COULD BE MODIFIED THROUGH THE
+    !>  RETURNED POINTER. THESE ARE UNCHARTED WATERS SO BE SURE WHAT YOU ARE
+    !>  DOING.
+    !
+    !-------------------------------------------------------------------------------
+    subroutine dyn_mpas_get_variable_pointer_c0(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        character(strkind), pointer, intent(out) :: variable_pointer
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_c0'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+
+        if (pool_name == 'cfg') then
+            ! Special case for config-related variables. They must be retrieved by calling `mpas_pool_get_config`.
+            call mpas_pool_get_config(mpas_pool, variable_name, variable_pointer)
+        else
+            call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+        end if
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_c0
+
+    subroutine dyn_mpas_get_variable_pointer_c1(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        character(strkind), pointer, intent(out) :: variable_pointer(:)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_c1'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+        call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_c1
+
+    subroutine dyn_mpas_get_variable_pointer_i0(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, pointer, intent(out) :: variable_pointer
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_i0'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+
+        if (pool_name == 'cfg') then
+            ! Special case for config-related variables. They must be retrieved by calling `mpas_pool_get_config`.
+            call mpas_pool_get_config(mpas_pool, variable_name, variable_pointer)
+        else if (pool_name == 'dim') then
+            ! Special case for dimension-related variables. They must be retrieved by calling `mpas_pool_get_dimension`.
+            call mpas_pool_get_dimension(mpas_pool, variable_name, variable_pointer)
+        else
+            call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+        end if
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_i0
+
+    subroutine dyn_mpas_get_variable_pointer_i1(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, pointer, intent(out) :: variable_pointer(:)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_i1'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+
+        if (pool_name == 'dim') then
+            ! Special case for dimension-related variables. They must be retrieved by calling `mpas_pool_get_dimension`.
+            call mpas_pool_get_dimension(mpas_pool, variable_name, variable_pointer)
+        else
+            call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+        end if
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_i1
+
+    subroutine dyn_mpas_get_variable_pointer_i2(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, pointer, intent(out) :: variable_pointer(:, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_i2'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+        call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_i2
+
+    subroutine dyn_mpas_get_variable_pointer_i3(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, pointer, intent(out) :: variable_pointer(:, :, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_i3'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+        call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_i3
+
+    subroutine dyn_mpas_get_variable_pointer_l0(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        logical, pointer, intent(out) :: variable_pointer
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_l0'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+
+        if (pool_name == 'cfg') then
+            ! Special case for config-related variables. They must be retrieved by calling `mpas_pool_get_config`.
+            call mpas_pool_get_config(mpas_pool, variable_name, variable_pointer)
+        end if
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_l0
+
+    subroutine dyn_mpas_get_variable_pointer_r0(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), pointer, intent(out) :: variable_pointer
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_r0'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+
+        if (pool_name == 'cfg') then
+            ! Special case for config-related variables. They must be retrieved by calling `mpas_pool_get_config`.
+            call mpas_pool_get_config(mpas_pool, variable_name, variable_pointer)
+        else
+            call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+        end if
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_r0
+
+    subroutine dyn_mpas_get_variable_pointer_r1(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), pointer, intent(out) :: variable_pointer(:)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_r1'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+        call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_r1
+
+    subroutine dyn_mpas_get_variable_pointer_r2(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), pointer, intent(out) :: variable_pointer(:, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_r2'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+        call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_r2
+
+    subroutine dyn_mpas_get_variable_pointer_r3(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), pointer, intent(out) :: variable_pointer(:, :, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_r3'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+        call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_r3
+
+    subroutine dyn_mpas_get_variable_pointer_r4(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), pointer, intent(out) :: variable_pointer(:, :, :, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_r4'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+        call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_r4
+
+    subroutine dyn_mpas_get_variable_pointer_r5(self, variable_pointer, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), pointer, intent(out) :: variable_pointer(:, :, :, :, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_pointer_r5'
+        type(mpas_pool_type), pointer :: mpas_pool => null()
+
+        call self % get_pool_pointer(mpas_pool, pool_name)
+        nullify(variable_pointer)
+        call mpas_pool_get_array(mpas_pool, variable_name, variable_pointer, timelevel=time_level)
+
+        if (.not. associated(variable_pointer)) then
+            call self % model_error('Failed to find variable', subname, __LINE__)
+        end if
+
+        nullify(mpas_pool)
+    end subroutine dyn_mpas_get_variable_pointer_r5
+
+    !-------------------------------------------------------------------------------
+    ! subroutine dyn_mpas_get_variable_value_*
+    !
+    !> \brief  A family of accessor subroutines for MPAS dynamical core instance
+    !> \author Kuan-Chih Wang
+    !> \date   2024-03-21
+    !> \details
+    !>  The `dyn_mpas_get_variable_value_*` subroutines are a family of accessor
+    !>  subroutines for drawing the VALUE of an internal variable from
+    !>  MPAS dynamical core instance. The `get_variable_value` generic interface
+    !>  should be used instead of the specific ones.
+    !
+    !-------------------------------------------------------------------------------
+    subroutine dyn_mpas_get_variable_value_c0(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        character(strkind), allocatable, intent(out) :: variable_value
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_c0'
+        character(strkind), pointer :: variable_pointer => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_c0
+
+    subroutine dyn_mpas_get_variable_value_c1(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        character(strkind), allocatable, intent(out) :: variable_value(:)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_c1'
+        character(strkind), pointer :: variable_pointer(:) => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_c1
+
+    subroutine dyn_mpas_get_variable_value_i0(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, allocatable, intent(out) :: variable_value
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_i0'
+        integer, pointer :: variable_pointer => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_i0
+
+    subroutine dyn_mpas_get_variable_value_i1(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, allocatable, intent(out) :: variable_value(:)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_i1'
+        integer, pointer :: variable_pointer(:) => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_i1
+
+    subroutine dyn_mpas_get_variable_value_i2(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, allocatable, intent(out) :: variable_value(:, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_i2'
+        integer, pointer :: variable_pointer(:, :) => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_i2
+
+    subroutine dyn_mpas_get_variable_value_i3(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        integer, allocatable, intent(out) :: variable_value(:, :, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_i3'
+        integer, pointer :: variable_pointer(:, :, :) => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_i3
+
+    subroutine dyn_mpas_get_variable_value_l0(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        logical, allocatable, intent(out) :: variable_value
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_l0'
+        logical, pointer :: variable_pointer => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_l0
+
+    subroutine dyn_mpas_get_variable_value_r0(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), allocatable, intent(out) :: variable_value
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_r0'
+        real(rkind), pointer :: variable_pointer => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_r0
+
+    subroutine dyn_mpas_get_variable_value_r1(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), allocatable, intent(out) :: variable_value(:)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_r1'
+        real(rkind), pointer :: variable_pointer(:) => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_r1
+
+    subroutine dyn_mpas_get_variable_value_r2(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), allocatable, intent(out) :: variable_value(:, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_r2'
+        real(rkind), pointer :: variable_pointer(:, :) => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_r2
+
+    subroutine dyn_mpas_get_variable_value_r3(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), allocatable, intent(out) :: variable_value(:, :, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_r3'
+        real(rkind), pointer :: variable_pointer(:, :, :) => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_r3
+
+    subroutine dyn_mpas_get_variable_value_r4(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), allocatable, intent(out) :: variable_value(:, :, :, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_r4'
+        real(rkind), pointer :: variable_pointer(:, :, :, :) => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_r4
+
+    subroutine dyn_mpas_get_variable_value_r5(self, variable_value, pool_name, variable_name, time_level)
+        class(mpas_dynamical_core_type), intent(in) :: self
+        real(rkind), allocatable, intent(out) :: variable_value(:, :, :, :, :)
+        character(*), intent(in) :: pool_name
+        character(*), intent(in) :: variable_name
+        integer, optional, intent(in) :: time_level
+
+        character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_variable_value_r5'
+        real(rkind), pointer :: variable_pointer(:, :, :, :, :) => null()
+        integer :: ierr
+
+        call self % get_variable_pointer(variable_pointer, pool_name, variable_name, time_level=time_level)
+        allocate(variable_value, source=variable_pointer, stat=ierr)
+
+        if (ierr /= 0) then
+            call self % model_error('Failed to allocate variable', subname, __LINE__)
+        end if
+
+        nullify(variable_pointer)
+    end subroutine dyn_mpas_get_variable_value_r5
 end module dyn_mpas_subdriver

--- a/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
@@ -1597,36 +1597,36 @@ contains
         real(rkind), intent(out) :: sphere_radius
 
         character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_get_global_mesh_dimension'
-        integer, allocatable :: maxedges_value
-        integer, allocatable :: ncellssolve_value
-        integer, allocatable :: nedgessolve_value
-        integer, allocatable :: nverticessolve_value
-        integer, allocatable :: nvertlevels_value
+        integer, pointer :: maxedges_pointer => null()
+        integer, pointer :: ncellssolve_pointer => null()
+        integer, pointer :: nedgessolve_pointer => null()
+        integer, pointer :: nverticessolve_pointer => null()
+        integer, pointer :: nvertlevels_pointer => null()
 
-        call self % get_variable_value(maxedges_value, 'dim', 'maxEdges')
-        call self % get_variable_value(ncellssolve_value, 'dim', 'nCellsSolve')
-        call self % get_variable_value(nedgessolve_value, 'dim', 'nEdgesSolve')
-        call self % get_variable_value(nverticessolve_value, 'dim', 'nVerticesSolve')
-        call self % get_variable_value(nvertlevels_value, 'dim', 'nVertLevels')
+        call self % get_variable_pointer(maxedges_pointer, 'dim', 'maxEdges')
+        call self % get_variable_pointer(ncellssolve_pointer, 'dim', 'nCellsSolve')
+        call self % get_variable_pointer(nedgessolve_pointer, 'dim', 'nEdgesSolve')
+        call self % get_variable_pointer(nverticessolve_pointer, 'dim', 'nVerticesSolve')
+        call self % get_variable_pointer(nvertlevels_pointer, 'dim', 'nVertLevels')
 
-        call mpas_dmpar_sum_int(self % domain_ptr % dminfo, ncellssolve_value, ncells_global)
-        call mpas_dmpar_sum_int(self % domain_ptr % dminfo, nedgessolve_value, nedges_global)
-        call mpas_dmpar_sum_int(self % domain_ptr % dminfo, nverticessolve_value, nvertices_global)
+        call mpas_dmpar_sum_int(self % domain_ptr % dminfo, ncellssolve_pointer, ncells_global)
+        call mpas_dmpar_sum_int(self % domain_ptr % dminfo, nedgessolve_pointer, nedges_global)
+        call mpas_dmpar_sum_int(self % domain_ptr % dminfo, nverticessolve_pointer, nvertices_global)
 
         ! Vertical levels are not decomposed.
         ! All tasks have the same number of vertical levels.
-        nvertlevels = nvertlevels_value
+        nvertlevels = nvertlevels_pointer
 
-        call mpas_dmpar_max_int(self % domain_ptr % dminfo, ncellssolve_value, ncells_max)
+        call mpas_dmpar_max_int(self % domain_ptr % dminfo, ncellssolve_pointer, ncells_max)
 
-        nedges_max = maxedges_value
+        nedges_max = maxedges_pointer
         sphere_radius = self % domain_ptr % sphere_radius
 
-        deallocate(maxedges_value)
-        deallocate(ncellssolve_value)
-        deallocate(nedgessolve_value)
-        deallocate(nverticessolve_value)
-        deallocate(nvertlevels_value)
+        nullify(maxedges_pointer)
+        nullify(ncellssolve_pointer)
+        nullify(nedgessolve_pointer)
+        nullify(nverticessolve_pointer)
+        nullify(nvertlevels_pointer)
     end subroutine dyn_mpas_get_global_mesh_dimension
 
     !> Helper subroutine for returning a pointer of `mpas_pool_type` to the named pool.

--- a/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
@@ -509,7 +509,7 @@ contains
     !-------------------------------------------------------------------------------
     subroutine dyn_mpas_read_namelist(self, namelist_path, &
             cf_calendar, start_date_time, stop_date_time, run_duration, initial_run)
-        class(mpas_dynamical_core_type), intent(inout) :: self
+        class(mpas_dynamical_core_type), intent(in) :: self
         character(*), intent(in) :: namelist_path, cf_calendar
         integer, intent(in) :: start_date_time(6), & ! YYYY, MM, DD, hh, mm, ss.
                                stop_date_time(6),  & ! YYYY, MM, DD, hh, mm, ss.
@@ -646,7 +646,7 @@ contains
     !
     !-------------------------------------------------------------------------------
     subroutine dyn_mpas_init_phase2(self, pio_iosystem)
-        class(mpas_dynamical_core_type), intent(inout) :: self
+        class(mpas_dynamical_core_type), intent(in) :: self
         type(iosystem_desc_t), pointer, intent(in) :: pio_iosystem
 
         character(*), parameter :: subname = 'dyn_mpas_subdriver::dyn_mpas_init_phase2'

--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -47,6 +47,7 @@ contains
     subroutine dyn_readnl(namelist_path)
         character(*), intent(in) :: namelist_path
 
+        character(*), parameter :: subname = 'dyn_comp::dyn_readnl'
         character(shr_kind_cs) :: cam_calendar
         integer :: log_unit(2)
         integer :: start_date_time(6), & ! YYYY, MM, DD, hh, mm, ss.

--- a/src/dynamics/mpas/dyn_grid.F90
+++ b/src/dynamics/mpas/dyn_grid.F90
@@ -10,7 +10,7 @@ module dyn_grid
     use dyn_comp, only: dyn_debug_print, mpas_dynamical_core
     use dynconst, only: dynconst_init, pi
     use physics_column_type, only: kind_pcol, physics_column_t
-    use physics_grid, only: phys_grid_init
+    use physics_grid, only: phys_decomp, phys_grid_init
     use ref_pres, only: ref_pres_init
     use spmd_utils, only: iam
     use std_atm_profile, only: std_atm_pres
@@ -460,12 +460,13 @@ contains
         character(*), intent(in) :: name
         integer :: dyn_grid_id
 
-        integer, parameter :: dyn_grid_id_offset = 0
         integer :: i
 
         do i = 1, size(dyn_grid_name)
             if (trim(adjustl(dyn_grid_name(i))) == trim(adjustl(name))) then
-                dyn_grid_id = dyn_grid_id_offset + i
+                ! Grid ids count from `phys_decomp` + 1.
+                ! This avoids id collisions between dynamics and physics grids.
+                dyn_grid_id = phys_decomp + i
 
                 return
             end if

--- a/src/dynamics/mpas/dyn_grid.F90
+++ b/src/dynamics/mpas/dyn_grid.F90
@@ -1,13 +1,455 @@
 module dyn_grid
+    ! Modules from CAM.
+    use cam_abortutils, only: endrun
+    use cam_constituents, only: num_advected
+    use cam_grid_support, only: cam_grid_register, cam_grid_attribute_register, &
+                                horiz_coord_t, horiz_coord_create, &
+                                max_hcoordname_len
+    use cam_initfiles, only: initial_file_get_id
+    use cam_map_utils, only: kind_imap => imap
+    use dyn_comp, only: dyn_debug_print, mpas_dynamical_core
+    use dynconst, only: dynconst_init, pi
+    use physics_column_type, only: kind_pcol, physics_column_t
+    use physics_grid, only: phys_grid_init
+    use ref_pres, only: ref_pres_init
+    use shr_kind_mod, only: kind_r8 => shr_kind_r8
+    use spmd_utils, only: iam
+    use std_atm_profile, only: std_atm_pres
+    use string_utils, only: stringify
+    use vert_coord, only: pver, pverp, vert_coord_init
+
+    ! Modules from external libraries.
+    use pio, only: file_desc_t
+
     implicit none
 
     private
     ! Provide APIs required by CAM Control.
     public :: model_grid_init
+
+    public :: dyn_grid_id
+    public :: dyn_grid_name
+
+    ! Grid names that are to be registered with CAM-SIMA by calling `cam_grid_register`.
+    ! Grid ids can be determined by calling `dyn_grid_id`.
+    character(max_hcoordname_len), parameter :: dyn_grid_name(*) = [ &
+        'mpas_cell',  &
+        'cam_cell',   &
+        'mpas_edge',  &
+        'mpas_vertex' &
+    ]
+
+    real(kind_r8), parameter :: deg_to_rad = pi / 180.0_kind_r8 ! Convert degrees to radians.
+    real(kind_r8), parameter :: rad_to_deg = 180.0_kind_r8 / pi ! Convert radians to degrees.
+
+    ! Local and global mesh dimensions.
+    integer :: ncells_solve,  nedges_solve,  nvertices_solve
+    integer :: ncells_global, nedges_global, nvertices_global, nvertlevels, ncells_max, nedges_max
+    real(kind_r8) :: sphere_radius
 contains
+    !> Initialize various model grids (e.g., dynamics, physics) in terms of dynamics decomposition.
+    !> Additionally, MPAS framework initialization and reading time-invariant (e.g., grid/mesh) variables
+    !> are also being completed in this subroutine.
+    !> (KCW, 2024-03-29)
+    !
+    ! Called by `cam_init` in `src/control/cam_comp.F90`.
+    subroutine model_grid_init()
+        character(*), parameter :: subname = 'dyn_grid::model_grid_init'
+        integer, allocatable :: ncellssolve, nedgessolve, nverticessolve
+        type(file_desc_t), pointer :: pio_file => null()
 
-! Called by `cam_init` in `src/control/cam_comp.F90`.
-subroutine model_grid_init()
-end subroutine model_grid_init
+        ! Initialize mathematical and physical constants for dynamics.
+        call dyn_debug_print('Calling dynconst_init')
 
+        call dynconst_init()
+
+        ! Initialize vertical coordinates.
+        ! `pver` comes from CAM-SIMA namelist.
+        ! `pverp` is set only after this call. Call it as soon as possible.
+        call dyn_debug_print('Calling vert_coord_init')
+
+        call vert_coord_init(1, pver)
+
+        ! Get PIO file descriptor for initial file.
+        pio_file => initial_file_get_id()
+
+        ! Finish MPAS framework initialization, including
+        ! the allocation of all blocks and fields managed by MPAS.
+        call mpas_dynamical_core % init_phase3(num_advected, pio_file)
+
+        ! Read time-invariant (e.g., grid/mesh) variables.
+        call mpas_dynamical_core % read_write_stream(pio_file, 'r', 'invariant')
+
+        ! Inquire local and global mesh dimensions and save them as module variables.
+        call dyn_debug_print('Inquiring local and global mesh dimensions')
+
+        call mpas_dynamical_core % get_variable_value(ncellssolve, 'dim', 'nCellsSolve')
+        call mpas_dynamical_core % get_variable_value(nedgessolve, 'dim', 'nEdgesSolve')
+        call mpas_dynamical_core % get_variable_value(nverticessolve, 'dim', 'nVerticesSolve')
+
+        ncells_solve = ncellssolve
+        nedges_solve = nedgessolve
+        nvertices_solve = nverticessolve
+
+        deallocate(ncellssolve)
+        deallocate(nedgessolve)
+        deallocate(nverticessolve)
+
+        call mpas_dynamical_core % get_global_mesh_dimension( &
+            ncells_global, nedges_global, nvertices_global, nvertlevels, ncells_max, nedges_max, &
+            sphere_radius)
+
+        call dyn_debug_print('ncells_global    = ' // stringify([ncells_global]))
+        call dyn_debug_print('nedges_global    = ' // stringify([nedges_global]))
+        call dyn_debug_print('nvertices_global = ' // stringify([nvertices_global]))
+        call dyn_debug_print('nvertlevels      = ' // stringify([nvertlevels]))
+        call dyn_debug_print('ncells_max       = ' // stringify([ncells_max]))
+        call dyn_debug_print('nedges_max       = ' // stringify([nedges_max]))
+        call dyn_debug_print('sphere_radius    = ' // stringify([sphere_radius]))
+
+        ! Check for consistency in numbers of vertical layers.
+        if (nvertlevels /= pver) then
+            call dyn_debug_print('Number of vertical layers in CAM-SIMA namelist, pver = ' // stringify([pver]))
+            call dyn_debug_print('Number of vertical layers in initial file, nvertlevels = ' // stringify([nvertlevels]))
+
+            call endrun('Numbers of vertical layers mismatch', subname, __LINE__)
+        end if
+
+        ! Initialize reference pressure.
+        call dyn_debug_print('Calling init_reference_pressure')
+
+        call init_reference_pressure()
+
+        ! Initialize physics grid.
+        call dyn_debug_print('Calling init_physics_grid')
+
+        call init_physics_grid()
+
+        ! Initialize CAM-SIMA grid.
+        call dyn_debug_print('Calling define_cam_grid')
+
+        call define_cam_grid()
+    end subroutine model_grid_init
+
+    !> Initialize reference pressure by computing necessary variables and calling `ref_pres_init`.
+    !> (KCW, 2024-03-25)
+    subroutine init_reference_pressure()
+        ! Number of pure pressure levels at model top.
+        integer, parameter :: num_pure_p_lev = 0
+        integer :: k, l
+        ! Reference pressure (Pa) at layer interfaces and midpoints.
+        real(kind_r8), allocatable :: p_ref_int(:)
+        real(kind_r8), allocatable :: p_ref_mid(:)
+        ! In MPAS, the vertical coordinate is denoted as lowercase "zeta", a Greek alphabet.
+        ! `zu` denotes zeta at u-wind levels (i.e., at layer midpoints).
+        ! `zw` denotes zeta at w-wind levels (i.e., at layer interfaces).
+        ! `dzw` denotes the delta/difference between `zw`.
+        ! `rdzw` denotes the reciprocal of `dzw`.
+        real(kind_r8), allocatable :: zu(:)
+        real(kind_r8), allocatable :: zw(:), dzw(:), rdzw(:)
+
+        ! Compute reference height.
+        call mpas_dynamical_core % get_variable_value(rdzw, 'all', 'rdzw', time_level=1)
+
+        allocate(dzw(pver))
+
+        dzw(:) = 1.0_kind_r8 / rdzw
+
+        allocate(zw(pverp))
+        allocate(zu(pver))
+
+        ! In MPAS, zeta coordinates are stored in increasing order (i.e., bottom to top of atmosphere).
+        ! In CAM-SIMA, however, index order is reversed (i.e., top to bottom of atmosphere).
+        ! Compute in reverse below.
+        zw(pverp) = 0.0_kind_r8
+
+        do k = pver, 1, -1
+            zw(k) = zw(k + 1) + dzw(pver - k + 1)
+            zu(k) = 0.5_kind_r8 * (zw(k + 1) + zw(k))
+        end do
+
+        ! Compute reference pressure from reference height.
+        allocate(p_ref_int(pverp))
+
+        call std_atm_pres(zw, p_ref_int)
+
+        allocate(p_ref_mid(pver))
+
+        p_ref_mid(:) = 0.5_kind_r8 * (p_ref_int(1:pver) + p_ref_int(2:pverp))
+
+        ! Print a nice table of reference height and pressure.
+        call dyn_debug_print('Reference layer information:')
+        call dyn_debug_print('----- | -------------- | --------------')
+        call dyn_debug_print('Index |     Height (m) | Pressure (hPa)')
+
+        do k = 1, pver
+            call dyn_debug_print(repeat('-', 5) // ' |  ' // stringify([zw(k)]) // &
+                ' |  ' // stringify([p_ref_int(k) / 100.0_kind_r8]))
+
+            l = len(stringify([k]))
+
+            call dyn_debug_print(repeat(' ', 5 - l) // stringify([k]) // ' |  ' // stringify([zu(k)]) // &
+                ' |  ' // stringify([p_ref_mid(k) / 100.0_kind_r8]))
+        end do
+
+        k = pverp
+
+        call dyn_debug_print(repeat('-', 5) // ' |  ' // stringify([zw(k)]) // &
+            ' |  ' // stringify([p_ref_int(k) / 100.0_kind_r8]))
+
+        call ref_pres_init(p_ref_int, p_ref_mid, num_pure_p_lev)
+    end subroutine init_reference_pressure
+
+    !> Initialize physics grid in terms of dynamics decomposition.
+    !> Provide grid and mapping information between global and local indexes to physics by calling `phys_grid_init`.
+    !> (KCW, 2024-03-27)
+    subroutine init_physics_grid()
+        character(max_hcoordname_len), allocatable :: dyn_attribute_name(:)
+        integer :: hdim1_d, hdim2_d
+        integer :: i
+        integer, allocatable :: indextocellid(:)  ! Global indexes of cell centers.
+        real(kind_r8), allocatable :: areacell(:) ! Cell areas (square meters).
+        real(kind_r8), allocatable :: latcell(:)  ! Cell center latitudes (radians).
+        real(kind_r8), allocatable :: loncell(:)  ! Cell center longitudes (radians).
+        type(physics_column_t), allocatable :: dyn_column(:) ! Grid and mapping information between global and local indexes.
+
+        hdim1_d = ncells_global
+
+        ! Setting `hdim2_d` to `1` indicates unstructured grid.
+        hdim2_d = 1
+
+        call mpas_dynamical_core % get_variable_value(areacell, 'mesh', 'areaCell')
+        call mpas_dynamical_core % get_variable_value(indextocellid, 'mesh', 'indexToCellID')
+        call mpas_dynamical_core % get_variable_value(latcell, 'mesh', 'latCell')
+        call mpas_dynamical_core % get_variable_value(loncell, 'mesh', 'lonCell')
+
+        allocate(dyn_column(ncells_solve))
+
+        do i = 1, ncells_solve
+            ! Column information.
+            dyn_column(i) % lat_rad = real(latcell(i), kind_pcol)
+            dyn_column(i) % lon_rad = real(loncell(i), kind_pcol)
+            dyn_column(i) % lat_deg = real(latcell(i) * rad_to_deg, kind_pcol)
+            dyn_column(i) % lon_deg = real(loncell(i) * rad_to_deg, kind_pcol)
+            ! Cell areas normalized to unit sphere.
+            dyn_column(i) % area    = real(areacell(i) / (sphere_radius ** 2), kind_pcol)
+            ! Cell weights normalized to unity.
+            dyn_column(i) % weight  = real(areacell(i) / (4.0_kind_r8 * pi * sphere_radius ** 2), kind_pcol)
+
+            ! File decomposition.
+            ! For unstructured grid, `coord_indices` is not used by `phys_grid_init`.
+            dyn_column(i) % coord_indices(:) = -1
+            ! In this case, `global_col_num` is used instead.
+            dyn_column(i) % global_col_num   = indextocellid(i)
+
+            ! Dynamics decomposition.
+            dyn_column(i) % dyn_task         = iam
+            dyn_column(i) % global_dyn_block = indextocellid(i)
+            dyn_column(i) % local_dyn_block  = i
+            ! `dyn_block_index` is not used due to no dynamics block offset, but it still needs to be allocated.
+            allocate(dyn_column(i) % dyn_block_index(0))
+        end do
+
+        ! `phys_grid_init` expects to receive the `area` attribute from dynamics.
+        ! However, do not let it because dynamics grid is different from physics grid.
+        allocate(dyn_attribute_name(0))
+
+        call phys_grid_init(hdim1_d, hdim2_d, 'mpas', dyn_column, 'mpas_cell', dyn_attribute_name)
+    end subroutine init_physics_grid
+
+    !> This subroutine defines and registers four variants of dynamics grids in terms of dynamics decomposition.
+    !> Their names are listed in `dyn_grid_name` and their corresponding ids can be determined by calling `dyn_grid_id`.
+    !> * "mpas_cell": Grid that is centered at MPAS "cell" points.
+    !> * "cam_cell": Grid that is also centered at MPAS "cell" points but uses standard CAM-SIMA coordinate and dimension names.
+    !> * "mpas_edge": Grid that is centered at MPAS "edge" points.
+    !> * "mpas_vertex": Grid that is centered at MPAS "vertex" points.
+    !> (KCW, 2024-03-28)
+    subroutine define_cam_grid()
+        integer :: i
+        integer, allocatable :: indextocellid(:)   ! Global indexes of cell centers.
+        integer, allocatable :: indextoedgeid(:)   ! Global indexes of edge nodes.
+        integer, allocatable :: indextovertexid(:) ! Global indexes of vertex nodes.
+        real(kind_r8), allocatable :: areacell(:)  ! Cell areas (square meters).
+        real(kind_r8), allocatable :: latcell(:)   ! Cell center latitudes (radians).
+        real(kind_r8), allocatable :: latedge(:)   ! Edge node latitudes (radians).
+        real(kind_r8), allocatable :: latvertex(:) ! Vertex node latitudes (radians).
+        real(kind_r8), allocatable :: loncell(:)   ! Cell center longitudes (radians).
+        real(kind_r8), allocatable :: lonedge(:)   ! Edge node longitudes (radians).
+        real(kind_r8), allocatable :: lonvertex(:) ! Vertex node longitudes (radians).
+
+        ! Global grid indexes. CAN be safely deallocated because its values are copied into
+        ! `cam_grid_attribute_*_t` and `horiz_coord_t`.
+        ! `kind_imap` is an integer kind of `PIO_OFFSET_KIND`.
+        integer(kind_imap), pointer :: global_grid_index(:)  => null()
+        ! Global grid maps. CANNOT be safely deallocated because `cam_filemap_t`
+        ! just uses pointers to point at it.
+        ! `kind_imap` is an integer kind of `PIO_OFFSET_KIND`.
+        integer(kind_imap), pointer :: global_grid_map(:, :) => null()
+        ! Cell areas (square meters). CANNOT be safely deallocated because `cam_grid_attribute_*_t`
+        ! just uses pointers to point at it.
+        real(kind_r8), pointer :: cell_area(:)   => null()
+        ! Cell weights normalized to unity. CANNOT be safely deallocated because `cam_grid_attribute_*_t`
+        ! just uses pointers to point at it.
+        real(kind_r8), pointer :: cell_weight(:) => null()
+        ! Latitude coordinates. CANNOT be safely deallocated because `cam_grid_t`
+        ! just uses pointers to point at it.
+        type(horiz_coord_t), pointer :: lat_coord => null()
+        ! Longitude coordinates. CANNOT be safely deallocated because `cam_grid_t`
+        ! just uses pointers to point at it.
+        type(horiz_coord_t), pointer :: lon_coord => null()
+
+        ! Construct coordinate and grid objects for cell center grid (i.e., "mpas_cell").
+        ! Standard MPAS coordinate and dimension names are used.
+
+        call mpas_dynamical_core % get_variable_value(areacell, 'mesh', 'areaCell')
+
+        call mpas_dynamical_core % get_variable_value(indextocellid, 'mesh', 'indexToCellID')
+        call mpas_dynamical_core % get_variable_value(latcell, 'mesh', 'latCell')
+        call mpas_dynamical_core % get_variable_value(loncell, 'mesh', 'lonCell')
+
+        allocate(global_grid_index(ncells_solve))
+
+        global_grid_index(:) = int(indextocellid, kind_imap)
+
+        lat_coord => horiz_coord_create('latCell', 'nCells', ncells_global, 'latitude', 'degrees_north', &
+            1, ncells_solve, latcell * rad_to_deg, map=global_grid_index)
+        lon_coord => horiz_coord_create('lonCell', 'nCells', ncells_global, 'longitude', 'degrees_east', &
+            1, ncells_solve, loncell * rad_to_deg, map=global_grid_index)
+
+        allocate(cell_area(ncells_solve))
+        allocate(cell_weight(ncells_solve))
+        allocate(global_grid_map(3, ncells_solve))
+
+        do i = 1, ncells_solve
+            cell_area(i)   = areacell(i)
+            cell_weight(i) = areacell(i) / (4.0_kind_r8 * pi * sphere_radius ** 2)
+
+            global_grid_map(1, i) = int(i, kind_imap)
+            global_grid_map(2, i) = int(1, kind_imap)
+            global_grid_map(3, i) = global_grid_index(i)
+        end do
+
+        call dyn_debug_print('Registering grid "mpas_cell" with id ' // stringify([dyn_grid_id('mpas_cell')]))
+
+        call cam_grid_register('mpas_cell', dyn_grid_id('mpas_cell'), lat_coord, lon_coord, global_grid_map, &
+            unstruct=.true., block_indexed=.false.)
+        call cam_grid_attribute_register('mpas_cell', 'cell_area', 'MPAS cell area', 'nCells', cell_area, &
+            map=global_grid_index)
+        call cam_grid_attribute_register('mpas_cell', 'cell_weight', 'MPAS cell weight', 'nCells', cell_weight, &
+            map=global_grid_index)
+
+        nullify(cell_area)
+        nullify(cell_weight)
+        nullify(lat_coord)
+        nullify(lon_coord)
+
+        ! Construct coordinate and grid objects for cell center grid (i.e., "cam_cell").
+        ! Standard CAM-SIMA coordinate and dimension names are used.
+
+        lat_coord => horiz_coord_create('lat', 'ncol', ncells_global, 'latitude', 'degrees_north', &
+            1, ncells_solve, latcell * rad_to_deg, map=global_grid_index)
+        lon_coord => horiz_coord_create('lon', 'ncol', ncells_global, 'longitude', 'degrees_east', &
+            1, ncells_solve, loncell * rad_to_deg, map=global_grid_index)
+
+        call dyn_debug_print('Registering grid "cam_cell" with id ' // stringify([dyn_grid_id('cam_cell')]))
+
+        call cam_grid_register('cam_cell', dyn_grid_id('cam_cell'), lat_coord, lon_coord, global_grid_map, &
+            unstruct=.true., block_indexed=.false.)
+
+        deallocate(global_grid_index)
+        nullify(global_grid_index)
+        nullify(global_grid_map)
+        nullify(lat_coord)
+        nullify(lon_coord)
+
+        ! Construct coordinate and grid objects for edge node grid (i.e., "mpas_edge").
+        ! Standard MPAS coordinate and dimension names are used.
+
+        call mpas_dynamical_core % get_variable_value(indextoedgeid, 'mesh', 'indexToEdgeID')
+        call mpas_dynamical_core % get_variable_value(latedge, 'mesh', 'latEdge')
+        call mpas_dynamical_core % get_variable_value(lonedge, 'mesh', 'lonEdge')
+
+        allocate(global_grid_index(nedges_solve))
+
+        global_grid_index(:) = int(indextoedgeid, kind_imap)
+
+        lat_coord => horiz_coord_create('latEdge', 'nEdges', nedges_global, 'latitude', 'degrees_north', &
+            1, nedges_solve, latedge * rad_to_deg, map=global_grid_index)
+        lon_coord => horiz_coord_create('lonEdge', 'nEdges', nedges_global, 'longitude', 'degrees_east', &
+            1, nedges_solve, lonedge * rad_to_deg, map=global_grid_index)
+
+        allocate(global_grid_map(3, nedges_solve))
+
+        do i = 1, nedges_solve
+            global_grid_map(1, i) = int(i, kind_imap)
+            global_grid_map(2, i) = int(1, kind_imap)
+            global_grid_map(3, i) = global_grid_index(i)
+        end do
+
+        call dyn_debug_print('Registering grid "mpas_edge" with id ' // stringify([dyn_grid_id('mpas_edge')]))
+
+        call cam_grid_register('mpas_edge', dyn_grid_id('mpas_edge'), lat_coord, lon_coord, global_grid_map, &
+            unstruct=.true., block_indexed=.false.)
+
+        deallocate(global_grid_index)
+        nullify(global_grid_index)
+        nullify(global_grid_map)
+        nullify(lat_coord)
+        nullify(lon_coord)
+
+        ! Construct coordinate and grid objects for vertex node grid (i.e., "mpas_vertex").
+        ! Standard MPAS coordinate and dimension names are used.
+
+        call mpas_dynamical_core % get_variable_value(indextovertexid, 'mesh', 'indexToVertexID')
+        call mpas_dynamical_core % get_variable_value(latvertex, 'mesh', 'latVertex')
+        call mpas_dynamical_core % get_variable_value(lonvertex, 'mesh', 'lonVertex')
+
+        allocate(global_grid_index(nvertices_solve))
+
+        global_grid_index(:) = int(indextovertexid, kind_imap)
+
+        lat_coord => horiz_coord_create('latVertex', 'nVertices', nvertices_global, 'latitude', 'degrees_north', &
+            1, nvertices_solve, latvertex * rad_to_deg, map=global_grid_index)
+        lon_coord => horiz_coord_create('lonVertex', 'nVertices', nvertices_global, 'longitude', 'degrees_east', &
+            1, nvertices_solve, lonvertex * rad_to_deg, map=global_grid_index)
+
+        allocate(global_grid_map(3, nvertices_solve))
+
+        do i = 1, nvertices_solve
+           global_grid_map(1, i) = int(i, kind_imap)
+           global_grid_map(2, i) = int(1, kind_imap)
+           global_grid_map(3, i) = global_grid_index(i)
+        end do
+
+        call dyn_debug_print('Registering grid "mpas_vertex" with id ' // stringify([dyn_grid_id('mpas_vertex')]))
+
+        call cam_grid_register('mpas_vertex', dyn_grid_id('mpas_vertex'), lat_coord, lon_coord, global_grid_map, &
+            unstruct=.true., block_indexed=.false.)
+
+        deallocate(global_grid_index)
+        nullify(global_grid_index)
+        nullify(global_grid_map)
+        nullify(lat_coord)
+        nullify(lon_coord)
+    end subroutine define_cam_grid
+
+    !> Helper function for returning grid id given its name.
+    !> (KCW, 2024-03-27)
+    pure function dyn_grid_id(name)
+        character(*), intent(in) :: name
+        integer :: dyn_grid_id
+
+        integer, parameter :: dyn_grid_id_offset = 0
+        integer :: i
+
+        do i = 1, size(dyn_grid_name)
+            if (trim(adjustl(dyn_grid_name(i))) == trim(adjustl(name))) then
+                dyn_grid_id = dyn_grid_id_offset + i
+
+                return
+            end if
+        end do
+
+        dyn_grid_id = 0
+    end function dyn_grid_id
 end module dyn_grid

--- a/src/dynamics/mpas/dyn_grid.F90
+++ b/src/dynamics/mpas/dyn_grid.F90
@@ -12,11 +12,13 @@ module dyn_grid
     use physics_column_type, only: kind_pcol, physics_column_t
     use physics_grid, only: phys_grid_init
     use ref_pres, only: ref_pres_init
-    use shr_kind_mod, only: kind_r8 => shr_kind_r8
     use spmd_utils, only: iam
     use std_atm_profile, only: std_atm_pres
     use string_utils, only: stringify
     use vert_coord, only: pver, pverp, vert_coord_init
+
+    ! Modules from CESM Share.
+    use shr_kind_mod, only: kind_r8 => shr_kind_r8
 
     ! Modules from external libraries.
     use pio, only: file_desc_t
@@ -32,7 +34,7 @@ module dyn_grid
 
     ! Grid names that are to be registered with CAM-SIMA by calling `cam_grid_register`.
     ! Grid ids can be determined by calling `dyn_grid_id`.
-    character(max_hcoordname_len), parameter :: dyn_grid_name(*) = [ &
+    character(*), parameter :: dyn_grid_name(*) = [ character(max_hcoordname_len) :: &
         'mpas_cell',  &
         'cam_cell',   &
         'mpas_edge',  &
@@ -309,7 +311,7 @@ contains
 
         allocate(global_grid_index(ncells_solve))
 
-        global_grid_index(:) = int(indextocellid, kind_imap)
+        global_grid_index(:) = int(indextocellid(1:ncells_solve), kind_imap)
 
         lat_coord => horiz_coord_create('latCell', 'nCells', ncells_global, 'latitude', 'degrees_north', &
             1, ncells_solve, latcell * rad_to_deg, map=global_grid_index)
@@ -371,7 +373,7 @@ contains
 
         allocate(global_grid_index(nedges_solve))
 
-        global_grid_index(:) = int(indextoedgeid, kind_imap)
+        global_grid_index(:) = int(indextoedgeid(1:nedges_solve), kind_imap)
 
         lat_coord => horiz_coord_create('latEdge', 'nEdges', nedges_global, 'latitude', 'degrees_north', &
             1, nedges_solve, latedge * rad_to_deg, map=global_grid_index)
@@ -406,7 +408,7 @@ contains
 
         allocate(global_grid_index(nvertices_solve))
 
-        global_grid_index(:) = int(indextovertexid, kind_imap)
+        global_grid_index(:) = int(indextovertexid(1:nvertices_solve), kind_imap)
 
         lat_coord => horiz_coord_create('latVertex', 'nVertices', nvertices_global, 'latitude', 'degrees_north', &
             1, nvertices_solve, latvertex * rad_to_deg, map=global_grid_index)


### PR DESCRIPTION
This PR implements the `model_grid_init` subroutine, which is responsible for initializing various model grids (e.g., dynamics, physics) in terms of dynamics decomposition. Additionally, MPAS framework initialization and reading time-invariant (e.g., grid/mesh) variables are also being done in this PR.

### Implementation notes:

* Finish MPAS framework initialization (`dyn_mpas_init_phase3`).
* Implement a **generic** mechanism (`dyn_mpas_read_write_stream`) for CAM-SIMA to input/output data to/from MPAS dynamical core. This mechanism is the consolidation and generalization of the `cam_mpas_read_static` [[1]](https://github.com/ESCOMP/CAM/blob/cam6_3_153/src/dynamics/mpas/driver/cam_mpas_subdriver.F90#L883), `cam_mpas_setup_restart` [[2]](https://github.com/ESCOMP/CAM/blob/cam6_3_153/src/dynamics/mpas/driver/cam_mpas_subdriver.F90#L1288), `cam_mpas_read_restart` [[3]](https://github.com/ESCOMP/CAM/blob/cam6_3_153/src/dynamics/mpas/driver/cam_mpas_subdriver.F90#L1747) and `cam_mpas_write_restart` [[4]](https://github.com/ESCOMP/CAM/blob/cam6_3_153/src/dynamics/mpas/driver/cam_mpas_subdriver.F90#L1917) subroutines in current CAM. Hundreds of lines of code are reduced as a result.
* Implement a **generic** mechanism (`dyn_mpas_exchange_halo`) for CAM-SIMA to exchange the halo layers of an arbitrary decomposed variable in MPAS dynamical core.
* Implement accessor subroutines (`dyn_mpas_get_variable_pointer_*` and `dyn_mpas_get_variable_value_*` families) for users to access the internal states of MPAS dynamical core.

### Test steps:

```bash
"<path-to>/CAM-SIMA/cime/scripts/create_newcase" --case "<case-name>" --compset FKESSLER --project "<project-id>" --res mpasa480_mpasa480 --run-unsupported
cd "<case-name>"
./case.setup
# Edit `env_build.xml`:
# * Change `CAM_LINKED_LIBS` to only `-lmpas`.
# * Change `DEBUG` to `TRUE`.
# Edit `env_run.xml`:
# * Change `DOUT_S` to `FALSE`.
# Add the following to `user_nl_cam`:
# * `config_block_decomp_file_prefix = '${DIN_LOC_ROOT}/atm/cam/inic/mpas/mpasa480.graph.info.part.'`.
./case.build
./case.submit
```

Observe log entries similar to the following in `atm.log.<job-id>.<date>-<time>`:

```
dyn_debug_print (0): Calling dynconst_init
dyn_debug_print (0): Calling vert_coord_init
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_init_phase3 entered
dyn_mpas_debug_print (0): Number of constituents is 3
dyn_mpas_debug_print (0): Checking PIO file descriptor
dyn_mpas_debug_print (0): Calling mpas_bootstrap_framework_phase1
dyn_mpas_debug_print (0): Calling mpas_bootstrap_framework_phase2
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_init_phase3 completed
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_read_write_stream entered
dyn_mpas_debug_print (0): Initializing stream
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_init_stream_with_pool entered
dyn_mpas_debug_print (0): Checking PIO file descriptor
dyn_mpas_debug_print (0): Creating "invariant" stream for reading
dyn_mpas_debug_print (0): Adding variables to stream
dyn_mpas_debug_print (0): var_info_list(1) % name = angleEdge
dyn_mpas_debug_print (0): var_info_list(1) % type = real
dyn_mpas_debug_print (0): var_info_list(1) % rank = 1
dyn_mpas_debug_print (0): var_info_list(2) % name = areaCell
dyn_mpas_debug_print (0): var_info_list(2) % type = real
dyn_mpas_debug_print (0): var_info_list(2) % rank = 1
dyn_mpas_debug_print (0): var_info_list(3) % name = areaTriangle
dyn_mpas_debug_print (0): var_info_list(3) % type = real
dyn_mpas_debug_print (0): var_info_list(3) % rank = 1

... (SNIPPED) ...

dyn_mpas_debug_print (0): var_info_list(67) % name = zgrid
dyn_mpas_debug_print (0): var_info_list(67) % type = real
dyn_mpas_debug_print (0): var_info_list(67) % rank = 2
dyn_mpas_debug_print (0): var_info_list(68) % name = zxu
dyn_mpas_debug_print (0): var_info_list(68) % type = real
dyn_mpas_debug_print (0): var_info_list(68) % rank = 2
dyn_mpas_debug_print (0): var_info_list(69) % name = zz
dyn_mpas_debug_print (0): var_info_list(69) % type = real
dyn_mpas_debug_print (0): var_info_list(69) % rank = 2
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_init_stream_with_pool completed
dyn_mpas_debug_print (0): Reading stream
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo entered
dyn_mpas_debug_print (0): Inquiring field information for "angleEdge"
dyn_mpas_debug_print (0): Exchanging halo layers for "angleEdge"
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo completed
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo entered
dyn_mpas_debug_print (0): Inquiring field information for "areaCell"
dyn_mpas_debug_print (0): Exchanging halo layers for "areaCell"
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo completed
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo entered
dyn_mpas_debug_print (0): Inquiring field information for "areaTriangle"
dyn_mpas_debug_print (0): Exchanging halo layers for "areaTriangle"
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo completed

... (SNIPPED) ...

dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo entered
dyn_mpas_debug_print (0): Inquiring field information for "zgrid"
dyn_mpas_debug_print (0): Exchanging halo layers for "zgrid"
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo completed
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo entered
dyn_mpas_debug_print (0): Inquiring field information for "zxu"
dyn_mpas_debug_print (0): Exchanging halo layers for "zxu"
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo completed
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo entered
dyn_mpas_debug_print (0): Inquiring field information for "zz"
dyn_mpas_debug_print (0): Exchanging halo layers for "zz"
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_exchange_halo completed
dyn_mpas_debug_print (0): Closing stream
dyn_mpas_debug_print (0): dyn_mpas_subdriver::dyn_mpas_read_write_stream completed
dyn_debug_print (0): Inquiring local and global mesh dimensions
dyn_debug_print (0): ncells_global    = 2562
dyn_debug_print (0): nedges_global    = 7680
dyn_debug_print (0): nvertices_global = 5120
dyn_debug_print (0): nvertlevels      = 32
dyn_debug_print (0): ncells_max       = 21
dyn_debug_print (0): nedges_max       = 10
dyn_debug_print (0): sphere_radius    =  6.371229E+06
dyn_debug_print (0): Calling init_reference_pressure
dyn_debug_print (0): Reference layer information:
dyn_debug_print (0): ----- | -------------- | --------------
dyn_debug_print (0): Index |     Height (m) | Pressure (hPa)
dyn_debug_print (0): ----- |   41426.919000 |       2.288976
dyn_debug_print (0):     1 |   38524.252750 |       3.700507
dyn_debug_print (0): ----- |   35621.586500 |       5.112039
dyn_debug_print (0):     2 |   33230.541800 |       7.720267
dyn_debug_print (0): ----- |   30839.497100 |      10.328496
dyn_debug_print (0):     3 |   28850.108750 |      14.600401
dyn_debug_print (0): ----- |   26860.720400 |      18.872306
dyn_debug_print (0):     4 |   25327.930900 |      24.561190
dyn_debug_print (0): ----- |   23795.141400 |      30.250074
dyn_debug_print (0):     5 |   22900.719950 |      35.104428
dyn_debug_print (0): ----- |   22006.298500 |      39.958781
dyn_debug_print (0):     6 |   21425.030750 |      43.949775
dyn_debug_print (0): ----- |   20843.763000 |      47.940770
dyn_debug_print (0):     7 |   20281.285500 |      52.586650
dyn_debug_print (0): ----- |   19718.808000 |      57.232531
dyn_debug_print (0):     8 |   19173.205650 |      62.605462
dyn_debug_print (0): ----- |   18627.603300 |      67.978393
dyn_debug_print (0):     9 |   18028.174800 |      75.051291
dyn_debug_print (0): ----- |   17428.746300 |      82.124188
dyn_debug_print (0):    10 |   16913.427200 |      89.370345
dyn_debug_print (0): ----- |   16398.108100 |      96.616502
dyn_debug_print (0):    11 |   15882.886800 |     105.139623
dyn_debug_print (0): ----- |   15367.665500 |     113.662745
dyn_debug_print (0):    12 |   14852.447700 |     123.689543
dyn_debug_print (0): ----- |   14337.229900 |     133.716342
dyn_debug_print (0):    13 |   13821.932800 |     145.514143
dyn_debug_print (0): ----- |   13306.635700 |     157.311944
dyn_debug_print (0):    14 |   12791.361350 |     171.190922
dyn_debug_print (0): ----- |   12276.087000 |     185.069901
dyn_debug_print (0):    15 |   11760.876700 |     201.395649
dyn_debug_print (0): ----- |   11245.666400 |     217.721397
dyn_debug_print (0):    16 |   10726.940100 |     236.885536
dyn_debug_print (0): ----- |   10208.213800 |     256.049675
dyn_debug_print (0):    17 |    9674.235795 |     278.559967
dyn_debug_print (0): ----- |    9140.257790 |     301.070258
dyn_debug_print (0):    18 |    8589.496200 |     327.542135
dyn_debug_print (0): ----- |    8038.734610 |     354.014011
dyn_debug_print (0):    19 |    7470.631760 |     385.146948
dyn_debug_print (0): ----- |    6902.528910 |     416.279885
dyn_debug_print (0):    20 |    6316.673385 |     452.886443
dyn_debug_print (0): ----- |    5730.817860 |     489.493000
dyn_debug_print (0):    21 |    5126.512605 |     532.546026
dyn_debug_print (0): ----- |    4522.207350 |     575.599052
dyn_debug_print (0):    22 |    3987.167550 |     618.653664
dyn_debug_print (0): ----- |    3452.127750 |     661.708275
dyn_debug_print (0):    23 |    3008.722795 |     701.214348
dyn_debug_print (0): ----- |    2565.317840 |     740.720421
dyn_debug_print (0):    24 |    2220.097655 |     774.051773
dyn_debug_print (0): ----- |    1874.877470 |     807.383125
dyn_debug_print (0):    25 |    1632.988910 |     832.153208
dyn_debug_print (0): ----- |    1391.100350 |     856.923292
dyn_debug_print (0):    26 |    1256.271760 |     871.255307
dyn_debug_print (0): ----- |    1121.443170 |     885.587323
dyn_debug_print (0):    27 |     998.067497 |     899.039705
dyn_debug_print (0): ----- |     874.691823 |     912.492088
dyn_debug_print (0):    28 |     763.097833 |     924.943081
dyn_debug_print (0): ----- |     651.503844 |     937.394075
dyn_debug_print (0):    29 |     551.799990 |     948.749828
dyn_debug_print (0): ----- |     452.096135 |     960.105582
dyn_debug_print (0):    30 |     364.453444 |     970.270667
dyn_debug_print (0): ----- |     276.810754 |     980.435752
dyn_debug_print (0):    31 |     201.464120 |     989.313386
dyn_debug_print (0): ----- |     126.117486 |     998.191020
dyn_debug_print (0):    32 |      63.058743 |    1005.720510
dyn_debug_print (0): ----- |       0.000000 |    1013.250000
dyn_debug_print (0): Calling init_physics_grid
Grid: physgrid, ID =  100, lat coord  = lat, lon coord  = lon, unstruct   =  T, block_ind  =  F, zonal_grid =  F
Attribute: area, long name = 'physics column areas'
           dimname = ncol
dyn_debug_print (0): Calling define_cam_grid
dyn_debug_print (0): Registering grid "mpas_cell" with id 101
Grid: mpas_cell, ID =  101, lat coord  = latCell, lon coord  = lonCell, unstruct   =  T, block_ind  =  F, zonal_grid =  F
Attribute: cell_area, long name = 'MPAS cell area'
           dimname = nCells
Attribute: cell_weight, long name = 'MPAS cell weight'
           dimname = nCells
dyn_debug_print (0): Registering grid "cam_cell" with id 102
Grid: cam_cell, ID =  102, lat coord  = lat, lon coord  = lon, unstruct   =  T, block_ind  =  F, zonal_grid =  F
dyn_debug_print (0): Registering grid "mpas_edge" with id 103
Grid: mpas_edge, ID =  103, lat coord  = latEdge, lon coord  = lonEdge, unstruct   =  T, block_ind  =  F, zonal_grid =  F
dyn_debug_print (0): Registering grid "mpas_vertex" with id 104
Grid: mpas_vertex, ID =  104, lat coord  = latVertex, lon coord  = lonVertex, unstruct   =  T, block_ind  =  F, zonal_grid =  F
```
