### PR TITLE
Simplify snapshot checking reporting and functionality

### DIFF
--- a/src/control/cam_comp.F90
+++ b/src/control/cam_comp.F90
@@ -455,7 +455,7 @@ CONTAINS
    !
    !-----------------------------------------------------------------------
    !
-   subroutine cam_timestep_final()
+   subroutine cam_timestep_final(do_ncdata_check)
       !-----------------------------------------------------------------------
       !
       ! Purpose:   Timestep final runs at the end of each timestep
@@ -464,12 +464,15 @@ CONTAINS
 
       use phys_comp, only: phys_timestep_final
 
+      !Flag for whether a snapshot (ncdata) check should be run or not
+      logical, intent(in) :: do_ncdata_check
+
       !
       !----------------------------------------------------------
       ! PHYS_TIMESTEP_FINAL Call the Physics package
       !----------------------------------------------------------
       !
-      call phys_timestep_final()
+      call phys_timestep_final(do_ncdata_check)
 
    end subroutine cam_timestep_final
 

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -313,11 +313,17 @@
               phys_timestep_init_zero="true">
       <long_name>Total tendency from physics suite</long_name>
     </variable>
-    <!-- Physics timestep -->
+    <!-- Timestep variables -->
     <variable local_name="dtime_phys"
               standard_name="timestep_for_physics"
               units="s" type="real" kind="kind_phys">
       <long_name>timestep for physics</long_name>
+    </variable>
+    <variable local_name="nstep"
+              standard_name="current_timestep_number"
+              units="count" type="integer">
+      <long_name>current timestep number</long_name>
+      <initial_value>0</initial_value>
     </variable>
     <!-- Error handling variables -->
     <variable local_name="errcode"

--- a/src/utils/time_manager.F90
+++ b/src/utils/time_manager.F90
@@ -528,6 +528,11 @@ subroutine advance_timestep()
    call ESMF_ClockAdvance( tm_clock, rc=rc )
    call chkrc(rc, sub//': error return from ESMF_ClockAdvance')
 
+! Write new timestep to CAM log file
+   write(iulog,*) '------------------------'
+   write(iulog,'(a,i8,a)') 'CAM-SIMA time step advanced (nstep = ',get_nstep(),')'
+   write(iulog,*) '------------------------'
+
 ! Set first step flag off.
 
    tm_first_restart_step = .false.

--- a/src/utils/time_manager.F90
+++ b/src/utils/time_manager.F90
@@ -520,6 +520,9 @@ subroutine advance_timestep()
 
 ! Increment the timestep number.
 
+! Use statements
+   use string_utils, only: stringify
+
 ! Local variables
    character(len=*), parameter :: sub = 'advance_timestep'
    integer :: rc
@@ -528,9 +531,10 @@ subroutine advance_timestep()
    call ESMF_ClockAdvance( tm_clock, rc=rc )
    call chkrc(rc, sub//': error return from ESMF_ClockAdvance')
 
-! Write new timestep to CAM log file
+! Write new timestep to CAM log file.
+
    write(iulog,*) '------------------------'
-   write(iulog,'(a,i8,a)') 'CAM-SIMA time step advanced (nstep = ',get_nstep(),')'
+   write(iulog,*) 'CAM-SIMA time step advanced (nstep = '//stringify([get_nstep()])//')'
    write(iulog,*) '------------------------'
 
 ! Set first step flag off.

--- a/src/utils/time_manager.F90
+++ b/src/utils/time_manager.F90
@@ -521,7 +521,11 @@ subroutine advance_timestep()
 ! Increment the timestep number.
 
 ! Use statements
-   use string_utils, only: stringify
+   use ESMF,          only: ESMF_ClockAdvance
+   use cam_logfile,   only: iulog
+   use physics_types, only: nstep
+   use spmd_utils,    only: masterproc
+   use string_utils,  only: stringify
 
 ! Local variables
    character(len=*), parameter :: sub = 'advance_timestep'
@@ -531,11 +535,16 @@ subroutine advance_timestep()
    call ESMF_ClockAdvance( tm_clock, rc=rc )
    call chkrc(rc, sub//': error return from ESMF_ClockAdvance')
 
+! Set current timestep number for use in CCPP physics schemes:
+   nstep = get_nstep()
+
 ! Write new timestep to CAM log file.
 
-   write(iulog,*) '------------------------'
-   write(iulog,*) 'CAM-SIMA time step advanced (nstep = '//stringify([get_nstep()])//')'
-   write(iulog,*) '------------------------'
+   if (masterproc) then
+      write(iulog,*) '------------------------'
+      write(iulog,*) 'CAM-SIMA time step advanced (nstep = '//stringify([nstep])//')'
+      write(iulog,*) '------------------------'
+   end if
 
 ! Set first step flag off.
 


### PR DESCRIPTION
This PR ensures that snapshot checks (e.g. `ncdata_check`) are only run during actual model run steps (not initialize or finalize steps), and that there is no offset between the model timestep and the input or check file time.

This PR also adds a new `current_timestep_number` registry variable which is updated every time the model time step advances, as well as a new log print statement that indicates which model timestep CAM-SIMA is currently on.

Fixes #268 

## Tests run:

Ran a physics testbed configuration with both Kessler and Held-Suarez physics for both a single timestep and for multiple timesteps (no differences found for any of the tests).

Also ran the official regression build tests on derecho for both GNU and Intel.