### PR TITLE
Fix find_input_name_idx bug

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -307,8 +307,6 @@
     <valid_values></valid_values>
     <default_value> </default_value>
     <values match="last" modifier="additive">
-      <!-- Turn on chemistry if not using physics testbed -->
-      <value compset="^((?!_CAM%PHYSTEST).)*$">-lmusica -ljsonfortran</value>
       <!-- Add MPAS if using mpas grid and not using physics testbed -->
       <value compset="^((?!_CAM%PHYSTEST).)*$" grid="a%mpasa[0-9]+">-lmpas</value>
     </values>

--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -36,7 +36,7 @@
       <option name="wallclock">00:10:00</option>
       <option name="comment">GNU build test for Moist Held-Suarez physics</option>
     </options>
-  </tests>
+  </test>
 
   <!-- Derecho dycore tests -->
   <test compset="FKESSLER" grid="mpasa480_mpasa480" name="SMS_Ln2" testmods="cam/outfrq_kessler_mpas_derecho_nooutput/">

--- a/src/physics/utils/physics_data.F90
+++ b/src/physics/utils/physics_data.F90
@@ -68,6 +68,8 @@ CONTAINS
       if (find_input_name_idx >= 0) then
          constituent_index = find_input_name_idx
          is_constituent = .true.
+      else
+         find_input_name_idx = no_exist_idx
       end if
 
       !Loop through physics variable standard names:


### PR DESCRIPTION
Resets find_input_name_idx to no_exist_idx after it is modified by const_get_index. Fixes the bug resulted in variables getting a huge <0 index value instead of -1, which caused an error in physics_read_data.

closes #237 

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the boundary datasets: N/A

Describe any substantial timing or memory changes: N/A

Code reviewed by: nusbaume, mwaxmonsky

List all existing files that have been modified, old files eliminated, new files added and describe the changes:

M src/physics/utils/physics_data.F90
* Reset find_input_name_idx to no_exist_idx after call to const_get_index

M cime_config/config_component.xml
* No longer include chemistry linked libs by default

If there were any failures reported from running test_driver.sh on any test
platform, and check that these failures have been OK'd by the gatekeeper,
then copy the lines from the td.*.status files for the failed tests to the
appropriate machine below. All failed tests must be justified.

derecho/intel/aux_cam
derecho/gnu/aux_cam

All tests pass.

Summarize any changes to answers, i.e.,

what code configurations: N/A
what platforms/compilers: N/A
nature of change (roundoff; larger than roundoff but same climate; new climate): N/A