### PR TITLE
Add git-fleximod ci test

### DIFF
--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  fleximod-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # oldest supported and latest supported
+        python-version: ["3.7", "3.x"]
+    steps:
+      - id: checkout-CESM
+        uses: actions/checkout@v4
+      - id: run-fleximod
+        run: |
+          $GITHUB_WORKSPACE/bin/git-fleximod update
+          $GITHUB_WORKSPACE/bin/git-fleximod test
+#      - name: Setup tmate session
+#        if: ${{ failure() }}
+#        uses: mxschmitt/action-tmate@v3
+        
+          

--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -1,8 +1,6 @@
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ development ]
 jobs:
   fleximod-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/fleximod_test.yaml
+++ b/.github/workflows/fleximod_test.yaml
@@ -1,13 +1,12 @@
 on:
   pull_request:
-    branches: [ development ]
 jobs:
   fleximod-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # oldest supported and latest supported
-        python-version: ["3.7", "3.x"]
+        python-version: ["3.8", "3.x"]
     steps:
       - id: checkout-CESM
         uses: actions/checkout@v4
@@ -15,8 +14,5 @@ jobs:
         run: |
           $GITHUB_WORKSPACE/bin/git-fleximod update
           $GITHUB_WORKSPACE/bin/git-fleximod test
-#      - name: Setup tmate session
-#        if: ${{ failure() }}
-#        uses: mxschmitt/action-tmate@v3
         
           

--- a/.lib/git-fleximod/git_fleximod/cli.py
+++ b/.lib/git-fleximod/git_fleximod/cli.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import argparse
 from git_fleximod import utils
 
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 
 def find_root_dir(filename=".gitmodules"):
     """ finds the highest directory in tree

--- a/.lib/git-fleximod/git_fleximod/cli.py
+++ b/.lib/git-fleximod/git_fleximod/cli.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import argparse
 from git_fleximod import utils
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 def find_root_dir(filename=".gitmodules"):
     """ finds the highest directory in tree

--- a/.lib/git-fleximod/git_fleximod/git_fleximod.py
+++ b/.lib/git-fleximod/git_fleximod/git_fleximod.py
@@ -195,18 +195,19 @@ def submodules_status(gitmodules, root_dir, toplevel=False, depth=0):
         submod = init_submodule_from_gitmodules(gitmodules, name, root_dir, logger)
             
         result,n,l,t = submod.status()
-        testfails += t
-        localmods += l
-        needsupdate += n
         if toplevel or not submod.toplevel():
             print(wrapper.fill(result))
-        subdir = os.path.join(root_dir, submod.path)
-        if os.path.exists(os.path.join(subdir, ".gitmodules")):
-            submod = GitModules(logger, confpath=subdir)
-            t,l,n = submodules_status(submod, subdir, depth=depth+1)
             testfails += t
             localmods += l
             needsupdate += n
+        subdir = os.path.join(root_dir, submod.path)
+        if os.path.exists(os.path.join(subdir, ".gitmodules")):
+            gsubmod = GitModules(logger, confpath=subdir)
+            t,l,n = submodules_status(gsubmod, subdir, depth=depth+1)
+            if toplevel or not submod.toplevel():
+                testfails += t
+                localmods += l
+                needsupdate += n
             
     return testfails, localmods, needsupdate
 

--- a/.lib/git-fleximod/git_fleximod/submodule.py
+++ b/.lib/git-fleximod/git_fleximod/submodule.py
@@ -103,7 +103,7 @@ class Submodule():
                     needsupdate = True
                     return result, needsupdate, localmods, testfails                    
                 rurl = git.git_operation("ls-remote","--get-url").rstrip()
-                line = git.git_operation("log", "--pretty=format:\"%h %d").partition('\n')[0]
+                line = git.git_operation("log", "--pretty=format:\"%h %d\"").partition('\n')[0]
                 parts = line.split()
                 ahash = parts[0][1:]
                 atag = None
@@ -112,12 +112,14 @@ class Submodule():
                     while idx < len(parts)-1:
                         idx = idx+1
                         if parts[idx] == 'tag:':
-                            atag = parts[idx+1][:-1]
+                            atag = parts[idx+1]
+                            while atag.endswith(')') or atag.endswith(',') or atag.endswith("\""):
+                                atag = atag[:-1]
                             if atag == self.fxtag:
                                 break
 
                 
-                #print(f"line is {line} ahash is {ahash} atag is {atag}")
+                #print(f"line is {line} ahash is {ahash} atag is {atag} {parts}")
                 #                atag = git.git_operation("describe", "--tags", "--always").rstrip()
                 # ahash =  git.git_operation("rev-list", "HEAD").partition("\n")[0]
                     
@@ -129,7 +131,7 @@ class Submodule():
                     result = f"  {self.name:>20} at tag {self.fxtag}"
                     recurse = True
                     testfails = False
-                elif self.fxtag and ahash[: len(self.fxtag)] == self.fxtag:
+                elif self.fxtag and (ahash[: len(self.fxtag)] == self.fxtag or (self.fxtag.find(ahash)==0)):
                     result = f"  {self.name:>20} at hash {ahash}"
                     recurse = True
                     testfails = False
@@ -146,7 +148,7 @@ class Submodule():
                     else:
                         result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {ahash}"
                     testfails = False
-
+                    
                 status = git.git_operation("status", "--ignore-submodules", "-uno")
                 if "nothing to commit" not in status:
                     localmods = True

--- a/.lib/git-fleximod/git_fleximod/submodule.py
+++ b/.lib/git-fleximod/git_fleximod/submodule.py
@@ -92,7 +92,7 @@ class Submodule():
                 needsupdate = True
             else:
                 result = f"e {self.name:>20} has no fxtag defined in .gitmodules{optional}"
-                testfails = True
+                testfails = False
         else:
             with utils.pushd(smpath):
                 git = GitInterface(smpath, self.logger)
@@ -106,10 +106,16 @@ class Submodule():
                 line = git.git_operation("log", "--pretty=format:\"%h %d").partition('\n')[0]
                 parts = line.split()
                 ahash = parts[0][1:]
+                atag = None
                 if len(parts) > 3:
-                    atag = parts[3][:-1]
-                else:
-                    atag = None
+                    idx = 0
+                    while idx < len(parts)-1:
+                        idx = idx+1
+                        if parts[idx] == 'tag:':
+                            atag = parts[idx+1][:-1]
+                            if atag == self.fxtag:
+                                break
+
                 
                 #print(f"line is {line} ahash is {ahash} atag is {atag}")
                 #                atag = git.git_operation("describe", "--tags", "--always").rstrip()
@@ -122,9 +128,11 @@ class Submodule():
                 if self.fxtag and atag == self.fxtag:
                     result = f"  {self.name:>20} at tag {self.fxtag}"
                     recurse = True
+                    testfails = False
                 elif self.fxtag and ahash[: len(self.fxtag)] == self.fxtag:
                     result = f"  {self.name:>20} at hash {ahash}"
                     recurse = True
+                    testfails = False
                 elif atag == ahash:
                     result = f"  {self.name:>20} at hash {ahash}"
                     recurse = True
@@ -133,14 +141,17 @@ class Submodule():
                     testfails = True
                     needsupdate = True
                 else:
-                    result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {atag}"
-                    testfails = True
-                    
+                   if atag:
+                        result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {atag}"
+                    else:
+                        result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {ahash}"
+                    testfails = False
+
                 status = git.git_operation("status", "--ignore-submodules", "-uno")
                 if "nothing to commit" not in status:
                     localmods = True
-                    result = "M" + textwrap.indent(status, "                      ")
-        
+                    result = "M" + textwrap.indent(status, "                      "
+#        print(f"result {result} needsupdate {needsupdate} localmods {localmods} testfails {testfails}")
         return result, needsupdate, localmods, testfails
 
     

--- a/.lib/git-fleximod/git_fleximod/submodule.py
+++ b/.lib/git-fleximod/git_fleximod/submodule.py
@@ -141,7 +141,7 @@ class Submodule():
                     testfails = True
                     needsupdate = True
                 else:
-                   if atag:
+                    if atag:
                         result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {atag}"
                     else:
                         result = f"e {self.name:>20} has no fxtag defined in .gitmodules, module at {ahash}"

--- a/.lib/git-fleximod/git_fleximod/submodule.py
+++ b/.lib/git-fleximod/git_fleximod/submodule.py
@@ -150,7 +150,7 @@ class Submodule():
                 status = git.git_operation("status", "--ignore-submodules", "-uno")
                 if "nothing to commit" not in status:
                     localmods = True
-                    result = "M" + textwrap.indent(status, "                      "
+                    result = "M" + textwrap.indent(status, "                      ")
 #        print(f"result {result} needsupdate {needsupdate} localmods {localmods} testfails {testfails}")
         return result, needsupdate, localmods, testfails
 

--- a/.lib/git-fleximod/pyproject.toml
+++ b/.lib/git-fleximod/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-fleximod"
-version = "0.8.3"
+version = "0.8.4"
 description = "Extended support for git-submodule and git-sparse-checkout"
 authors = ["Jim Edwards <jedwards@ucar.edu>"]
 maintainers = ["Jim Edwards <jedwards@ucar.edu>"]

--- a/.lib/git-fleximod/pyproject.toml
+++ b/.lib/git-fleximod/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-fleximod"
-version = "0.8.2"
+version = "0.8.3"
 description = "Extended support for git-submodule and git-sparse-checkout"
 authors = ["Jim Edwards <jedwards@ucar.edu>"]
 maintainers = ["Jim Edwards <jedwards@ucar.edu>"]

--- a/.lib/git-fleximod/tbump.toml
+++ b/.lib/git-fleximod/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/jedwards4b/git-fleximod/"
 
 [version]
-current = "0.8.2"
+current = "0.8.3"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/.lib/git-fleximod/tbump.toml
+++ b/.lib/git-fleximod/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/jedwards4b/git-fleximod/"
 
 [version]
-current = "0.8.3"
+current = "0.8.4"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before


### PR DESCRIPTION
Updates git-fleximod to v8.4 and adds the git-fleximod github workflow.

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the boundary datasets: N/A

Describe any substantial timing or memory changes: N/A

Code reviewed by: cacraigucar, mwaxmonsky, nusbaume

List all existing files that have been modified, old files eliminated, new files added and describe the changes:

A .github/workflows/fleximod_test.yaml

derecho/intel/aux_cam: all tests pass
derecho/gnu/aux_cam:   all tests pass

Summarize any changes to answers, i.e.,

what code configurations: N/A
what platforms/compilers: N/A
nature of change (roundoff; larger than roundoff but same climate; new climate): N/A