### PR TITLE
Upgrade MPAS to version 8.2.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
         path          = src/dynamics/mpas/dycore
         url           = https://github.com/MPAS-Dev/MPAS-Model.git
         fxsparse      = ../.mpas_sparse_checkout
-        fxtag         = ed6f8e39ec0a811b6d079ca0fc6f9fb6e30bad23
+        fxtag         = v8.2.1
         fxrequired    = AlwaysRequired
         fxDONOTUSEurl = https://github.com/MPAS-Dev/MPAS-Model.git
 [submodule "ncar-physics"]

--- a/src/dynamics/mpas/Makefile.in.CESM
+++ b/src/dynamics/mpas/Makefile.in.CESM
@@ -125,7 +125,6 @@ $(LIBROOT)/libmpas.a: libmpas.a
 
 libmpas.a: $(AUTOCLEAN_DEPS) dycore externals frame ops subdrv
 	$(AR) $(ARFLAGS) < libmpas-archiver-script.txt
-	@find -P . -name "*.mod" -type f -exec $(LN) "{}" . ";"
 
 .PHONY: libmpas-clean
 libmpas-clean: clean
@@ -140,4 +139,5 @@ subdrv: driver/dyn_mpas_subdriver.o
 
 %.o: %.F90 dycore frame ops
 	( cd $(<D); $(FC) $(CPPFLAGS) $(FFLAGS) -c $(<F) $(CPPINCLUDES) $(FCINCLUDES) -I../framework -I../operators -I../core_$(CORE) -I../core_$(CORE)/dynamics )
-	$(LN) $(@) .
+	$(LN) $(*).mod .
+	$(LN) $(*).o .

--- a/src/dynamics/mpas/Makefile.in.CESM
+++ b/src/dynamics/mpas/Makefile.in.CESM
@@ -4,6 +4,15 @@ ifeq ($(strip $(LIBROOT)),)
     LIBROOT = ..
 endif
 
+ifeq ($(strip $(SRCROOT)),)
+    $(warning `SRCROOT` should not be empty. Defaulting to `..`)
+
+    SRCROOT = ..
+    MPAS_SRC_ROOT = $(SRCROOT)
+else
+    MPAS_SRC_ROOT = $(SRCROOT)/src/dynamics/mpas/dycore
+endif
+
 #
 # Define and export variables used by MPAS build infrastructure.
 #
@@ -19,7 +28,7 @@ export BUILD_TARGET    = N/A
 export CORE            = atmosphere
 export EXE_NAME        = atmosphere_model
 export GEN_F90         = false
-export GIT_VERSION     = N/A
+export GIT_VERSION     = $(shell git -C "$(MPAS_SRC_ROOT)" describe --always --dirty --tags || echo "N/A")
 export NAMELIST_SUFFIX = atmosphere
 
 # Customize variables (e.g., build options) for use with CESM.
@@ -57,9 +66,9 @@ all:
 	@echo 'Users are responsible to provide all necessary build options via environment variables or command line arguments.'
 	@echo ''
 	@echo 'Usage hints:'
-	@echo '    `make libmpas-prepare ESM="CESM" LIBROOT="..."`'
-	@echo '    `make libmpas-build ESM="CESM" LIBROOT="..."`'
-	@echo '    `make libmpas-clean ESM="CESM" LIBROOT="..."`'
+	@echo '    `make libmpas-prepare ESM="CESM" LIBROOT="..." SRCROOT="..."`'
+	@echo '    `make libmpas-build ESM="CESM" LIBROOT="..." SRCROOT="..."`'
+	@echo '    `make libmpas-clean ESM="CESM" LIBROOT="..." SRCROOT="..."`'
 
 .PHONY: libmpas-prepare
 libmpas-prepare: libmpas-archiver-script.txt libmpas-no-physics libmpas-prefix-namelist-groups libmpas-preview

--- a/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
@@ -10,7 +10,12 @@ module dyn_mpas_subdriver
     use, intrinsic :: iso_fortran_env, only: output_unit
 
     ! Modules from external libraries.
+#ifdef MPAS_USE_MPI_F08
+    use mpi_f08, only: mpi_comm_null, mpi_comm_rank, mpi_success, &
+                       mpi_comm_type => mpi_comm, operator(==), operator(/=)
+#else
     use mpi, only: mpi_comm_null, mpi_comm_rank, mpi_success
+#endif
     use pio, only: pio_char, pio_int, pio_real, pio_double, &
                    file_desc_t, iosystem_desc_t, pio_file_is_open, pio_iosystem_is_active, &
                    pio_inq_varid, pio_inq_varndims, pio_inq_vartype, pio_noerr
@@ -47,6 +52,7 @@ module dyn_mpas_subdriver
                                   mpas_pool_add_dimension, mpas_pool_get_dimension, &
                                   mpas_pool_get_field, mpas_pool_get_field_info, &
                                   mpas_pool_initialize_time_levels
+    use mpas_stream_inquiry, only: mpas_stream_inquiry_new_streaminfo
     use mpas_stream_manager, only: postread_reindex, prewrite_reindex, postwrite_reindex
     use mpas_string_utils, only: mpas_string_replace
     use mpas_timekeeping, only: mpas_get_clock_time, mpas_get_time
@@ -76,7 +82,11 @@ module dyn_mpas_subdriver
 
         ! Initialized by `dyn_mpas_init_phase1`.
         integer :: log_unit = output_unit
+#ifdef MPAS_USE_MPI_F08
+        type(mpi_comm_type) :: mpi_comm = mpi_comm_null
+#else
         integer :: mpi_comm = mpi_comm_null
+#endif
         integer :: mpi_rank = 0
         logical :: mpi_rank_root = .false.
 
@@ -447,7 +457,11 @@ contains
     !-------------------------------------------------------------------------------
     subroutine dyn_mpas_init_phase1(self, mpi_comm, model_error_impl, log_unit, mpas_log_unit)
         class(mpas_dynamical_core_type), intent(inout) :: self
+#ifdef MPAS_USE_MPI_F08
+        type(mpi_comm_type), intent(in) :: mpi_comm
+#else
         integer, intent(in) :: mpi_comm
+#endif
         procedure(model_error_if) :: model_error_impl
         integer, intent(in) :: log_unit
         integer, intent(in) :: mpas_log_unit(2)
@@ -503,7 +517,7 @@ contains
         call self % debug_print('Calling mpas_framework_init_phase1')
 
         ! Initialize MPAS framework with supplied MPI communicator group.
-        call mpas_framework_init_phase1(self % domain_ptr % dminfo, mpi_comm=self % mpi_comm)
+        call mpas_framework_init_phase1(self % domain_ptr % dminfo, external_comm=self % mpi_comm)
 
         call self % debug_print('Setting up core')
 
@@ -706,6 +720,15 @@ contains
         ! Initialize MPAS framework with supplied PIO system descriptor.
         call mpas_framework_init_phase2(self % domain_ptr, io_system=pio_iosystem)
 
+        ! Instantiate `streaminfo` but do not actually initialize it. Any queries made to it will always return `.false.`.
+        ! This is the intended behavior because MPAS as a dynamical core is not responsible for managing IO.
+        self % domain_ptr % streaminfo => mpas_stream_inquiry_new_streaminfo()
+
+        if (.not. associated(self % domain_ptr % streaminfo)) then
+            call self % model_error('Stream info instantiation failed for core ' // trim(self % domain_ptr % core % corename), &
+                subname, __LINE__)
+        end if
+
         ierr = self % domain_ptr % core % define_packages(self % domain_ptr % packages)
 
         if (ierr /= 0) then
@@ -714,7 +737,8 @@ contains
         end if
 
         ierr = self % domain_ptr % core % setup_packages( &
-            self % domain_ptr % configs, self % domain_ptr % packages, self % domain_ptr % iocontext)
+            self % domain_ptr % configs, self % domain_ptr % streaminfo, &
+            self % domain_ptr % packages, self % domain_ptr % iocontext)
 
         if (ierr /= 0) then
             call self % model_error('Package setup failed for core ' // trim(self % domain_ptr % core % corename), &

--- a/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
+++ b/src/dynamics/mpas/driver/dyn_mpas_subdriver.F90
@@ -12,7 +12,7 @@ module dyn_mpas_subdriver
     ! Modules from external libraries.
 #ifdef MPAS_USE_MPI_F08
     use mpi_f08, only: mpi_comm_null, mpi_comm_rank, mpi_success, &
-                       mpi_comm_type => mpi_comm, operator(==), operator(/=)
+                       mpi_comm_type => mpi_comm, operator(==)
 #else
     use mpi, only: mpi_comm_null, mpi_comm_rank, mpi_success
 #endif


### PR DESCRIPTION
Currently, CAM-SIMA uses MPAS at commit `ed6f8e39ec0a811b6d079ca0fc6f9fb6e30bad23`, which is half way between MPAS versions 8.0.1 and 8.1.0.

This PR upgrades MPAS to version 8.2.1, which was released on August 7, 2024.

* MPAS dynamical core and its subdriver in CAM-SIMA now support MPI Fortran 2008 interface through the `mpi_f08` module. It can be enabled by defining the `MPAS_USE_MPI_F08` macro in `CPPFLAGS`.
* The log file (e.g., `log.atmosphere.0000.out`) produced by MPAS dynamical core now correctly indicates its git version string. Before, it would always show "N/A" in the log, which is not very helpful. Now, if the git submodule of MPAS is aligned at a tag, it will just show the tag name (e.g., "v8.2.1"). Otherwise, if the git submodule of MPAS is not aligned at a tag, it will show the nearest tag name, the number of commits after that tag and the abbreviated commit hash (e.g., "v8.0.1-54-ged6f8e39e").
* Tidy up the build directory of MPAS dynamical core.