### PR TITLE
Bring in constituent tendency updater

### DIFF
--- a/src/data/write_init_files.py
+++ b/src/data/write_init_files.py
@@ -23,6 +23,7 @@ _EXCLUDED_STDNAMES = {'suite_name', 'suite_part',
                           'number_of_ccpp_constituents',
                           'number_of_ccpp_advected_constituents',
                           'ccpp_constituents',
+                          'ccpp_constituent_tendencies',
                           'ccpp_constituent_properties',
                           'ccpp_constituent_minimum_values',
                           'ccpp_error_message',
@@ -326,7 +327,7 @@ def gather_ccpp_req_vars(cap_database):
         for cvar in cap_database.call_list(phase).variable_list():
             stdname = cvar.get_prop_value('standard_name')
             intent = cvar.get_prop_value('intent')
-            is_const = cvar.get_prop_value('advected')
+            is_const = cvar.get_prop_value('advected') or cvar.get_prop_value('constituent')
             if ((intent in _INPUT_TYPES) and
                 (stdname not in req_vars) and
                 (stdname not in _EXCLUDED_STDNAMES)):


### PR DESCRIPTION
**DRAFT until we have (1) a new framework tag and (2) a new atmospheric_physics tag.**

Tag name (required for main):
Originator(s): peverwhee

Summary (include the keyword ['closes', 'fixes', 'resolves'] and issue number): Brings in and enables new apply_constituent_tendencies scheme.

Describe any changes made to build system: Exclude constituent tendencies from required variables (now handled by the CCPP Framework)

Describe any changes made to the namelist: None

List any changes to the defaults for the input datasets (e.g. boundary datasets): None

List all files eliminated and why: None

List all files added and what they do: None

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

M     src/data/write_init_files.py
- exclude constituent tendency variables (and array) from required variables list

If there are new failures (compare to the existing-test-failures.txt file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

CAM-SIMA date used for the baseline comparison tests if different than latest: