### PR TITLE
Read total energy using dycore formula from updated CAM snapshots; update standard names

### DIFF
--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -235,7 +235,7 @@
       <ic_file_input_names>te_cur_dyn state_te_cur_dyn</ic_file_input_names>
     </variable>
     <variable local_name="tw_ini"
-              standard_name="vertically_integrated_moist_air_and_condensed_water_of_initial_state"
+              standard_name="vertically_integrated_water_vapor_and_condensed_water_of_initial_state"
               units="kg m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -243,7 +243,7 @@
       <ic_file_input_names>tw_ini state_tw_ini</ic_file_input_names>
     </variable>
     <variable local_name="tw_cur"
-              standard_name="vertically_integrated_moist_air_and_condensed_water_of_current_state"
+              standard_name="vertically_integrated_water_vapor_and_condensed_water_of_current_state"
               units="kg m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -313,6 +313,12 @@
       <data>inverse_exner_function_wrt_surface_pressure</data>
       <data>frontogenesis_function</data>
       <data>frontogenesis_angle</data>
+      <data>vertically_integrated_total_energy_of_initial_state_using_physics_energy_formula</data>
+      <data>vertically_integrated_total_energy_of_current_state_using_physics_energy_formula</data>
+      <data>vertically_integrated_total_energy_of_initial_state_using_dycore_energy_formula</data>
+      <data>vertically_integrated_total_energy_of_current_state_using_dycore_energy_formula</data>
+      <data>vertically_integrated_water_vapor_and_condensed_water_of_initial_state</data>
+      <data>vertically_integrated_water_vapor_and_condensed_water_of_current_state</data>
     </ddt>
     <ddt type="physics_tend">
       <data>tendency_of_air_temperature_due_to_model_physics</data>

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -235,7 +235,7 @@
       <ic_file_input_names>te_cur_dyn state_te_cur_dyn</ic_file_input_names>
     </variable>
     <variable local_name="tw_ini"
-              standard_name="vertically_integrated_total_water_of_initial_state"
+              standard_name="vertically_integrated_moist_air_and_condensed_water_of_initial_state"
               units="kg m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">
@@ -243,7 +243,7 @@
       <ic_file_input_names>tw_ini state_tw_ini</ic_file_input_names>
     </variable>
     <variable local_name="tw_cur"
-              standard_name="vertically_integrated_total_water_of_current_state"
+              standard_name="vertically_integrated_moist_air_and_condensed_water_of_current_state"
               units="kg m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -202,21 +202,37 @@
       <dimensions>horizontal_dimension vertical_interface_dimension</dimensions>
       <ic_file_input_names>zi state_zi</ic_file_input_names>
     </variable>
-    <variable local_name="te_ini"
-              standard_name="vertically_integrated_energies_of_initial_state_in_cam"
+    <variable local_name="te_ini_phys"
+              standard_name="vertically_integrated_total_energy_of_initial_state_using_physics_energy_formula"
               units="J m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">
       <dimensions>horizontal_dimension</dimensions>
-      <ic_file_input_names>te_ini state_te_ini</ic_file_input_names>
+      <ic_file_input_names>te_ini_phys state_te_ini_phys</ic_file_input_names>
     </variable>
-    <variable local_name="te_cur"
-              standard_name="vertically_integrated_energies_of_current_state_in_cam"
+    <variable local_name="te_cur_phys"
+              standard_name="vertically_integrated_total_energy_of_current_state_using_physics_energy_formula"
               units="J m-2"
               type="real" kind="kind_phys"
               allocatable="pointer">
       <dimensions>horizontal_dimension</dimensions>
-      <ic_file_input_names>te_cur state_te_cur</ic_file_input_names>
+      <ic_file_input_names>te_cur_phys state_te_cur_phys</ic_file_input_names>
+    </variable>
+    <variable local_name="te_ini_dyn"
+              standard_name="vertically_integrated_total_energy_of_initial_state_using_dycore_energy_formula"
+              units="J m-2"
+              type="real" kind="kind_phys"
+              allocatable="pointer">
+      <dimensions>horizontal_dimension</dimensions>
+      <ic_file_input_names>te_ini_dyn state_te_ini_dyn</ic_file_input_names>
+    </variable>
+    <variable local_name="te_cur_dyn"
+              standard_name="vertically_integrated_total_energy_of_current_state_using_dycore_energy_formula"
+              units="J m-2"
+              type="real" kind="kind_phys"
+              allocatable="pointer">
+      <dimensions>horizontal_dimension</dimensions>
+      <ic_file_input_names>te_cur_dyn state_te_cur_dyn</ic_file_input_names>
     </variable>
     <variable local_name="tw_ini"
               standard_name="vertically_integrated_total_water_of_initial_state"

--- a/tools/stdnames_to_inputnames_dictionary.xml
+++ b/tools/stdnames_to_inputnames_dictionary.xml
@@ -184,13 +184,13 @@
       <ic_file_input_name>state_te_cur_dyn</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="vertically_integrated_moist_air_and_condensed_water_of_initial_state">
+  <entry stdname="vertically_integrated_water_vapor_and_condensed_water_of_initial_state">
     <ic_file_input_names>
       <ic_file_input_name>tw_ini</ic_file_input_name>
       <ic_file_input_name>state_tw_ini</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="vertically_integrated_moist_air_and_condensed_water_of_current_state">
+  <entry stdname="vertically_integrated_water_vapor_and_condensed_water_of_current_state">
     <ic_file_input_names>
       <ic_file_input_name>tw_cur</ic_file_input_name>
       <ic_file_input_name>state_tw_cur</ic_file_input_name>

--- a/tools/stdnames_to_inputnames_dictionary.xml
+++ b/tools/stdnames_to_inputnames_dictionary.xml
@@ -160,16 +160,28 @@
       <ic_file_input_name>state_zi</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="vertically_integrated_energies_of_initial_state_in_cam">
+  <entry stdname="vertically_integrated_total_energy_of_initial_state_using_physics_energy_formula">
     <ic_file_input_names>
-      <ic_file_input_name>te_ini</ic_file_input_name>
-      <ic_file_input_name>state_te_ini</ic_file_input_name>
+      <ic_file_input_name>te_ini_phys</ic_file_input_name>
+      <ic_file_input_name>state_te_ini_phys</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="vertically_integrated_energies_of_current_state_in_cam">
+  <entry stdname="vertically_integrated_total_energy_of_current_state_using_physics_energy_formula">
     <ic_file_input_names>
-      <ic_file_input_name>te_cur</ic_file_input_name>
-      <ic_file_input_name>state_te_cur</ic_file_input_name>
+      <ic_file_input_name>te_cur_phys</ic_file_input_name>
+      <ic_file_input_name>state_te_cur_phys</ic_file_input_name>
+    </ic_file_input_names>
+  </entry>
+  <entry stdname="vertically_integrated_total_energy_of_initial_state_using_dycore_energy_formula">
+    <ic_file_input_names>
+      <ic_file_input_name>te_ini_dyn</ic_file_input_name>
+      <ic_file_input_name>state_te_ini_dyn</ic_file_input_name>
+    </ic_file_input_names>
+  </entry>
+  <entry stdname="vertically_integrated_total_energy_of_current_state_using_dycore_energy_formula">
+    <ic_file_input_names>
+      <ic_file_input_name>te_cur_dyn</ic_file_input_name>
+      <ic_file_input_name>state_te_cur_dyn</ic_file_input_name>
     </ic_file_input_names>
   </entry>
   <entry stdname="vertically_integrated_total_water_of_initial_state">

--- a/tools/stdnames_to_inputnames_dictionary.xml
+++ b/tools/stdnames_to_inputnames_dictionary.xml
@@ -184,13 +184,13 @@
       <ic_file_input_name>state_te_cur_dyn</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="vertically_integrated_total_water_of_initial_state">
+  <entry stdname="vertically_integrated_moist_air_and_condensed_water_of_initial_state">
     <ic_file_input_names>
       <ic_file_input_name>tw_ini</ic_file_input_name>
       <ic_file_input_name>state_tw_ini</ic_file_input_name>
     </ic_file_input_names>
   </entry>
-  <entry stdname="vertically_integrated_total_water_of_current_state">
+  <entry stdname="vertically_integrated_moist_air_and_condensed_water_of_current_state">
     <ic_file_input_names>
       <ic_file_input_name>tw_cur</ic_file_input_name>
       <ic_file_input_name>state_tw_cur</ic_file_input_name>


### PR DESCRIPTION
Companion issue in CAM: https://github.com/ESCOMP/CAM/issues/1141

Companion PR in CAM: https://github.com/ESCOMP/CAM/pull/1142
this PR in CAM will update snapshots with new variables.

Updates to CAM-SIMA:
- read ncdata variables te_ini_phys, te_ini_dyn, te_cur_phys, te_cur_dyn
- update to standard names per discussion in https://github.com/ESCOMP/CAM/issues/1141