### PR TITLE
Implement constituents infrastructure in analytic IC routines

### DIFF
--- a/src/control/cam_comp.F90
+++ b/src/control/cam_comp.F90
@@ -16,7 +16,7 @@ module cam_comp
 
    use spmd_utils,                only: masterproc, mpicom
    use cam_control_mod,           only: cam_ctrl_init, cam_ctrl_set_orbit
-   use cam_physics_control,       only: cam_ctrl_set_physics_type
+   use cam_control_mod,           only: cam_ctrl_set_physics_type
    use cam_control_mod,           only: caseid, ctitle
    use runtime_opts,              only: read_namelist
    use runtime_obj,               only: cam_runtime_opts
@@ -25,7 +25,8 @@ module cam_comp
    use time_manager,              only: is_first_step, is_first_restart_step
 
    use camsrfexch,                only: cam_out_t, cam_in_t
-   use physics_types,             only: phys_state, phys_tend, dtime_phys
+   use physics_types,             only: phys_state, phys_tend
+   use physics_types,             only: dtime_phys
    use dyn_comp,                  only: dyn_import_t, dyn_export_t
 
    use perf_mod,                  only: t_barrierf, t_startf, t_stopf
@@ -58,6 +59,7 @@ module cam_comp
    ! Private interface (here to avoid circular dependency)
    private :: cam_register_constituents
 
+
 !-----------------------------------------------------------------------
 CONTAINS
 !-----------------------------------------------------------------------
@@ -85,7 +87,7 @@ CONTAINS
       use dyn_comp,             only: dyn_init
 !      use cam_restart,          only: cam_read_restart
       use camsrfexch,           only: hub2atm_alloc, atm2hub_alloc
-      use cam_history,          only: history_init_files
+!      use cam_history,          only: hist_init_files
 !      use history_scam,         only: scm_intht
       use cam_pio_utils,        only: init_pio_subsystem
       use cam_instance,         only: inst_suffix
@@ -233,7 +235,9 @@ CONTAINS
       ! if (single_column) then
       !    call scm_intht()
       ! end if
-      call history_init_files(model_doi_url, caseid, ctitle)
+!!XXgoldyXX: v need to import this
+!      call hist_init_files(model_doi_url, caseid, ctitle)
+!!XXgoldyXX: ^ need to import this
 
    end subroutine cam_init
 
@@ -392,8 +396,10 @@ CONTAINS
       !           file output.
       !
       !-----------------------------------------------------------------------
+!      use cam_history,  only: wshist, wrapup
 !      use cam_restart,  only: cam_write_restart
 !      use qneg_module,  only: qneg_print_summary
+      use time_manager, only: is_last_step
 
       type(cam_out_t), intent(inout)        :: cam_out  ! Output from CAM to surface
       type(cam_in_t),  intent(inout)        :: cam_in   ! Input from surface to CAM
@@ -403,6 +409,18 @@ CONTAINS
       integer,         intent(in), optional :: mon_spec ! Simulation month
       integer,         intent(in), optional :: day_spec ! Simulation day
       integer,         intent(in), optional :: sec_spec ! Secs in current simulation day
+
+      !----------------------------------------------------------
+      ! History and restart logic: Write and/or dispose history
+      !                            tapes if required
+      !----------------------------------------------------------
+      !
+!!XXgoldyXX: v need to import this
+!      call t_barrierf('sync_wshist', mpicom)
+!      call t_startf('wshist')
+!      call wshist()
+!      call t_stopf('wshist')
+!!XXgoldyXX: ^ need to import this
 
       !
       ! Write restart files
@@ -423,39 +441,37 @@ CONTAINS
          call t_stopf('cam_write_restart')
       end if
 
+!!XXgoldyXX: v need to import this
+!      call t_startf ('cam_run4_wrapup')
+!      call wrapup(rstwr, nlend)
+!      call t_stopf  ('cam_run4_wrapup')
+!!XXgoldyXX: ^ need to import this
+
+      call shr_sys_flush(iulog)
+
    end subroutine cam_run4
 
    !
    !-----------------------------------------------------------------------
    !
-   subroutine cam_timestep_final(rstwr, nlend, do_ncdata_check)
+   subroutine cam_timestep_final(do_ncdata_check)
       !-----------------------------------------------------------------------
       !
       ! Purpose:   Timestep final runs at the end of each timestep
       !
       !-----------------------------------------------------------------------
 
-      use phys_comp,    only: phys_timestep_final
-      use cam_history,  only: history_write_files
-      use cam_history,  only: history_wrap_up
-      logical, intent(in)  :: rstwr    ! write restart file
-      logical, intent(in)  :: nlend    ! this is final timestep
-      !Flag for whether a snapshot (ncdata) check should be run or not
-      ! - flag is true if this is not the first or last step
-      logical, intent(in)  :: do_ncdata_check
+      use phys_comp, only: phys_timestep_final
 
-      if (do_ncdata_check .or. get_nstep() == 0) then
-         call history_write_files()
-         ! peverwhee - todo: handle restarts
-         call history_wrap_up(rstwr, nlend)
-      end if
+      !Flag for whether a snapshot (ncdata) check should be run or not
+      logical, intent(in) :: do_ncdata_check
+
       !
       !----------------------------------------------------------
       ! PHYS_TIMESTEP_FINAL Call the Physics package
       !----------------------------------------------------------
       !
       call phys_timestep_final(do_ncdata_check)
-      call shr_sys_flush(iulog)
 
    end subroutine cam_timestep_final
 
@@ -526,6 +542,7 @@ CONTAINS
       ! physics suite being invoked during this run.
       use cam_abortutils,            only: endrun, check_allocate
       use runtime_obj,               only: runtime_options
+      use runtime_obj,               only: wv_stdname
       use phys_comp,                 only: phys_suite_name
       use cam_constituents,          only: cam_constituents_init
       use cam_constituents,          only: const_set_qmin, const_get_index
@@ -535,7 +552,6 @@ CONTAINS
       use cam_ccpp_cap,              only: cam_ccpp_number_constituents
       use cam_ccpp_cap,              only: cam_model_const_properties
       use cam_ccpp_cap,              only: cam_ccpp_is_scheme_constituent
-      use runtime_obj,               only: wv_stdname
 
       ! Dummy arguments
       type(runtime_options), intent(in) :: cam_runtime_opts
@@ -546,7 +562,6 @@ CONTAINS
       integer                                        :: errflg
       character(len=512)                             :: errmsg
       type(ccpp_constituent_prop_ptr_t), pointer     :: const_props(:)
-      type(ccpp_constituent_properties_t), allocatable, target :: dynamic_constituents(:)
       character(len=*), parameter :: subname = 'cam_register_constituents: '
 
       ! Initalize error flag and message:

--- a/src/control/cam_comp.F90
+++ b/src/control/cam_comp.F90
@@ -16,7 +16,7 @@ module cam_comp
 
    use spmd_utils,                only: masterproc, mpicom
    use cam_control_mod,           only: cam_ctrl_init, cam_ctrl_set_orbit
-   use cam_control_mod,           only: cam_ctrl_set_physics_type
+   use cam_physics_control,       only: cam_ctrl_set_physics_type
    use cam_control_mod,           only: caseid, ctitle
    use runtime_opts,              only: read_namelist
    use runtime_obj,               only: cam_runtime_opts
@@ -25,8 +25,7 @@ module cam_comp
    use time_manager,              only: is_first_step, is_first_restart_step
 
    use camsrfexch,                only: cam_out_t, cam_in_t
-   use physics_types,             only: phys_state, phys_tend
-   use physics_types,             only: dtime_phys
+   use physics_types,             only: phys_state, phys_tend, dtime_phys
    use dyn_comp,                  only: dyn_import_t, dyn_export_t
 
    use perf_mod,                  only: t_barrierf, t_startf, t_stopf
@@ -59,7 +58,6 @@ module cam_comp
    ! Private interface (here to avoid circular dependency)
    private :: cam_register_constituents
 
-
 !-----------------------------------------------------------------------
 CONTAINS
 !-----------------------------------------------------------------------
@@ -87,7 +85,7 @@ CONTAINS
       use dyn_comp,             only: dyn_init
 !      use cam_restart,          only: cam_read_restart
       use camsrfexch,           only: hub2atm_alloc, atm2hub_alloc
-!      use cam_history,          only: hist_init_files
+      use cam_history,          only: history_init_files
 !      use history_scam,         only: scm_intht
       use cam_pio_utils,        only: init_pio_subsystem
       use cam_instance,         only: inst_suffix
@@ -235,9 +233,7 @@ CONTAINS
       ! if (single_column) then
       !    call scm_intht()
       ! end if
-!!XXgoldyXX: v need to import this
-!      call hist_init_files(model_doi_url, caseid, ctitle)
-!!XXgoldyXX: ^ need to import this
+      call history_init_files(model_doi_url, caseid, ctitle)
 
    end subroutine cam_init
 
@@ -396,10 +392,8 @@ CONTAINS
       !           file output.
       !
       !-----------------------------------------------------------------------
-!      use cam_history,  only: wshist, wrapup
 !      use cam_restart,  only: cam_write_restart
 !      use qneg_module,  only: qneg_print_summary
-      use time_manager, only: is_last_step
 
       type(cam_out_t), intent(inout)        :: cam_out  ! Output from CAM to surface
       type(cam_in_t),  intent(inout)        :: cam_in   ! Input from surface to CAM
@@ -409,18 +403,6 @@ CONTAINS
       integer,         intent(in), optional :: mon_spec ! Simulation month
       integer,         intent(in), optional :: day_spec ! Simulation day
       integer,         intent(in), optional :: sec_spec ! Secs in current simulation day
-
-      !----------------------------------------------------------
-      ! History and restart logic: Write and/or dispose history
-      !                            tapes if required
-      !----------------------------------------------------------
-      !
-!!XXgoldyXX: v need to import this
-!      call t_barrierf('sync_wshist', mpicom)
-!      call t_startf('wshist')
-!      call wshist()
-!      call t_stopf('wshist')
-!!XXgoldyXX: ^ need to import this
 
       !
       ! Write restart files
@@ -441,37 +423,39 @@ CONTAINS
          call t_stopf('cam_write_restart')
       end if
 
-!!XXgoldyXX: v need to import this
-!      call t_startf ('cam_run4_wrapup')
-!      call wrapup(rstwr, nlend)
-!      call t_stopf  ('cam_run4_wrapup')
-!!XXgoldyXX: ^ need to import this
-
-      call shr_sys_flush(iulog)
-
    end subroutine cam_run4
 
    !
    !-----------------------------------------------------------------------
    !
-   subroutine cam_timestep_final(do_ncdata_check)
+   subroutine cam_timestep_final(rstwr, nlend, do_ncdata_check)
       !-----------------------------------------------------------------------
       !
       ! Purpose:   Timestep final runs at the end of each timestep
       !
       !-----------------------------------------------------------------------
 
-      use phys_comp, only: phys_timestep_final
-
+      use phys_comp,    only: phys_timestep_final
+      use cam_history,  only: history_write_files
+      use cam_history,  only: history_wrap_up
+      logical, intent(in)  :: rstwr    ! write restart file
+      logical, intent(in)  :: nlend    ! this is final timestep
       !Flag for whether a snapshot (ncdata) check should be run or not
-      logical, intent(in) :: do_ncdata_check
+      ! - flag is true if this is not the first or last step
+      logical, intent(in)  :: do_ncdata_check
 
+      if (do_ncdata_check .or. get_nstep() == 0) then
+         call history_write_files()
+         ! peverwhee - todo: handle restarts
+         call history_wrap_up(rstwr, nlend)
+      end if
       !
       !----------------------------------------------------------
       ! PHYS_TIMESTEP_FINAL Call the Physics package
       !----------------------------------------------------------
       !
       call phys_timestep_final(do_ncdata_check)
+      call shr_sys_flush(iulog)
 
    end subroutine cam_timestep_final
 
@@ -551,6 +535,7 @@ CONTAINS
       use cam_ccpp_cap,              only: cam_ccpp_number_constituents
       use cam_ccpp_cap,              only: cam_model_const_properties
       use cam_ccpp_cap,              only: cam_ccpp_is_scheme_constituent
+      use runtime_obj,               only: wv_stdname
 
       ! Dummy arguments
       type(runtime_options), intent(in) :: cam_runtime_opts
@@ -561,6 +546,7 @@ CONTAINS
       integer                                        :: errflg
       character(len=512)                             :: errmsg
       type(ccpp_constituent_prop_ptr_t), pointer     :: const_props(:)
+      type(ccpp_constituent_properties_t), allocatable, target :: dynamic_constituents(:)
       character(len=*), parameter :: subname = 'cam_register_constituents: '
 
       ! Initalize error flag and message:
@@ -569,9 +555,7 @@ CONTAINS
 
       ! Check if water vapor is already marked as a constituent by the
       ! physics:
-      call cam_ccpp_is_scheme_constituent(                                              &
-           "water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water",                &
-           is_constituent, errflg, errmsg)
+      call cam_ccpp_is_scheme_constituent(wv_stdname, is_constituent, errflg, errmsg)
 
       if (errflg /= 0) then
          call endrun(subname//trim(errmsg), file=__FILE__, line=__LINE__)
@@ -589,7 +573,7 @@ CONTAINS
 
          ! Register the constituents so they can be advected:
          call host_constituents(1)%instantiate( &
-              std_name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water",    &
+              std_name=wv_stdname,              &
               long_name="water vapor mixing ratio w.r.t moist air and condensed_water", &
               units="kg kg-1",                                                          &
               default_value=0._kind_phys,                                               &
@@ -639,8 +623,7 @@ CONTAINS
       if (phys_suite_name /= 'held_suarez_1994') then !Held-Suarez is "dry" physics
 
          ! Get constituent index for water vapor:
-         call const_get_index("water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water", &
-                              const_idx)
+         call const_get_index(wv_stdname, const_idx)
 
          ! Set new minimum value:
          call const_set_qmin(const_idx, 1.E-12_kind_phys)

--- a/src/control/runtime_obj.F90
+++ b/src/control/runtime_obj.F90
@@ -9,6 +9,9 @@ module runtime_obj
    integer,          public, parameter :: unset_int    = huge(1)
    real(r8),         public, parameter :: unset_real   = huge(1.0_r8)
 
+   ! Water vapor constituent standard name
+   character(len=*), public, parameter :: wv_stdname = 'water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water'
+
    ! Public interfaces and data
 
    !> \section arg_table_runtime_options  Argument Table

--- a/src/data/air_composition.F90
+++ b/src/data/air_composition.F90
@@ -130,8 +130,10 @@ CONTAINS
       use cam_logfile,          only: iulog
       use physconst,            only: r_universal, cpwv
       use physconst,            only: rh2o, cpliq, cpice
+      use physconst,            only: cpair, rair
       use physics_grid,         only: pcols => columns_on_task
       use vert_coord,           only: pver
+      use runtime_obj,          only: wv_stdname
       use cam_constituents,     only: const_name, num_advected
       use cam_constituents,     only: const_set_thermo_active
       use cam_constituents,     only: const_set_water_species
@@ -305,9 +307,8 @@ CONTAINS
             !
             ! Q
             !
-         case('water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water')
-            call air_species_info('water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water', &
-                                  ix, mw)
+         case(wv_stdname) !water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+            call air_species_info(wv_stdname, ix, mw)
             thermodynamic_active_species_idx(icnst) = ix
             thermodynamic_active_species_cp (icnst) = cpwv
             thermodynamic_active_species_cv (icnst) = cv3 / mw
@@ -454,6 +455,15 @@ CONTAINS
          has_liq = .false.
          has_ice = .false.
       end do
+
+      !Set dry air thermodynamic properities if no dry air species provided:
+      if (dry_species_num == 0) then
+        !Note:  The zeroeth index is used to represent all of dry
+        !       instead of just N2 in this configuration
+        thermodynamic_active_species_cp(0) = cpair
+        thermodynamic_active_species_cv(0) = cpair - rair
+        thermodynamic_active_species_R(0)  = rair
+      end if
 
       water_species_in_air_num = water_species_num
       dry_air_species_num = dry_species_num

--- a/src/data/air_composition.F90
+++ b/src/data/air_composition.F90
@@ -459,7 +459,7 @@ CONTAINS
       !Set dry air thermodynamic properities if no dry air species provided:
       if (dry_species_num == 0) then
         !Note:  The zeroeth index is used to represent all of dry
-        !       instead of just N2 in this configuration
+        !       air instead of just N2 in this configuration
         thermodynamic_active_species_cp(0) = cpair
         thermodynamic_active_species_cv(0) = cpair - rair
         thermodynamic_active_species_R(0)  = rair

--- a/src/dynamics/se/dycore/prim_state_mod.F90
+++ b/src/dynamics/se/dycore/prim_state_mod.F90
@@ -418,11 +418,11 @@ CONTAINS
     use cam_abortutils,         only: endrun
     use control_mod,    only: nu_top
     !
-    type (element_t),             intent(inout) :: elem(:)    
+    type (element_t),             intent(inout) :: elem(:)
     type (TimeLevel_t), target,   intent(in)    :: tl
     type (hybrid_t),              intent(in)    :: hybrid
     integer,                      intent(in)    :: nets,nete
-    type(fvm_struct),             intent(inout) :: fvm(:)        
+    type(fvm_struct),             intent(inout) :: fvm(:)
     real (kind=r8),               intent(in)    :: omega_cn(2,nets:nete)
     ! Local variables...
     integer            :: k,ie
@@ -457,7 +457,7 @@ CONTAINS
        nsplit=2*nsplit_baseline
        fvm_supercycling     = rsplit
        fvm_supercycling_jet = rsplit
-       nu_top=2.0_r8*nu_top       
+       nu_top=2.0_r8*nu_top
       !
       ! write diagnostics to log file
       !
@@ -470,7 +470,7 @@ CONTAINS
        end if
        dtime = get_step_size()
        tstep = dtime / real(nsplit*qsplit*rsplit, r8)
-       
+
     else if (nsplit.ne.nsplit_baseline.and.max_o(1)<0.4_r8*threshold) then
       !
       ! should nsplit be reduced again?
@@ -480,9 +480,9 @@ CONTAINS
        fvm_supercycling     = rsplit
        fvm_supercycling_jet = rsplit
        nu_top=nu_top/2.0_r8
-       
+
 !       nu_div_scale_top(:) = 1.0_r8
-       
+
        dtime = get_step_size()
        tstep = dtime / real(nsplit*qsplit*rsplit, r8)
        if(hybrid%masterthread) then

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -9,8 +9,7 @@ use cam_constituents,       only: const_name, const_longname, num_advected
 use cam_constituents,       only: const_get_index, const_is_wet, const_qmin
 use cam_constituents,       only: readtrace
 use air_composition,        only: const_is_water_species
-use cam_control_mod,        only: initial_run
-use cam_physics_control,    only: simple_phys
+use cam_control_mod,        only: initial_run, simple_phys
 use cam_initfiles,          only: initial_file_get_id, topo_file_get_id, pertlim
 use dyn_grid,               only: ini_grid_name, timelevel, hvcoord, edgebuf
 

--- a/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
+++ b/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
@@ -50,10 +50,13 @@ contains
 
   subroutine bc_dry_jw06_set_ic(vcoord, latvals, lonvals, U, V, T, PS, PHIS, &
                                 Q, m_cnst, mask, verbose)
-    use dyn_tests_utils,  only: vc_moist_pressure, vc_dry_pressure, vc_height
-    use cam_constituents, only: const_get_index
-    !use constituents,    only: cnst_name
-    !use const_init,      only: cnst_init_default
+    use shr_kind_mod,              only: cx => shr_kind_cx
+    use dyn_tests_utils,           only: vc_moist_pressure, vc_dry_pressure, vc_height
+    use runtime_obj,               only: wv_stdname
+    use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
+    use cam_ccpp_cap,              only: cam_model_const_properties
+    use ccpp_kinds,                only: kind_phys
+    use cam_constituents,          only: const_get_index, const_qmin
 
     !-----------------------------------------------------------------------
     !
@@ -79,13 +82,15 @@ contains
     logical, allocatable              :: mask_use(:)
     logical                           :: verbose_use
     logical                           :: lu,lv,lt,lq,l3d_vars
+    logical                           :: const_has_default
     integer                           :: i, k, m
     integer                           :: ncol
     integer                           :: nlev
     integer                           :: ncnst
     integer                           :: iret
-    integer                           :: ix_rain, ix_cld_liq
+    integer                           :: ix_q, m_cnst_ix_q
     character(len=*), parameter       :: subname = 'BC_DRY_JW06_SET_IC'
+    character(len=cx)                 :: errmsg !CCPP error message
     real(r8)                          :: tmp
     real(r8)                          :: r(size(latvals))
     real(r8)                          :: eta
@@ -93,9 +98,15 @@ contains
     real(r8)                          :: perturb_lon, perturb_lat
     real(r8)                          :: phi_vertical
     real(r8)                          :: u_wind(size(latvals))
+    real(kind_phys)                   :: const_default_value !Constituent default value
+    real(kind_phys)                   :: const_qmin_value    !Constituent minimum value
 
-       a_omega                = rearth*omega
-       exponent               = rair*gamma/gravit
+    !Private array of constituent properties (for property interface functions)
+    type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
+
+    !Set local constants:
+    a_omega                = rearth*omega
+    exponent               = rair*gamma/gravit
 
     allocate(mask_use(size(latvals)), stat=iret)
     call check_allocate(iret, subname, 'mask_use(size(latvals))', &
@@ -115,10 +126,6 @@ contains
     else
       verbose_use = .true.
     end if
-
-    !set constituent indices
-    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water', ix_cld_liq)
-    call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', ix_rain)
 
     ncol = size(latvals, 1)
     nlev = -1
@@ -236,40 +243,63 @@ contains
         end if
       end if
       if (lq) then
+         !Get water vapor constituent index:
+         call const_get_index(wv_stdname, ix_q)
+
+         !Determine which "Q" variable index matches water vapor:
+         m_cnst_ix_q = findloc(m_cnst, ix_q, dim=1)
+
         do k = 1, nlev
           where(mask_use)
-            Q(:,k,1) = 0.0_r8
+            Q(:,k,m_cnst_ix_q) = 0.0_r8
           end where
         end do
-!Un-comment once constituents are working in CAMDEN -JN:
-#if 0
         if(masterproc.and. verbose_use) then
-          write(iulog,*) '         ', trim(cnst_name(m_cnst(1))), ' initialized by "',subname,'"'
+          write(iulog,*) '         ', wv_stdname, ' initialized by "',subname,'"'
         end if
-#endif
       end if
     end if
 
-!Un-comment once constituents are working in CAMDEN -JN:
-#if 0
     if (lq) then
-      ncnst = size(m_cnst, 1)
+      ncnst = size(m_cnst)
       if ((vcoord == vc_moist_pressure) .or. (vcoord == vc_dry_pressure)) then
-        do m = 2, ncnst
-          call cnst_init_default(m_cnst(m), latvals, lonvals, Q(:,:,m_cnst(m)),&
-               mask=mask_use, verbose=verbose_use, notfound=.false.)
-        end do
-      end if
-    end if
-#else
-    if (lq) then
-      if ((vcoord == vc_moist_pressure) .or. (vcoord == vc_dry_pressure)) then
-        !Initialize cloud liquid and rain until constituent routines are enabled:
-        Q(:,:,ix_cld_liq) = 0.0_r8
-        Q(:,:,ix_rain)    = 0.0_r8
-      end if
-    end if
-#endif
+        do m = 1, ncnst
+
+          !Skip water vapor, as it was aleady set above:
+          if (m == m_cnst_ix_q) cycle
+
+          !Extract constituent minimum value:
+          const_qmin_value = const_qmin(m_cnst(m))
+
+          !Initialize constituent to its minimum value:
+          Q(:,:,m) = real(const_qmin_value, r8)
+
+          if (iret /= 0) then
+            call endrun(errmsg, file=__FILE__, line=__LINE__)
+          end if
+
+          if (const_has_default) then
+
+            !If default value exists, then extract default value
+            !from constituent properties object:
+            call const_props(m_cnst(m))%default_value(const_default_value, &
+                                                      iret,        &
+                                                      errmsg)
+            if (iret /= 0) then
+              call endrun(errmsg, file=__FILE__, line=__LINE__)
+            end if
+
+            !Set constituent to default value in masked region:
+            do k=1,nlev
+              where(mask_use)
+                Q(:,k,m) = real(const_default_value, r8)
+              end where
+            end do
+
+          end if !has_default
+        end do   !m_cnst
+      end if     !lq
+    end if       !l3d_vars
 
     deallocate(mask_use)
 

--- a/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
+++ b/src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
@@ -243,11 +243,11 @@ contains
         end if
       end if
       if (lq) then
-         !Get water vapor constituent index:
-         call const_get_index(wv_stdname, ix_q)
+        !Get water vapor constituent index:
+        call const_get_index(wv_stdname, ix_q)
 
-         !Determine which "Q" variable index matches water vapor:
-         m_cnst_ix_q = findloc(m_cnst, ix_q, dim=1)
+        !Determine which "Q" variable index matches water vapor:
+        m_cnst_ix_q = findloc(m_cnst, ix_q, dim=1)
 
         do k = 1, nlev
           where(mask_use)
@@ -261,7 +261,12 @@ contains
     end if
 
     if (lq) then
+      !Determine total number of constituents:
       ncnst = size(m_cnst)
+
+      !Extract constituent properties from CCPP constituents object:
+      const_props => cam_model_const_properties()
+
       if ((vcoord == vc_moist_pressure) .or. (vcoord == vc_dry_pressure)) then
         do m = 1, ncnst
 
@@ -274,6 +279,10 @@ contains
           !Initialize constituent to its minimum value:
           Q(:,:,m) = real(const_qmin_value, r8)
 
+          !Check for default value in constituent properties object:
+          call const_props(m_cnst(m))%has_default(const_has_default, &
+                                                  iret,      &
+                                                  errmsg)
           if (iret /= 0) then
             call endrun(errmsg, file=__FILE__, line=__LINE__)
           end if
@@ -298,8 +307,8 @@ contains
 
           end if !has_default
         end do   !m_cnst
-      end if     !lq
-    end if       !l3d_vars
+      end if     !vcoord
+    end if       !lq
 
     deallocate(mask_use)
 

--- a/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
+++ b/src/dynamics/tests/initial_conditions/ic_held_suarez.F90
@@ -24,8 +24,12 @@ CONTAINS
 
   subroutine hs94_set_ic(latvals, lonvals, U, V, T, PS, PHIS,           &
        Q, m_cnst, mask, verbose)
-    !use const_init,    only: cnst_init_default
-    use cam_constituents, only: const_get_index
+    use shr_kind_mod,              only: cx => shr_kind_cx
+    use ccpp_kinds,                only: kind_phys
+    use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
+    use cam_ccpp_cap,              only: cam_model_const_properties
+    use cam_constituents,          only: const_get_index, const_qmin
+    use runtime_obj,               only: wv_stdname
 
     !-----------------------------------------------------------------------
     !
@@ -49,13 +53,20 @@ CONTAINS
     ! Local variables
     logical, allocatable              :: mask_use(:)
     logical                           :: verbose_use
+    logical                           :: const_has_default
     integer                           :: i, k, m
-    integer                           :: ix_cld_liq, ix_rain
+    integer                           :: ix_q
     integer                           :: ncol
     integer                           :: nlev
     integer                           :: ncnst
     integer                           :: iret
+    real(kind_phys)                   :: const_default_value !Constituent default value
+    real(kind_phys)                   :: const_qmin_value    !Constituent minimum value
+    character(len=cx)                 :: errmsg              !CCPP error message
     character(len=*), parameter       :: subname = 'HS94_SET_IC'
+
+    !Private array of constituent properties (for property interface functions)
+    type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
 
     allocate(mask_use(size(latvals)), stat=iret)
     call check_allocate(iret, subname, 'mask_use(size(latvals))', &
@@ -75,12 +86,6 @@ CONTAINS
     else
       verbose_use = .true.
     end if
-
-    !set constituent indices
-    call const_get_index('cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water', &
-                         ix_cld_liq, abort=.false.)
-    call const_get_index('rain_mixing_ratio_wrt_moist_air_and_condensed_water', &
-                         ix_rain, abort=.false.)
 
     ncol = size(latvals, 1)
     nlev = -1
@@ -137,32 +142,65 @@ CONTAINS
     end if
 
     if (present(Q)) then
+      !Get water vapor constituent index:
+      call const_get_index(wv_stdname, ix_q)
+
+      !Get constituent properties object:
+      const_props => cam_model_const_properties()
+
+      !Determine array sizes:
       nlev = size(Q, 2)
       ncnst = size(m_cnst, 1)
+
+      !Loop over all constituents:
       do m = 1, ncnst
-        if (m_cnst(m) == 1) then
+        if (m_cnst(m) == ix_q) then
           ! No water vapor in Held-Suarez
           do k = 1, nlev
             where(mask_use)
-              Q(:,k,m_cnst(m)) = 0.0_r8
+              Q(:,k,m) = 0.0_r8
             end where
           end do
-!Un-comment once constituents are working in CAMDEN -JN:
-#if 0
+
           if(masterproc .and. verbose_use) then
-            write(iulog,*) '          ', trim(cnst_name(m_cnst(m))), ' initialized by "',subname,'"'
+            write(iulog,*) '          ', wv_stdname, ' initialized by "',subname,'"'
           end if
 
         else
-          call cnst_init_default(m_cnst(m), latvals, lonvals, Q(:,:,m_cnst(m)),&
-               mask=mask_use, verbose=verbose_use, notfound=.false.)
-#else
-        else
-          !Initialize cloud liquid and rain until constituent routines are enabled:
-          Q(:,:,ix_cld_liq) = 0.0_r8
-          Q(:,:,ix_rain)    = 0.0_r8
-#endif
-        end if
+          !Extract constituent minimum value:
+          const_qmin_value = const_qmin(m_cnst(m))
+
+          !Initialize constituent to its minimum value:
+          Q(:,:,m) = real(const_qmin_value, r8)
+
+          !Check for default value in constituent properties object:
+          call const_props(m_cnst(m))%has_default(const_has_default, &
+                                                iret,      &
+                                                errmsg)
+          if (iret /= 0) then
+            call endrun(errmsg, file=__FILE__, line=__LINE__)
+          end if
+
+          if (const_has_default) then
+
+            !If default value exists, then extract default value
+            !from constituent properties object:
+            call const_props(m_cnst(m))%default_value(const_default_value, &
+                                                      iret,        &
+                                                      errmsg)
+            if (iret /= 0) then
+              call endrun(errmsg, file=__FILE__, line=__LINE__)
+            end if
+
+            !Set constituent to default value in masked region:
+            do k=1,nlev
+              where(mask_use)
+                Q(:,k,m) = real(const_default_value, r8)
+              end where
+            end do
+
+          end if !has_default
+        end if !water vapor
       end do
     end if
 

--- a/src/dynamics/tests/initial_conditions/ic_us_standard_atm.F90
+++ b/src/dynamics/tests/initial_conditions/ic_us_standard_atm.F90
@@ -7,19 +7,6 @@ module ic_us_standard_atmosphere
 !
 !-------------------------------------------------------------------------------
 
-use shr_kind_mod,        only: r8 => shr_kind_r8
-use spmd_utils,          only: masterproc
-
-use hycoef,              only: ps0, hyam, hybm
-use physconst,           only: gravit
-!use constituents,        only: cnst_name
-!use const_init,          only: cnst_init_default
-
-use std_atm_profile,     only: std_atm_pres, std_atm_height, std_atm_temp
-
-use cam_logfile,         only: iulog
-use cam_abortutils,      only: endrun, check_allocate
-
 implicit none
 private
 save
@@ -32,6 +19,19 @@ CONTAINS
 
 subroutine us_std_atm_set_ic(latvals, lonvals, zint, U, V, T, PS, PHIS_IN, &
        PHIS_OUT, Q, m_cnst, mask, verbose)
+
+   use shr_kind_mod,              only: r8 => shr_kind_r8, cx => shr_kind_cx
+   use ccpp_kinds,                only: kind_phys
+   use spmd_utils,                only: masterproc
+   use hycoef,                    only: ps0, hyam, hybm
+   use physconst,                 only: gravit
+   use std_atm_profile,           only: std_atm_pres, std_atm_height, std_atm_temp
+   use cam_logfile,               only: iulog
+   use cam_abortutils,            only: endrun, check_allocate
+   use runtime_obj,               only: wv_stdname
+   use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
+   use cam_ccpp_cap,              only: cam_model_const_properties
+   use cam_constituents,          only: const_get_index, const_qmin
 
    !----------------------------------------------------------------------------
    !
@@ -58,14 +58,22 @@ subroutine us_std_atm_set_ic(latvals, lonvals, zint, U, V, T, PS, PHIS_IN, &
    ! Local variables
    logical, allocatable              :: mask_use(:)
    logical                           :: verbose_use
+   logical                           :: const_has_default
    integer                           :: i, k, m
    integer                           :: ncol
    integer                           :: nlev, nlevp
    integer                           :: ncnst
    integer                           :: iret
+   integer                           :: ix_q, m_cnst_ix_q
    character(len=*), parameter       :: subname = 'us_std_atm_set_ic'
+   character(len=cx)                 :: errmsg !CCPP error message
    real(r8)                          :: psurf(1)
    real(r8), allocatable             :: pmid(:), zmid(:), zmid2d(:,:)
+   real(kind_phys)                   :: const_default_value !Constituent default value
+   real(kind_phys)                   :: const_qmin_value    !Constituent minimum value
+
+   !Private array of constituent properties (for property interface functions)
+   type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
    !----------------------------------------------------------------------------
 
    ! check input consistency
@@ -208,35 +216,58 @@ subroutine us_std_atm_set_ic(latvals, lonvals, zint, U, V, T, PS, PHIS_IN, &
          zmid2d = 0.5_r8*(zint(:,1:nlev) + zint(:,2:nlev+1))
       end if
 
-      ncnst = size(m_cnst, 1)
+      !Get water vapor constituent index:
+      call const_get_index(wv_stdname, ix_q)
+
+      !Determine which "Q" variable index matches water vapor:
+      m_cnst_ix_q = findloc(m_cnst, ix_q, dim=1)
+
+      ncnst = size(m_cnst)
       do m = 1, ncnst
-         if (m_cnst(m) == 1) then
+         if (m_cnst(m) == m_cnst_ix_q) then
             ! No water vapor in profile
             do k = 1, nlev
                where(mask_use)
                   Q(:,k,m_cnst(m)) = 0.0_r8
                end where
             end do
-!Un-comment once constituents are working in CAMDEN -JN:
-#if 0
             if(masterproc .and. verbose_use) then
-               write(iulog,*) '          ', trim(cnst_name(m_cnst(m))), ' initialized by '//subname
+               write(iulog,*) '          ', wv_stdname, ' initialized by '//subname
             end if
          else
-            if (present(zint)) then
-               call cnst_init_default(m_cnst(m), latvals, lonvals, Q(:,:,m_cnst(m)),&
-                  mask=mask_use, verbose=verbose_use, notfound=.false., z=zmid2d)
-            else
-               call cnst_init_default(m_cnst(m), latvals, lonvals, Q(:,:,m_cnst(m)),&
-                  mask=mask_use, verbose=verbose_use, notfound=.false.)
-            end if
-#else
-         else
-           !Initialize cloud liquid and rain until constituent routines are enabled:
-           Q(:,:,m_cnst(m)) = 0.0_r8
-#endif
-         end if
-      end do
+
+           !Extract constituent minimum value:
+           const_qmin_value = const_qmin(m_cnst(m))
+
+           !Initialize constituent to its minimum value:
+           Q(:,:,m) = real(const_qmin_value, r8)
+
+           if (iret /= 0) then
+              call endrun(errmsg, file=__FILE__, line=__LINE__)
+           end if
+
+           if (const_has_default) then
+
+              !If default value exists, then extract default value
+              !from constituent properties object:
+              call const_props(m_cnst(m))%default_value(const_default_value, &
+                                                        iret,        &
+                                                        errmsg)
+              if (iret /= 0) then
+                call endrun(errmsg, file=__FILE__, line=__LINE__)
+              end if
+
+              !Set constituent to default value in masked region:
+              do k=1,nlev
+                 where(mask_use)
+                    Q(:,k,m) = real(const_default_value, r8)
+                 end where
+              end do
+
+           end if !has_default
+
+         end if !water vapor
+      end do    !ncnst
 
       if (allocated(zmid2d)) deallocate(zmid2d)
 

--- a/src/dynamics/tests/initial_conditions/ic_us_standard_atm.F90
+++ b/src/dynamics/tests/initial_conditions/ic_us_standard_atm.F90
@@ -222,7 +222,12 @@ subroutine us_std_atm_set_ic(latvals, lonvals, zint, U, V, T, PS, PHIS_IN, &
       !Determine which "Q" variable index matches water vapor:
       m_cnst_ix_q = findloc(m_cnst, ix_q, dim=1)
 
+      !Determine total number of constituents:
       ncnst = size(m_cnst)
+
+      !Extract constituent properties from CCPP constituents object:
+      const_props => cam_model_const_properties()
+
       do m = 1, ncnst
          if (m_cnst(m) == m_cnst_ix_q) then
             ! No water vapor in profile
@@ -242,8 +247,12 @@ subroutine us_std_atm_set_ic(latvals, lonvals, zint, U, V, T, PS, PHIS_IN, &
            !Initialize constituent to its minimum value:
            Q(:,:,m) = real(const_qmin_value, r8)
 
+           !Check for default value in constituent properties object:
+           call const_props(m_cnst(m))%has_default(const_has_default, &
+                                                   iret,      &
+                                                   errmsg)
            if (iret /= 0) then
-              call endrun(errmsg, file=__FILE__, line=__LINE__)
+             call endrun(errmsg, file=__FILE__, line=__LINE__)
            end if
 
            if (const_has_default) then

--- a/src/dynamics/tests/namelist_definition_analy_ic.xml
+++ b/src/dynamics/tests/namelist_definition_analy_ic.xml
@@ -8,7 +8,9 @@
     <type>char*80</type>
     <category>dyn_test</category>
     <group>analytic_ic_nl</group>
-    <valid_values>none,held_suarez_1994,moist_baroclinic_wave_dcmip2016,dry_baroclinic_wave_dcmip2016,dry_baroclinic_wave_jw2006</valid_values>
+    <valid_values>
+      none,held_suarez_1994,moist_baroclinic_wave_dcmip2016,dry_baroclinic_wave_dcmip2016,dry_baroclinic_wave_jw2006,us_standard_atmosphere
+    </valid_values>
     <desc>
       Specify the type of analytic initial conditions for an initial run.
       held_suarez_1994: Initial conditions specified in Held and Suarez (1994)


### PR DESCRIPTION
Originator(s): nusbaume, adamrher

Summary:

Adds in the subroutine/function hooks needed for the analytic ICs to properly interact with the CCPP constituents object.  This PR also contains some bug fixes for the air composition and SE dycore dynamics-physics coupling routines that were found via testing with the FKESSLER and FHS94 compsets.   Finally, this PR also includes some slight cleanup of the use of the water vapor constituent standard name within the core CAM-SIMA host code. 

Fixes #287

cod reviewed by:  adamrher, peverwhee

Describe any changes made to build system:  N/A

Describe any changes made to the namelist:

M       src/dynamics/tests/namelist_definition_analy_ic.xml
    - Added the US standard atmosphere option to the analytic IC types.

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes:

M       src/control/cam_comp.F90
M       src/control/runtime_obj.F90
    - Added new "wv_stdname" parameter to cleanup water vapor standard name usage.

M       src/data/air_composition.F90
    -  Fix cpair bug when no dry air species are listed, and use new "wv_stdname" parameter.

M       src/dynamics/se/dp_coupling.F90
    -  Implement qneg and remaining constituents infrastructure, and add missing wet-to-dry conversion step.

M       src/dynamics/se/dycore/prim_state_mod.F90
    -  Whitespace cleanup.

M       src/dynamics/se/dyn_comp.F90
M       src/dynamics/tests/initial_conditions/ic_baro_dry_jw06.F90
M       src/dynamics/tests/initial_conditions/ic_baroclinic.F90
M       src/dynamics/tests/initial_conditions/ic_held_suarez.F90
M       src/dynamics/tests/initial_conditions/ic_us_standard_atm.F90
    - Implement new constituents infrastructure in analytic IC routines.

If there are new failures (compare to the existing-test-failures.txt file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:  All Pass

derecho/gnu/aux_sima:  All Pass

CAM-SIMA date used for the baseline comparison tests if different than latest: