### PR TITLE
Fix CCPP Fortran parser / build error with tropopause_find

### DIFF
--- a/src/physics/utils/tropopause_climo_read.F90
+++ b/src/physics/utils/tropopause_climo_read.F90
@@ -17,6 +17,9 @@ module tropopause_climo_read
   public :: tropopause_climo_readnl
   public :: tropopause_climo_read_file
 
+  ! Private module data
+  character(len=shr_kind_cl)           :: tropopause_climo_file = unset_str
+
 !> \section arg_table_tropopause_climo_read  Argument Table
 !! \htmlinclude tropopause_climo_read.html
   ! months in year for climatological tropopause pressure data
@@ -27,9 +30,6 @@ module tropopause_climo_read
 
   ! monthly day-of-year times corresponding to climatological data (12)
   real(kind_phys), public, allocatable :: tropp_days(:)
-
-  ! Private module data
-  character(len=shr_kind_cl)           :: tropopause_climo_file = unset_str
 
 contains
   ! Read namelist variable tropopause_climo_file.
@@ -235,7 +235,6 @@ contains
     !--------------------------------------------------------
     call mark_as_initialized('tropopause_air_pressure_from_climatology_dataset')
     call mark_as_initialized('tropopause_calendar_days_from_climatology')
-    call mark_as_initialized('filename_of_tropopause_climatology')
 
   end subroutine tropopause_climo_read_file
 end module tropopause_climo_read

--- a/src/physics/utils/tropopause_climo_read.meta
+++ b/src/physics/utils/tropopause_climo_read.meta
@@ -21,9 +21,3 @@
   units = 1
   type = real | kind = kind_phys
   dimensions = (number_of_months_in_year)
-[ tropopause_climo_file ]
-  standard_name = filename_of_tropopause_climatology
-  long_name = File path to tropopause climatology file
-  units = none
-  type = character | kind = len=256
-  dimensions = ()


### PR DESCRIPTION
The CCPP Fortran parser is not able to read module variables of character type defined with the `shr_kind_cl` parameter size.

The `tropopause_climo_file` variable does not need to be a CCPP variable anyway so it has been removed. This will fix the build process again.

Verified that it builds (need to either remove `tropopause_diagnostics` from tropopause_find test SDF -or- merge the history PR) and runs with CAM snapshot.