### PR TITLE
New const_get_index logic without cam_ccpp_cap dependency (in atmos_phys)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,8 +13,8 @@
         fxDONOTUSEurl = https://github.com/MPAS-Dev/MPAS-Model.git
 [submodule "ncar-physics"]
         path          = src/physics/ncar_ccpp
-        url           = https://github.com/jimmielin/atmospheric_physics
-        fxtag         = fbea5c86954f6d043d8d8a94715cb745469114b8
+        url           = https://github.com/ESCOMP/atmospheric_physics
+        fxtag         = 67bb908e
         fxrequired    = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 [submodule "ccs_config"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,8 +13,8 @@
         fxDONOTUSEurl = https://github.com/MPAS-Dev/MPAS-Model.git
 [submodule "ncar-physics"]
         path          = src/physics/ncar_ccpp
-        url           = https://github.com/ESCOMP/atmospheric_physics
-        fxtag         = atmos_phys0_05_001
+        url           = https://github.com/jimmielin/atmospheric_physics
+        fxtag         = fbea5c86954f6d043d8d8a94715cb745469114b8
         fxrequired    = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 [submodule "ccs_config"]

--- a/cime_config/cam_autogen.py
+++ b/cime_config/cam_autogen.py
@@ -602,7 +602,7 @@ def generate_physics_suites(build_cache, preproc_defs, host_name,
         if not os.path.isdir(atm_phys_util_dir):
             #CAM-SIMA will likely not run without this, so raise an error
             emsg = "ERROR: Unable to find CCPP physics utilities directory:\n"
-            emsg += f" {atm_phys_util_dir}\n Have you run 'checkout_externals'?"
+            emsg += f" {atm_phys_util_dir}\n Have you run 'git-fleximod'?"
             raise CamAutoGenError(emsg)
         # end if
 
@@ -611,6 +611,16 @@ def generate_physics_suites(build_cache, preproc_defs, host_name,
         for util_file in atm_phys_util_files:
             shutil.copy(util_file, physics_blddir)
         # end for
+
+        # Copy to_be_ccppized utility modules to the build directory,
+        # as SIMA cam_constituents depends on them.
+        atm_phys_to_be_ccppized_dir = os.path.join(atm_phys_top_dir, "to_be_ccppized")
+
+        # Check that the directory exists and copy to build directory
+        if os.path.isdir(atm_phys_to_be_ccppized_dir):
+             atm_phys_to_be_ccppized_files = glob.glob(os.path.join(atm_phys_to_be_ccppized_dir, "*.F90"))
+             for to_be_ccppized_file in atm_phys_to_be_ccppized_files:
+                shutil.copy(to_be_ccppized_file, physics_blddir)
     # end if
 
     if do_gen_ccpp or do_gen_nl:

--- a/cime_config/cam_autogen.py
+++ b/cime_config/cam_autogen.py
@@ -600,7 +600,7 @@ def generate_physics_suites(build_cache, preproc_defs, host_name,
 
         # Check that directory exists
         if not os.path.isdir(atm_phys_util_dir):
-            #CAM-SIMA will likely not run without this, so raise an error
+            # CAM-SIMA will likely not run without this, so raise an error
             emsg = "ERROR: Unable to find CCPP physics utilities directory:\n"
             emsg += f" {atm_phys_util_dir}\n Have you run 'git-fleximod'?"
             raise CamAutoGenError(emsg)
@@ -614,13 +614,22 @@ def generate_physics_suites(build_cache, preproc_defs, host_name,
 
         # Copy to_be_ccppized utility modules to the build directory,
         # as SIMA cam_constituents depends on them.
+        # Note: to_be_ccppized utility modules to be removed once functionality is migrated
+        # to SIMA or CCPPized in atmospheric_physics.
         atm_phys_to_be_ccppized_dir = os.path.join(atm_phys_top_dir, "to_be_ccppized")
 
-        # Check that the directory exists and copy to build directory
-        if os.path.isdir(atm_phys_to_be_ccppized_dir):
-             atm_phys_to_be_ccppized_files = glob.glob(os.path.join(atm_phys_to_be_ccppized_dir, "*.F90"))
-             for to_be_ccppized_file in atm_phys_to_be_ccppized_files:
-                shutil.copy(to_be_ccppized_file, physics_blddir)
+        # Check that the directory exists
+        if not os.path.isdir(atm_phys_to_be_ccppized_dir):
+            # CAM-SIMA will likely not run without this, so raise an error
+            emsg = "ERROR: Unable to find CCPP physics to_be_ccppized directory:\n"
+            emsg += f" {atm_phys_util_dir}\n Have you run 'git-fleximod'?"
+            raise CamAutoGenError(emsg)
+        # end if
+
+        atm_phys_to_be_ccppized_files = glob.glob(os.path.join(atm_phys_to_be_ccppized_dir, "*.F90"))
+        for to_be_ccppized_file in atm_phys_to_be_ccppized_files:
+           shutil.copy(to_be_ccppized_file, physics_blddir)
+        # end for
     # end if
 
     if do_gen_ccpp or do_gen_nl:

--- a/cime_config/cam_autogen.py
+++ b/cime_config/cam_autogen.py
@@ -622,7 +622,7 @@ def generate_physics_suites(build_cache, preproc_defs, host_name,
         if not os.path.isdir(atm_phys_to_be_ccppized_dir):
             # CAM-SIMA will likely not run without this, so raise an error
             emsg = "ERROR: Unable to find CCPP physics to_be_ccppized directory:\n"
-            emsg += f" {atm_phys_util_dir}\n Have you run 'git-fleximod'?"
+            emsg += f" {atm_phys_to_be_ccppized_dir}\n Have you run 'git-fleximod'?"
             raise CamAutoGenError(emsg)
         # end if
 

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -285,10 +285,14 @@ CONTAINS
    !#######################################################################
 
    subroutine const_get_index(name, cindex, abort, warning, caller)
-      use shr_kind_mod,   only: CX => SHR_KIND_CX
-      use cam_abortutils, only: endrun
-      use cam_logfile,    only: iulog
-      use cam_ccpp_cap,   only: cam_const_get_index
+      ! from to_be_ccppized utility routine
+      use ccpp_const_utils,     only: ccpp_const_get_idx
+
+      use shr_kind_mod,         only: CX => SHR_KIND_CX
+      use cam_abortutils,       only: endrun
+      use cam_logfile,          only: iulog
+      use phys_vars_init_check, only: std_name_len
+      use string_utils,         only: to_str
 
       ! Get the index of a constituent with standard name, <name>.
       ! Setting optional <abort> argument to .false. returns control to
@@ -298,11 +302,11 @@ CONTAINS
       !    instead of <subname> in messages.
 
       !-----------------------------Arguments---------------------------------
-      character(len=*),           intent(in)  :: name   ! constituent name
-      integer,                    intent(out) :: cindex ! global constituent ind
-      logical,          optional, intent(in)  :: abort  ! flag controlling abort
+      character(len=*),           intent(in)  :: name    ! constituent name
+      integer,                    intent(out) :: cindex  ! global constituent index
+      logical,          optional, intent(in)  :: abort   ! flag controlling abort
       logical,          optional, intent(in)  :: warning ! flag controlling warning
-      character(len=*), optional, intent(in)  :: caller ! calling routine
+      character(len=*), optional, intent(in)  :: caller  ! calling routine
 
       !---------------------------Local workspace-----------------------------
       logical                     :: warning_on_error
@@ -312,10 +316,14 @@ CONTAINS
       character(len=*), parameter :: subname = 'const_get_index: '
       !-----------------------------------------------------------------------
 
-      ! Find tracer name in the master table
-      call cam_const_get_index(name, cindex, errcode=errcode, errmsg=errmsg)
+      call ccpp_const_get_idx(const_props, name, cindex, errmsg, errcode)
 
       if (errcode /= 0) then
+         call endrun(subname//"Error "//to_str(errcode)//": "//           &
+                 trim(errmsg), file=__FILE__, line=__LINE__)
+      endif
+
+      if (cindex == -1) then
          ! Unrecognized name, set an error return and possibly abort
          cindex = -1
          if (present(abort)) then

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -319,7 +319,7 @@ CONTAINS
       call ccpp_const_get_idx(const_props, name, cindex, errmsg, errcode)
 
       if (errcode /= 0) then
-         call endrun(subname//"Error "//stringify(errcode)//": "//           &
+         call endrun(subname//"Error "//stringify((/errcode/))//": "//           &
                  trim(errmsg), file=__FILE__, line=__LINE__)
       endif
 

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -292,7 +292,7 @@ CONTAINS
       use cam_abortutils,       only: endrun
       use cam_logfile,          only: iulog
       use phys_vars_init_check, only: std_name_len
-      use string_utils,         only: to_str
+      use string_utils,         only: stringify
 
       ! Get the index of a constituent with standard name, <name>.
       ! Setting optional <abort> argument to .false. returns control to
@@ -319,7 +319,7 @@ CONTAINS
       call ccpp_const_get_idx(const_props, name, cindex, errmsg, errcode)
 
       if (errcode /= 0) then
-         call endrun(subname//"Error "//to_str(errcode)//": "//           &
+         call endrun(subname//"Error "//stringify(errcode)//": "//           &
                  trim(errmsg), file=__FILE__, line=__LINE__)
       endif
 


### PR DESCRIPTION
Companion atmospheric_physics PR: https://github.com/ESCOMP/atmospheric_physics/pull/135

This avoids a circular dependency if schemes require const_get_index, which presently depends on cam_ccpp_cap, which depends on individual schemes.