### PR TITLE
Update standard names for tropopause_find

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "ncar-physics"]
         path          = src/physics/ncar_ccpp
 	url           = https://github.com/ESCOMP/atmospheric_physics
-	fxtag         = e7a599f4bb1533f7cdcd8723b1f864e11578e96c
+	fxtag         = 491e56247815ef23bfd8dba65d1e3c3b78ba164a
         fxrequired    = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 [submodule "ccs_config"]

--- a/src/physics/utils/tropopause_climo_read.F90
+++ b/src/physics/utils/tropopause_climo_read.F90
@@ -233,8 +233,8 @@ contains
     !--------------------------------------------------------
     ! Mark variables as initialized so they are not read from initial conditions
     !--------------------------------------------------------
-    call mark_as_initialized('tropopause_air_pressure_from_climatology_dataset')
-    call mark_as_initialized('tropopause_calendar_days_from_climatology')
+    call mark_as_initialized('tropopause_air_pressure_from_tropopause_climatology_dataset')
+    call mark_as_initialized('tropopause_calendar_days_from_tropopause_climatology')
 
   end subroutine tropopause_climo_read_file
 end module tropopause_climo_read

--- a/src/physics/utils/tropopause_climo_read.meta
+++ b/src/physics/utils/tropopause_climo_read.meta
@@ -6,7 +6,7 @@
   name  = tropopause_climo_read
   type  = module
 [ tropp_slices ]
-  standard_name = number_of_months_in_year
+  standard_name = number_of_time_slices_in_climatology_dataset
   units = 1
   type = integer
   dimensions = ()
@@ -14,10 +14,10 @@
   standard_name = tropopause_air_pressure_from_climatology_dataset
   units = Pa
   type = real | kind = kind_phys
-  dimensions = (horizontal_dimension, number_of_months_in_year)
+  dimensions = (horizontal_dimension, number_of_time_slices_in_climatology_dataset)
 [ tropp_days ]
   standard_name = tropopause_calendar_days_from_climatology
   long_name = Climatological tropopause calendar day indices from file
   units = 1
   type = real | kind = kind_phys
-  dimensions = (number_of_months_in_year)
+  dimensions = (number_of_time_slices_in_climatology_dataset)

--- a/src/physics/utils/tropopause_climo_read.meta
+++ b/src/physics/utils/tropopause_climo_read.meta
@@ -6,18 +6,18 @@
   name  = tropopause_climo_read
   type  = module
 [ tropp_slices ]
-  standard_name = number_of_time_slices_in_climatology_dataset
+  standard_name = number_of_time_slices_in_tropopause_climatology_dataset
   units = 1
   type = integer
   dimensions = ()
 [ tropp_p_loc ]
-  standard_name = tropopause_air_pressure_from_climatology_dataset
+  standard_name = tropopause_air_pressure_from_tropopause_climatology_dataset
   units = Pa
   type = real | kind = kind_phys
-  dimensions = (horizontal_dimension, number_of_time_slices_in_climatology_dataset)
+  dimensions = (horizontal_dimension, number_of_time_slices_in_tropopause_climatology_dataset)
 [ tropp_days ]
-  standard_name = tropopause_calendar_days_from_climatology
+  standard_name = tropopause_calendar_days_from_tropopause_climatology
   long_name = Climatological tropopause calendar day indices from file
   units = 1
   type = real | kind = kind_phys
-  dimensions = (number_of_time_slices_in_climatology_dataset)
+  dimensions = (number_of_time_slices_in_tropopause_climatology_dataset)


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

Fixes #308 by updating tropopause_find standard names.

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

Updates standard names for tropopause_find
M       src/physics/utils/tropopause_climo_read.F90
M       src/physics/utils/tropopause_climo_read.meta

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
