### PR TITLE
Improve robustness of cam open/close file register code to fix issues with history output

### DIFF
--- a/src/history/cam_hist_file.F90
+++ b/src/history/cam_hist_file.F90
@@ -1015,6 +1015,7 @@ CONTAINS
          end do
       end do
       ! Determine the maximum number of dimensions
+      max_mdims = 0
       do field_index = 1, size(this%field_list)
          max_mdims = max(max_mdims, size(this%field_list(field_index)%dimensions()))
       end do


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin 

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

- Fixes #332 (`max_mdims` used before defined)
- Fixes #331 (unassociated `of%file_desc` in `cam_register_open_file` leading to crash with >2 history files)

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

```
Fixes #331
M       src/history/cam_hist_file.F90

Fixes #332
M       src/utils/cam_abortutils.F90

```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
