### PR TITLE
fix real32 gnu issue

### DIFF
--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -9,7 +9,6 @@
   <!-- Derecho physics tests -->
   <test compset="FPHYStest" grid="ne3pg3_ne3pg3_mg37" name="SMS_Ln2" testmods="cam/outfrq_kessler_derecho">
     <machines>
-      <machine name="derecho" compiler="intel" category="aux_sima"/>
       <machine name="derecho" compiler="gnu" category="aux_sima"/>
     </machines>
     <options>
@@ -19,7 +18,6 @@
   </test>
   <test compset="FPHYStest" grid="ne3pg3_ne3pg3_mg37" name="SMS_Ln2" testmods="cam/outfrq_held_suarez_derecho">
     <machines>
-      <machine name="derecho" compiler="intel" category="aux_sima"/>
       <machine name="derecho" compiler="gnu" category="aux_sima"/>
     </machines>
     <options>
@@ -29,7 +27,6 @@
   </test>
   <test compset="FPHYStest" grid="ne3pg3_ne3pg3_mg37" name="SMS_Ln2" testmods="cam/outfrq_tj2016_before_coupler_derecho">
     <machines>
-      <machine name="derecho" compiler="intel" category="aux_sima"/>
       <machine name="derecho" compiler="gnu" category="aux_sima"/>
     </machines>
     <options>
@@ -39,7 +36,6 @@
   </test>
   <test compset="FPHYStest" grid="ne3pg3_ne3pg3_mg37" name="SMS_Ln2" testmods="cam/outfrq_tj2016_after_coupler_derecho">
     <machines>
-      <machine name="derecho" compiler="intel" category="aux_sima"/>
       <machine name="derecho" compiler="gnu" category="aux_sima"/>
     </machines>
     <options>

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_kessler_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_kessler_derecho/user_nl_cam
@@ -1,7 +1,6 @@
 ncdata=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_kessler_snapshot_derecho_gnu_before_c20240412.nc
 ncdata_check=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_kessler_snapshot_derecho_gnu_after_c20240412.nc
 ncdata_check_err=.true.
-min_difference=1.0e-15
 debug_output=0
 pver=30
 hist_add_inst_fields;h2: Q, T

--- a/src/history/cam_hist_file.F90
+++ b/src/history/cam_hist_file.F90
@@ -1485,7 +1485,8 @@ CONTAINS
                split_file_index == instantaneous_file_index .and. .not. restart) then
                cycle
             end if
-            call this%write_field(this%field_list(field_idx), split_file_index, restart, start, field_idx)
+            call this%write_field(this%field_list(field_idx), split_file_index, restart, start, field_idx, &
+               this%precision())
          end do
       end do
       call t_stopf  ('write_field')
@@ -1495,13 +1496,14 @@ CONTAINS
    ! ========================================================================
 
    subroutine config_write_field(this, field, split_file_index, restart, &
-      sample_index, field_index)
+      sample_index, field_index, field_precision)
       use pio,                 only: PIO_OFFSET_KIND, pio_setframe
       use hist_buffer,         only: hist_buffer_t
       use hist_api,            only: hist_buffer_norm_value
       use cam_grid_support,    only: cam_grid_write_dist_array
       use cam_abortutils,      only: check_allocate, endrun
       use hist_field,          only: hist_field_info_t
+      use shr_kind_mod,        only: r4 => shr_kind_r4
       ! Dummy arguments
       class(hist_file_t),      intent(inout) :: this
       type(hist_field_info_t), intent(inout) :: field
@@ -1509,6 +1511,7 @@ CONTAINS
       logical,                 intent(in)    :: restart
       integer,                 intent(in)    :: sample_index
       integer,                 intent(in)    :: field_index
+      character(len=*),        intent(in)    :: field_precision
 
       ! Local variables
       integer, allocatable           :: field_shape(:) ! Field file dim sizes
@@ -1522,7 +1525,8 @@ CONTAINS
       type(var_desc_t)               :: varid
       integer                        :: field_decomp
       integer                        :: idx
-      real(r8), allocatable          :: field_data(:,:)
+      real(r8), allocatable          :: field_data_r8(:,:)
+      real(r4), allocatable          :: field_data_r4(:,:)
       class(hist_buffer_t), pointer  :: buff_ptr
       character(len=*), parameter    :: subname = 'config_write_field: '
 
@@ -1533,11 +1537,21 @@ CONTAINS
       end_dims = field%end_dims()
       frank = size(field_shape)
       if (frank == 1) then
-         allocate(field_data(end_dims(1) - beg_dims(1) + 1, 1), stat=ierr)
-         call check_allocate(ierr, subname, 'field_data', file=__FILE__, line=__LINE__-1)
+         if (trim(field_precision) == 'REAL32') then
+            allocate(field_data_r4(end_dims(1) - beg_dims(1) + 1, 1), stat=ierr)
+            call check_allocate(ierr, subname, 'field_data_r4', file=__FILE__, line=__LINE__-1)
+         else
+            allocate(field_data_r8(end_dims(1) - beg_dims(1) + 1, 1), stat=ierr)
+            call check_allocate(ierr, subname, 'field_data_r8', file=__FILE__, line=__LINE__-1)
+         end if
       else
-         allocate(field_data(end_dims(1) - beg_dims(1) + 1, field_shape(2)), stat=ierr)
-         call check_allocate(ierr, subname, 'field_data', file=__FILE__, line=__LINE__-1)
+         if (trim(field_precision) == 'REAL32') then
+            allocate(field_data_r4(end_dims(1) - beg_dims(1) + 1, field_shape(2)), stat=ierr)
+            call check_allocate(ierr, subname, 'field_data_r4', file=__FILE__, line=__LINE__-1)
+         else
+            allocate(field_data_r8(end_dims(1) - beg_dims(1) + 1, field_shape(2)), stat=ierr)
+            call check_allocate(ierr, subname, 'field_data_r8', file=__FILE__, line=__LINE__-1)
+         end if
       end if
       ! Shape of array
       dimind = field%dimensions()
@@ -1556,13 +1570,25 @@ CONTAINS
          call pio_setframe(this%hist_files(split_file_index), varid, int(sample_index,kind=PIO_OFFSET_KIND))
          buff_ptr => field%buffers
          if (frank == 1) then
-            call hist_buffer_norm_value(buff_ptr, field_data(:,1))
-            call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
-                 field_shape, field_data(:,1), varid)
+            if (trim(field_precision) == 'REAL32') then
+               call hist_buffer_norm_value(buff_ptr, field_data_r4(:,1))
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
+                    field_shape, field_data_r4(:,1), varid)
+            else
+               call hist_buffer_norm_value(buff_ptr, field_data_r8(:,1))
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
+                    field_shape, field_data_r8(:,1), varid)
+            end if
          else
-            call hist_buffer_norm_value(buff_ptr, field_data)
-            call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
-                 field_shape, field_data, varid)
+            if (trim(field_precision) == 'REAL32') then
+               call hist_buffer_norm_value(buff_ptr, field_data_r4)
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
+                    field_shape, field_data_r4, varid)
+            else
+               call hist_buffer_norm_value(buff_ptr, field_data_r8)
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
+                    field_shape, field_data_r8, varid)
+            end if
          end if
       end do
 

--- a/src/history/cam_hist_file.F90
+++ b/src/history/cam_hist_file.F90
@@ -1416,7 +1416,7 @@ CONTAINS
       ! Increment samples
       this%num_samples = this%num_samples + 1
 
-      start = mod(this%num_samples, this%max_frames)
+      start = mod(this%num_samples-1, this%max_frames) + 1
       count1 = 1
 
       is_initfile = (this%hfile_type == hfile_type_init_value)

--- a/src/history/cam_hist_file.F90
+++ b/src/history/cam_hist_file.F90
@@ -1415,7 +1415,7 @@ CONTAINS
       ! Increment samples
       this%num_samples = this%num_samples + 1
 
-      start = mod(this%num_samples, this%max_frames) + 1
+      start = mod(this%num_samples, this%max_frames)
       count1 = 1
 
       is_initfile = (this%hfile_type == hfile_type_init_value)

--- a/src/history/cam_hist_file.F90
+++ b/src/history/cam_hist_file.F90
@@ -1528,6 +1528,7 @@ CONTAINS
       real(r8), allocatable          :: field_data_r8(:,:)
       real(r4), allocatable          :: field_data_r4(:,:)
       class(hist_buffer_t), pointer  :: buff_ptr
+      character(len=CL)              :: errmsg
       character(len=*), parameter    :: subname = 'config_write_field: '
 
       !!! Get the field's shape and decomposition
@@ -1538,19 +1539,19 @@ CONTAINS
       frank = size(field_shape)
       if (frank == 1) then
          if (trim(field_precision) == 'REAL32') then
-            allocate(field_data_r4(end_dims(1) - beg_dims(1) + 1, 1), stat=ierr)
-            call check_allocate(ierr, subname, 'field_data_r4', file=__FILE__, line=__LINE__-1)
+            allocate(field_data_r4(end_dims(1) - beg_dims(1) + 1, 1), stat=ierr, errmsg=errmsg)
+            call check_allocate(ierr, subname, 'field_data_r4', file=__FILE__, line=__LINE__-1, errmsg=errmsg)
          else
-            allocate(field_data_r8(end_dims(1) - beg_dims(1) + 1, 1), stat=ierr)
-            call check_allocate(ierr, subname, 'field_data_r8', file=__FILE__, line=__LINE__-1)
+            allocate(field_data_r8(end_dims(1) - beg_dims(1) + 1, 1), stat=ierr, errmsg=errmsg)
+            call check_allocate(ierr, subname, 'field_data_r8', file=__FILE__, line=__LINE__-1, errmsg=errmsg)
          end if
       else
          if (trim(field_precision) == 'REAL32') then
-            allocate(field_data_r4(end_dims(1) - beg_dims(1) + 1, field_shape(2)), stat=ierr)
-            call check_allocate(ierr, subname, 'field_data_r4', file=__FILE__, line=__LINE__-1)
+            allocate(field_data_r4(end_dims(1) - beg_dims(1) + 1, field_shape(2)), stat=ierr, errmsg=errmsg)
+            call check_allocate(ierr, subname, 'field_data_r4', file=__FILE__, line=__LINE__-1, errmsg=errmsg)
          else
-            allocate(field_data_r8(end_dims(1) - beg_dims(1) + 1, field_shape(2)), stat=ierr)
-            call check_allocate(ierr, subname, 'field_data_r8', file=__FILE__, line=__LINE__-1)
+            allocate(field_data_r8(end_dims(1) - beg_dims(1) + 1, field_shape(2)), stat=ierr, errmsg=errmsg)
+            call check_allocate(ierr, subname, 'field_data_r8', file=__FILE__, line=__LINE__-1, errmsg=errmsg)
          end if
       end if
       ! Shape of array
@@ -1572,21 +1573,21 @@ CONTAINS
          if (frank == 1) then
             if (trim(field_precision) == 'REAL32') then
                call hist_buffer_norm_value(buff_ptr, field_data_r4(:,1))
-               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1), &
                     field_shape, field_data_r4(:,1), varid)
             else
                call hist_buffer_norm_value(buff_ptr, field_data_r8(:,1))
-               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1), &
                     field_shape, field_data_r8(:,1), varid)
             end if
          else
             if (trim(field_precision) == 'REAL32') then
                call hist_buffer_norm_value(buff_ptr, field_data_r4)
-               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1:frank), &
                     field_shape, field_data_r4, varid)
             else
                call hist_buffer_norm_value(buff_ptr, field_data_r8)
-               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1: frank), &
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1:frank), &
                     field_shape, field_data_r8, varid)
             end if
          end if

--- a/src/history/cam_hist_file.F90
+++ b/src/history/cam_hist_file.F90
@@ -1574,11 +1574,11 @@ CONTAINS
          if (frank == 1) then
             if (trim(field_precision) == 'REAL32') then
                call hist_buffer_norm_value(buff_ptr, field_data_r4(:,1))
-               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1), &
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, (/dim_sizes(1)/), &
                     field_shape, field_data_r4(:,1), varid)
             else
                call hist_buffer_norm_value(buff_ptr, field_data_r8(:,1))
-               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, dim_sizes(1), &
+               call cam_grid_write_dist_array(this%hist_files(split_file_index), field_decomp, (/dim_sizes(1)/), &
                     field_shape, field_data_r8(:,1), varid)
             end if
          else

--- a/test/existing-test-failures.txt
+++ b/test/existing-test-failures.txt
@@ -5,4 +5,4 @@ SMS_Ln2.mpasa480_mpasa480.FKESSLER.derecho_gnu.cam-outfrq_kessler_mpas_derecho (
 SMS_Ln9.ne5pg3_ne5pg3_mg37.FCAM7.derecho_intel.cam-outfrq_se_cslam_analy_ic (Overall: PEND) details:
 SMS_Ln9.ne5pg3_ne5pg3_mg37.FCAM7.derecho_gnu.cam-outfrq_se_cslam_analy_ic (Overall: PEND) details:
  - build failure due to dadadj_apply_qv_tendency removal, needs to be updated to use constituent tendency updater atmospheric_physics#179
- - also expected runtime failure CAM-SIMA#335
+ - also expected runtime failure until we have a CCPP-Framework tag from https://github.com/NCAR/ccpp-framework/pull/618


### PR DESCRIPTION
Tag name (required for release branches): sima0_01_000
Originator(s): peverwhee

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number): 
Select correct field_data buffer (r8 vs r4) depending on the precision of the file in question
closes #336 "History using REAL32 does not appear to write properly"
closes #341 "History code always outputs an "empty" zero timestep"
addresses #343 "Add intel snapshot testing"

Describe any changes made to build system: n/a

Describe any changes made to the namelist: n/a

List any changes to the defaults for the input datasets (e.g. boundary datasets): n/a

List all files eliminated and why: n/a

List all files added and what they do: n/a

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
M   src/history/cam_hist_file.F90
- add r4 array and use that conditionally if precision is REAL32
- fix bug where the sample number was being incremented twice

M   test/existing-test-failures.txt
- update test failures file to point to framework PR we're waiting on

M   cime_config/testdefs/testlist_cam.xml
- remove intel snapshot tests since we don't currently have any intel snapshots!

M   cime_config/testdefs/testmods_dirs/cam/outfrq_kessler_derecho/user_nl_cam
- remove min_difference that was added to get the intel test (that no longer exist) to run

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima: All DIFF because of the nstep=0 bug, but confirmed that the results were b4b with a slice of the baselines (removing the erroneous nstep=0 sample). These are the first "correct" baselines for cam7

derecho/gnu/aux_sima: All DIFF because of the nstep=0 bug, but confirmed that the results were b4b with a slice of the baselines (removing the erroneous nstep=0 sample). These are the first "correct" baselines for cam7

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
