### PR TITLE
Fix water vapor (Q) register incompatibility with initialize_constituents scheme

### DIFF
--- a/src/control/cam_comp.F90
+++ b/src/control/cam_comp.F90
@@ -615,6 +615,8 @@ CONTAINS
               default_value=0._kind_phys,                                               &
               vertical_dim="vertical_layer_dimension",                                  &
               advected=.true.,                                                          &
+              water_species = .true.,                                                   &
+              mixing_ratio_type = 'wet',                                                &
            errcode=errflg, errmsg=errmsg)
 
          if (errflg /= 0) then


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

Add `water_species` and `mixing_ratio_type = 'wet'` property for when `cam_register_constituents` registers water vapor when no other scheme explicitly uses water vapor (but might use all CCPP constituents as a whole)

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

```
Add water_species = .true. and mixing_ratio_type = 'wet' to wv_stdname
M       src/control/cam_comp.F90
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
