### PR TITLE
Bugfix for write_init_files

### DIFF
--- a/src/data/write_init_files.py
+++ b/src/data/write_init_files.py
@@ -388,6 +388,9 @@ def write_ic_params(outfile, host_vars, ic_names, registry_constituents):
     else:
         max_slen = 0
     # end if
+    # Extend max_slen if any constituent names are longer
+    max_slen = max(max_slen, max(len(x) for x in registry_constituents))
+
     outfile.write(f"integer, public, parameter :: std_name_len = {max_slen}", 1)
 
     outfile.blank_line()


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): peverwhee

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

extend stdname_max_len for constituent standard names

Describe any changes made to build system:

Describe any changes made to the namelist: n/a

List any changes to the defaults for the input datasets (e.g. boundary datasets): n/a

List all files eliminated and why: n/a

List all files added and what they do: n/a

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

M src/data/write_init_files.py
- include constituent standard names when determining maximum standard name length

M atmospheric_physics submodule
- did not update .gitmodules file, but submodule itself was out of sync

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima: all PASS

derecho/gnu/aux_sima: all PASS

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
