### PR TITLE
add "protected = true" to orbital data metadata

### DIFF
--- a/src/physics/utils/orbital_data.meta
+++ b/src/physics/utils/orbital_data.meta
@@ -9,13 +9,16 @@
   units = rad
   type = real | kind = kind_phys
   dimensions = ()
+  protected = True
 [earth_sun_distance]
   standard_name = earth_sun_distance
   units = AU
   type = real | kind = kind_phys
   dimensions = ()
+  protected = True
 [solar_zenith_angle]
   standard_name = solar_zenith_angle
   units = rad
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension)
+  protected = True


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): peverwhee

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

Adds "protected = true" to orbital_data metadata so the generated code doesn't try to read it in from file.

Describe any changes made to build system: n/a

Describe any changes made to the namelist: n/a

List any changes to the defaults for the input datasets (e.g. boundary datasets): n/a

List all files eliminated and why: n/a

List all files added and what they do: n/a

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
M   src/physics/utils/orbital_data.meta
- add "protected = true" attribute

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima: all PASS

derecho/gnu/aux_sima: all PASS

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
