### PR TITLE
Configure option syntax now only uses dashes

### DIFF
--- a/cime_config/cam_config.py
+++ b/cime_config/cam_config.py
@@ -589,7 +589,7 @@ class ConfigCAM:
         [('analytic_ic', False), ('dyn', 'se'), ('dyn_kind', 'REAL64'), ('phys_kind', 'REAL64'), ('physics_suites', 'kessler')]
 
         5.  Check that parse_config_opts works as expected when given both a string and logical argument:
-        >>> config_opts = ConfigCAM.parse_config_opts("--physics-suites kessler --dyn se --analytic_ic")
+        >>> config_opts = ConfigCAM.parse_config_opts("--physics-suites kessler --dyn se --analytic-ic")
         >>> vargs = vars(config_opts)
         >>> [(x, vargs[x]) for x in sorted(vargs)]
         [('analytic_ic', True), ('dyn', 'se'), ('dyn_kind', 'REAL64'), ('phys_kind', 'REAL64'), ('physics_suites', 'kessler')]

--- a/cime_config/cam_config.py
+++ b/cime_config/cam_config.py
@@ -613,26 +613,38 @@ class ConfigCAM:
                                          epilog="Allowed values of "+cco_str)
 
         #Add argument options:
-        parser.add_argument("--physics-suites", "-physics-suites", type=str,
-                            required=True, metavar='<CCPP_SDFs>',
+        parser.add_argument("--physics-suites",
+                            type=str,
+                            required=True,
+                            metavar='<CCPP_SDFs>',
                             help="""Semicolon-separated list of Physics Suite
                                  Definition Files (SDFs)""")
 
-        parser.add_argument("--dyn", "-dyn", metavar='<dycore>',
-                            type=str, required=False, default="",
+        parser.add_argument("--dyn",
+                            type=str,
+                            required=False,
+                            metavar='<dycore>',
+                            default="",
                             help="""Name of dycore""")
 
-        parser.add_argument("--analytic-ic", "-analytic-ic",
-                            action='store_true', required=False,
+        parser.add_argument("--analytic-ic",
+                            action='store_true',
+                            required=False,
                             help="""Flag to turn on Analytic Initial
                                  Conditions (ICs).""")
 
-        parser.add_argument("--dyn-kind", "-dyn-kind",
-                            type=str, required=False, default="REAL64",
+        parser.add_argument("--dyn-kind",
+                            type=str,
+                            required=False,
+                            metavar='<kind string>',
+                            default="REAL64",
                             help="""Fortran kind used in dycore for type real.""")
 
-        parser.add_argument("--phys-kind", "-phys-kind",
-                            type=str, required=False, default="REAL64",
+        parser.add_argument("--phys-kind",
+                            type=str,
+                            required=False,
+                            metavar='<kind string>',
+                            default="REAL64",
                             help="""Fortran kind used in physics for type real.""")
 
         popts = [opt for opt in config_opts.split(" ") if opt]

--- a/cime_config/cam_config.py
+++ b/cime_config/cam_config.py
@@ -503,6 +503,10 @@ class ConfigCAM:
                      "To specify the Kessler and Held-Suarez suites as ",
                      "run time options, use '--physics-suites kessler;held_suarez_1994'."]
 
+        #--------------------------
+        # Set physics_suites string
+        #--------------------------
+
         self.create_config("physics_suites", phys_desc,
                            user_config_opts.physics_suites)
 
@@ -618,16 +622,16 @@ class ConfigCAM:
                             type=str, required=False, default="",
                             help="""Name of dycore""")
 
-        parser.add_argument("--analytic_ic", "-analytic_ic",
+        parser.add_argument("--analytic-ic", "-analytic-ic",
                             action='store_true', required=False,
                             help="""Flag to turn on Analytic Initial
                                  Conditions (ICs).""")
 
-        parser.add_argument("--dyn_kind", "-dyn_kind",
+        parser.add_argument("--dyn-kind", "-dyn-kind",
                             type=str, required=False, default="REAL64",
                             help="""Fortran kind used in dycore for type real.""")
 
-        parser.add_argument("--phys_kind", "-phys_kind",
+        parser.add_argument("--phys-kind", "-phys-kind",
                             type=str, required=False, default="REAL64",
                             help="""Fortran kind used in physics for type real.""")
 

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -162,10 +162,10 @@
 
       <!-- Simple models -->
       <value compset="_CAM%ADIAB">--physics-suites adiabatic</value>
-      <value compset="_CAM%TJ16">--physics-suites tj2016 --analytic_ic</value>
+      <value compset="_CAM%TJ16">--physics-suites tj2016 --analytic-ic</value>
 <!--      <value compset="_CAM%KESSLER">-phys kessler -chem terminator -analytic_ic</value> -->
-      <value compset="_CAM%KESSLER">--physics-suites kessler --analytic_ic</value>
-      <value compset="_CAM%HS94">--physics-suites held_suarez_1994 --analytic_ic</value>
+      <value compset="_CAM%KESSLER">--physics-suites kessler --analytic-ic</value>
+      <value compset="_CAM%HS94">--physics-suites held_suarez_1994 --analytic-ic</value>
       <value compset="_CAM%PHYSTEST">--dyn none --physics-suites adiabatic</value>
 
       <!-- Aquaplanet -->

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_se_cslam_analy_ic/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_se_cslam_analy_ic/shell_commands
@@ -1,2 +1,2 @@
 ./xmlchange CAM_LINKED_LIBS=" "
-./xmlchange --append CAM_CONFIG_OPTS="--analytic_ic"
+./xmlchange --append CAM_CONFIG_OPTS="--analytic-ic"

--- a/test/unit/test_cam_config.py
+++ b/test/unit/test_cam_config.py
@@ -67,7 +67,7 @@ class FakeCase:
             "COMP_ATM" : "cam",
             "EXEROOT"  : "/some/made-up/path",
             "CASEROOT" : "/another/made-up/path",
-            "CAM_CONFIG_OPTS" : "-dyn none --physics-suites mango;papaya",
+            "CAM_CONFIG_OPTS" : "--dyn none --physics-suites mango;papaya",
             "COMP_ROOT_DIR_ATM" : "/a/third/made-up/path",
             "CAM_CPPDEFS" : "UNSET",
             "NTHRDS_ATM" : 1,


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): nusbaume

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

Fixes #357 - Should convert CAM_CONFIG_OPTS argument syntax to use dashes instead of underscores

Describe any changes made to build system:

All arguments that can be used in the `CAM_CONFIG_OPTS` XML variable in a CAM-SIMA case's `env_build.xml` file now use dashes instead of underscores.  Also all single-dash config options (e.g. `-dyn` versus `--dyn`) have been removed to avoid any confusion as users move from CAM to CAM-SIMA). 

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

M       cime_config/cam_config.py
M       cime_config/config_component.xml
  - Convert CAM_CONFIG_OPTS argument syntax to use dashes instead of underscores, and remove single-dash options.  Also add an extra comment.

M       cime_config/testdefs/testmods_dirs/cam/outfrq_se_cslam_analy_ic/shell_commands
  - Update syntax for regression test that used analytic ICs to now use dashes (`--analytic-ic`)

M       test/unit/test_cam_config.py
  - Fix unit test structure that was using a no-longer-supported single-dash config argument.

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:  ALL PASS

derecho/gnu/aux_sima:  ALL PASS

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
