### PR TITLE
Work around a GNU Fortran bug regarding unlimited polymorphic entities

### DIFF
--- a/.github/workflows/fortran_unit_tests.yml
+++ b/.github/workflows/fortran_unit_tests.yml
@@ -37,13 +37,13 @@ jobs:
       - name: Build cam-sima
         run: |
           cmake \
-            -DCMAKE_PREFIX_PATH=/home/runner/work/CAM-SIMA/CAM-SIMA/pFUnit/build/installed \
+            -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/pFUnit/build/installed \
             -DCAM_SIMA_ENABLE_CODE_COVERAGE=ON \
             -B./build \
             -S./test/unit/fortran
           cd build
           make
-      
+
       - name: Run fortran unit tests
         run: |
           cd build && ctest -V --output-on-failure --output-junit test_results.xml
@@ -54,7 +54,7 @@ jobs:
           name: unit-test-results-${{ env.FC }}
           path: build/test_results.xml
 
-      - name: Setup GCov
+      - name: Setup Gcov
         run: |
           python3 -m venv venv
           source venv/bin/activate

--- a/test/unit/fortran/src/core_utils/test_string_core_utils.pf
+++ b/test/unit/fortran/src/core_utils/test_string_core_utils.pf
@@ -91,9 +91,7 @@ subroutine test_stringify_empty_arrays()
 
 end subroutine test_stringify_empty_arrays
 
-! Ignoring this test due to a bug in the GNU compiler >= v12.
-! https://github.com/ESCOMP/CAM-SIMA/pull/326#discussion_r1909520600
-@test(#ifndef= __GNUC__)
+@test
 subroutine test_stringify_character_array
     use funit
     use string_core_utils, only: core_stringify

--- a/test/unit/fortran/src/core_utils/test_string_core_utils.pf
+++ b/test/unit/fortran/src/core_utils/test_string_core_utils.pf
@@ -72,7 +72,7 @@ subroutine test_stringify_empty_arrays()
     use funit
     use string_core_utils, only: core_stringify
 
-    character(128), allocatable :: carr(:)
+    character(len=128), allocatable :: carr(:)
     integer(int32), allocatable :: i32arr(:)
     integer(int64), allocatable :: i64arr(:)
     logical, allocatable :: larr(:)
@@ -95,20 +95,20 @@ subroutine test_stringify_character_array()
     use funit
     use string_core_utils, only: core_stringify
 
-    character(*), parameter :: custom_separator = '<'
-    character(*), parameter :: custom_separator_with_spaces = ' < '
-    character(*), parameter :: expected_default_separator = &
+    character(len=*), parameter :: custom_separator = '<'
+    character(len=*), parameter :: custom_separator_with_spaces = ' < '
+    character(len=*), parameter :: expected_default_separator = &
         'Talc, Gypsum, Calcite, Fluorite, Apatite, Orthoclase, Quartz, Topaz, Corundum, Diamond'
-    character(*), parameter :: expected_custom_separator = &
+    character(len=*), parameter :: expected_custom_separator = &
         'Talc<Gypsum<Calcite<Fluorite<Apatite<Orthoclase<Quartz<Topaz<Corundum<Diamond'
-    character(*), parameter :: expected_custom_separator_with_spaces = &
+    character(len=*), parameter :: expected_custom_separator_with_spaces = &
         'Talc < Gypsum < Calcite < Fluorite < Apatite < Orthoclase < Quartz < Topaz < Corundum < Diamond'
 
-    character(128), allocatable :: carr(:)
+    character(len=128), allocatable :: carr(:)
 
     allocate(carr(10))
 
-    carr(:) = [ character(len(carr)) :: &
+    carr(:) = [ character(len=len(carr)) :: &
         '      Talc', 'Gypsum', 'Calcite', 'Fluorite', 'Apatite', &
         'Orthoclase', 'Quartz', '  Topaz', 'Corundum', 'Diamond' ]
 
@@ -126,13 +126,13 @@ subroutine test_stringify_integer_array()
     use funit
     use string_core_utils, only: core_stringify
 
-    character(*), parameter :: custom_separator = '<'
-    character(*), parameter :: custom_separator_with_spaces = ' < '
-    character(*), parameter :: expected_default_separator = &
+    character(len=*), parameter :: custom_separator = '<'
+    character(len=*), parameter :: custom_separator_with_spaces = ' < '
+    character(len=*), parameter :: expected_default_separator = &
         '-10000, -1000, -100, -10, -1, 1, 10, 100, 1000, 10000'
-    character(*), parameter :: expected_custom_separator = &
+    character(len=*), parameter :: expected_custom_separator = &
         '-10000<-1000<-100<-10<-1<1<10<100<1000<10000'
-    character(*), parameter :: expected_custom_separator_with_spaces = &
+    character(len=*), parameter :: expected_custom_separator_with_spaces = &
         '-10000 < -1000 < -100 < -10 < -1 < 1 < 10 < 100 < 1000 < 10000'
 
     integer(int32), allocatable :: i32arr(:)
@@ -160,14 +160,14 @@ subroutine test_stringify_integer_extreme_values()
     use funit
     use string_core_utils, only: core_stringify
 
-    character(*), parameter :: custom_separator_with_spaces = ' < '
-    character(*), parameter :: expected_int32_default_separator = &
+    character(len=*), parameter :: custom_separator_with_spaces = ' < '
+    character(len=*), parameter :: expected_int32_default_separator = &
         '-2147483647, -1000, -100, -10, -1, 1, 10, 100, 1000, 2147483647'
-    character(*), parameter :: expected_int64_default_separator = &
+    character(len=*), parameter :: expected_int64_default_separator = &
         '-9223372036854775807, -1000, -100, -10, -1, 1, 10, 100, 1000, 9223372036854775807'
-    character(*), parameter :: expected_int32_custom_separator_with_spaces = &
+    character(len=*), parameter :: expected_int32_custom_separator_with_spaces = &
         '-2147483647 < -1000 < -100 < -10 < -1 < 1 < 10 < 100 < 1000 < 2147483647'
-    character(*), parameter :: expected_int64_custom_separator_with_spaces = &
+    character(len=*), parameter :: expected_int64_custom_separator_with_spaces = &
         '-9223372036854775807 < -1000 < -100 < -10 < -1 < 1 < 10 < 100 < 1000 < 9223372036854775807'
 
     integer(int32), allocatable :: i32arr(:)
@@ -193,15 +193,15 @@ subroutine test_stringify_floating_point_array()
     use funit
     use string_core_utils, only: core_stringify
 
-    character(*), parameter :: custom_separator = '<'
-    character(*), parameter :: custom_separator_with_spaces = ' < '
-    character(*), parameter :: expected_default_separator = &
+    character(len=*), parameter :: custom_separator = '<'
+    character(len=*), parameter :: custom_separator_with_spaces = ' < '
+    character(len=*), parameter :: expected_default_separator = &
         '-10000.000000,  -1000.000000,   -100.000000,    -10.000000,     -1.000000, ' // &
         '     1.000000,     10.000000,    100.000000,   1000.000000,  10000.000000'
-    character(*), parameter :: expected_custom_separator = &
+    character(len=*), parameter :: expected_custom_separator = &
         '-10000.000000< -1000.000000<  -100.000000<   -10.000000<    -1.000000<' // &
         '     1.000000<    10.000000<   100.000000<  1000.000000< 10000.000000'
-    character(*), parameter :: expected_custom_separator_with_spaces = &
+    character(len=*), parameter :: expected_custom_separator_with_spaces = &
         '-10000.000000 <  -1000.000000 <   -100.000000 <    -10.000000 <     -1.000000 < ' // &
         '     1.000000 <     10.000000 <    100.000000 <   1000.000000 <  10000.000000'
 
@@ -231,11 +231,11 @@ subroutine test_stringify_floating_point_scientific_notation()
     use funit
     use string_core_utils, only: core_stringify
 
-    character(*), parameter :: custom_separator_with_spaces = ' < '
-    character(*), parameter :: expected_default_separator = &
+    character(len=*), parameter :: custom_separator_with_spaces = ' < '
+    character(len=*), parameter :: expected_default_separator = &
         '-1.000000E+05, -1.000000E+03, -1.000000E+02, -1.000000E+01, -1.000000E+00, ' // &
         ' 1.000000E+00,  1.000000E+01,  1.000000E+02,  1.000000E+03,  1.000000E+05'
-    character(*), parameter :: expected_custom_separator_with_spaces = &
+    character(len=*), parameter :: expected_custom_separator_with_spaces = &
         '-1.000000E+05 < -1.000000E+03 < -1.000000E+02 < -1.000000E+01 < -1.000000E+00 < ' // &
         ' 1.000000E+00 <  1.000000E+01 <  1.000000E+02 <  1.000000E+03 <  1.000000E+05'
 
@@ -260,17 +260,17 @@ subroutine test_stringify_floating_point_extreme_values()
     use funit
     use string_core_utils, only: core_stringify
 
-    character(*), parameter :: custom_separator_with_spaces = ' < '
-    character(*), parameter :: expected_real32_default_separator = &
+    character(len=*), parameter :: custom_separator_with_spaces = ' < '
+    character(len=*), parameter :: expected_real32_default_separator = &
         '-3.402823E+38, -1.000000E+03, -1.000000E+02, -1.000000E+01, -1.000000E+00, ' // &
         ' 1.000000E+00,  1.000000E+01,  1.000000E+02,  1.000000E+03,  3.402823E+38'
-    character(*), parameter :: expected_real64_default_separator = &
+    character(len=*), parameter :: expected_real64_default_separator = &
         '-9.999999E+99, -1.000000E+03, -1.000000E+02, -1.000000E+01, -1.000000E+00, ' // &
         ' 1.000000E+00,  1.000000E+01,  1.000000E+02,  1.000000E+03,  9.999999E+99'
-    character(*), parameter :: expected_real32_custom_separator_with_spaces = &
+    character(len=*), parameter :: expected_real32_custom_separator_with_spaces = &
         '-3.402823E+38 < -1.000000E+03 < -1.000000E+02 < -1.000000E+01 < -1.000000E+00 < ' // &
         ' 1.000000E+00 <  1.000000E+01 <  1.000000E+02 <  1.000000E+03 <  3.402823E+38'
-    character(*), parameter :: expected_real64_custom_separator_with_spaces = &
+    character(len=*), parameter :: expected_real64_custom_separator_with_spaces = &
         '-9.999999E+99 < -1.000000E+03 < -1.000000E+02 < -1.000000E+01 < -1.000000E+00 < ' // &
         ' 1.000000E+00 <  1.000000E+01 <  1.000000E+02 <  1.000000E+03 <  9.999999E+99'
 
@@ -296,13 +296,13 @@ subroutine test_stringify_logical_array()
     use funit
     use string_core_utils, only: core_stringify
 
-    character(*), parameter :: custom_separator = '.or.'
-    character(*), parameter :: custom_separator_with_spaces = ' .or. '
-    character(*), parameter :: expected_default_separator = &
+    character(len=*), parameter :: custom_separator = '.or.'
+    character(len=*), parameter :: custom_separator_with_spaces = ' .or. '
+    character(len=*), parameter :: expected_default_separator = &
         'T, F, T, F, T, F, T, F, T, F'
-    character(*), parameter :: expected_custom_separator = &
+    character(len=*), parameter :: expected_custom_separator = &
         'T.or.F.or.T.or.F.or.T.or.F.or.T.or.F.or.T.or.F'
-    character(*), parameter :: expected_custom_separator_with_spaces = &
+    character(len=*), parameter :: expected_custom_separator_with_spaces = &
         'T .or. F .or. T .or. F .or. T .or. F .or. T .or. F .or. T .or. F'
 
     logical, allocatable :: larr(:)

--- a/test/unit/fortran/src/core_utils/test_string_core_utils.pf
+++ b/test/unit/fortran/src/core_utils/test_string_core_utils.pf
@@ -79,79 +79,99 @@ subroutine test_stringify_empty_arrays()
     real(real32), allocatable :: r32arr(:)
     real(real64), allocatable :: r64arr(:)
 
-
     allocate(carr(0), i32arr(0), i64arr(0), larr(0), r32arr(0), r64arr(0))
 
-    @assertEqual("", core_stringify(carr))
-    @assertEqual("", core_stringify(i32arr))
-    @assertEqual("", core_stringify(i64arr))
-    @assertEqual("", core_stringify(larr))
-    @assertEqual("", core_stringify(r32arr))
-    @assertEqual("", core_stringify(r64arr))
-
+    ! Empty arrays of any intrinsic data types should result in empty character strings.
+    @assertEqual('', core_stringify(carr))
+    @assertEqual('', core_stringify(i32arr))
+    @assertEqual('', core_stringify(i64arr))
+    @assertEqual('', core_stringify(larr))
+    @assertEqual('', core_stringify(r32arr))
+    @assertEqual('', core_stringify(r64arr))
 end subroutine test_stringify_empty_arrays
 
 @test
-subroutine test_stringify_character_array
+subroutine test_stringify_character_array()
     use funit
     use string_core_utils, only: core_stringify
 
+    character(*), parameter :: custom_separator = '<'
+    character(*), parameter :: custom_separator_with_spaces = ' < '
+    character(*), parameter :: expected_default_separator = &
+        'Talc, Gypsum, Calcite, Fluorite, Apatite, Orthoclase, Quartz, Topaz, Corundum, Diamond'
+    character(*), parameter :: expected_custom_separator = &
+        'Talc<Gypsum<Calcite<Fluorite<Apatite<Orthoclase<Quartz<Topaz<Corundum<Diamond'
+    character(*), parameter :: expected_custom_separator_with_spaces = &
+        'Talc < Gypsum < Calcite < Fluorite < Apatite < Orthoclase < Quartz < Topaz < Corundum < Diamond'
+
     character(128), allocatable :: carr(:)
+
     allocate(carr(10))
 
     carr(:) = [ character(len(carr)) :: &
         '      Talc', 'Gypsum', 'Calcite', 'Fluorite', 'Apatite', &
         'Orthoclase', 'Quartz', '  Topaz', 'Corundum', 'Diamond' ]
 
-    @assertEqual('Talc, Gypsum, Calcite, Fluorite, Apatite, Orthoclase, Quartz, Topaz, Corundum, Diamond', core_stringify(carr))
-    @assertEqual('Talc<Gypsum<Calcite<Fluorite<Apatite<Orthoclase<Quartz<Topaz<Corundum<Diamond', core_stringify(carr, separator='<'))
-    @assertEqual('Talc < Gypsum < Calcite < Fluorite < Apatite < Orthoclase < Quartz < Topaz < Corundum < Diamond', core_stringify(carr, separator=' < '))
+    ! Spaces around each value should be trimmed. The separator should default to ", ".
+    @assertEqual(expected_default_separator, core_stringify(carr))
 
+    ! Spaces around the separator should be preserved.
+    @assertEqual(expected_custom_separator, core_stringify(carr, separator=custom_separator))
+    @assertEqual(expected_custom_separator_with_spaces, core_stringify(carr, separator=custom_separator_with_spaces))
 end subroutine test_stringify_character_array
 
 @test
-subroutine test_stringify_integer_array
+subroutine test_stringify_integer_array()
     use, intrinsic :: iso_fortran_env, only: int32, int64
     use funit
     use string_core_utils, only: core_stringify
 
+    character(*), parameter :: custom_separator = '<'
+    character(*), parameter :: custom_separator_with_spaces = ' < '
+    character(*), parameter :: expected_default_separator = &
+        '-10000, -1000, -100, -10, -1, 1, 10, 100, 1000, 10000'
+    character(*), parameter :: expected_custom_separator = &
+        '-10000<-1000<-100<-10<-1<1<10<100<1000<10000'
+    character(*), parameter :: expected_custom_separator_with_spaces = &
+        '-10000 < -1000 < -100 < -10 < -1 < 1 < 10 < 100 < 1000 < 10000'
+
     integer(int32), allocatable :: i32arr(:)
     integer(int64), allocatable :: i64arr(:)
-    character(len=*), parameter :: separator = "<"
-    character(len=*), parameter :: separator_with_space = " < "
-    character(len=*), parameter :: no_separator_expected = '-10000, -1000, -100, -10, -1, 1, 10, 100, 1000, 10000'
-    character(len=*), parameter :: separator_expected    = '-10000<-1000<-100<-10<-1<1<10<100<1000<10000'
-    character(len=*), parameter :: separator_with_space_expected = '-10000 < -1000 < -100 < -10 < -1 < 1 < 10 < 100 < 1000 < 10000'
 
     allocate(i32arr(10), i64arr(10))
 
     i32arr(:) = [-10000, -1000, -100, -10, -1, 1, 10, 100, 1000, 10000]
     i64arr(:) = int(i32arr, int64)
 
-    @assertEqual(no_separator_expected, core_stringify(i32arr))
-    @assertEqual(no_separator_expected, core_stringify(i64arr))
+    ! Spaces around each value should be trimmed. The separator should default to ", ".
+    @assertEqual(expected_default_separator, core_stringify(i32arr))
+    @assertEqual(expected_default_separator, core_stringify(i64arr))
 
-    @assertEqual(separator_expected, core_stringify(i32arr, separator=separator))
-    @assertEqual(separator_expected, core_stringify(i64arr, separator=separator))
-
-    @assertEqual(separator_with_space_expected, core_stringify(i32arr, separator=separator_with_space))
-    @assertEqual(separator_with_space_expected, core_stringify(i64arr, separator=separator_with_space))
-
+    ! Spaces around the separator should be preserved.
+    @assertEqual(expected_custom_separator, core_stringify(i32arr, separator=custom_separator))
+    @assertEqual(expected_custom_separator, core_stringify(i64arr, separator=custom_separator))
+    @assertEqual(expected_custom_separator_with_spaces, core_stringify(i32arr, separator=custom_separator_with_spaces))
+    @assertEqual(expected_custom_separator_with_spaces, core_stringify(i64arr, separator=custom_separator_with_spaces))
 end subroutine test_stringify_integer_array
 
 @test
-subroutine test_stringify_integer_extreme_values
+subroutine test_stringify_integer_extreme_values()
     use, intrinsic :: iso_fortran_env, only: int32, int64
     use funit
     use string_core_utils, only: core_stringify
 
+    character(*), parameter :: custom_separator_with_spaces = ' < '
+    character(*), parameter :: expected_int32_default_separator = &
+        '-2147483647, -1000, -100, -10, -1, 1, 10, 100, 1000, 2147483647'
+    character(*), parameter :: expected_int64_default_separator = &
+        '-9223372036854775807, -1000, -100, -10, -1, 1, 10, 100, 1000, 9223372036854775807'
+    character(*), parameter :: expected_int32_custom_separator_with_spaces = &
+        '-2147483647 < -1000 < -100 < -10 < -1 < 1 < 10 < 100 < 1000 < 2147483647'
+    character(*), parameter :: expected_int64_custom_separator_with_spaces = &
+        '-9223372036854775807 < -1000 < -100 < -10 < -1 < 1 < 10 < 100 < 1000 < 9223372036854775807'
+
     integer(int32), allocatable :: i32arr(:)
     integer(int64), allocatable :: i64arr(:)
-    character(len=*), parameter :: separator_with_space = " < "
-    character(len=*), parameter :: int32_no_separator_expected = '-2147483647, -1000, -100, -10, -1, 1, 10, 100, 1000, 2147483647'
-    character(len=*), parameter :: int32_separator_with_space_expected = '-2147483647 < -1000 < -100 < -10 < -1 < 1 < 10 < 100 < 1000 < 2147483647'
-    character(len=*), parameter :: int64_no_separator_expected =  '-9223372036854775807, -1000, -100, -10, -1, 1, 10, 100, 1000, 9223372036854775807'
-    character(len=*), parameter :: int64_separator_with_space_expected = '-9223372036854775807 < -1000 < -100 < -10 < -1 < 1 < 10 < 100 < 1000 < 9223372036854775807'
 
     allocate(i32arr(10), i64arr(10))
 
@@ -160,97 +180,102 @@ subroutine test_stringify_integer_extreme_values
     i64arr(1) = -huge(i64arr)
     i64arr(10) = huge(i64arr)
 
-    @assertEqual(int32_no_separator_expected, core_stringify(i32arr))
-    @assertEqual(int64_no_separator_expected, core_stringify(i64arr))
-    @assertEqual(int32_separator_with_space_expected, core_stringify(i32arr, separator=separator_with_space))
-    @assertEqual(int64_separator_with_space_expected, core_stringify(i64arr, separator=separator_with_space))
-
+    ! Extreme values should be handled properly.
+    @assertEqual(expected_int32_default_separator, core_stringify(i32arr))
+    @assertEqual(expected_int64_default_separator, core_stringify(i64arr))
+    @assertEqual(expected_int32_custom_separator_with_spaces, core_stringify(i32arr, separator=custom_separator_with_spaces))
+    @assertEqual(expected_int64_custom_separator_with_spaces, core_stringify(i64arr, separator=custom_separator_with_spaces))
 end subroutine test_stringify_integer_extreme_values
 
 @test
-subroutine test_stringify_floating_point_values
+subroutine test_stringify_floating_point_array()
     use, intrinsic :: iso_fortran_env, only: real32, real64
     use funit
     use string_core_utils, only: core_stringify
 
+    character(*), parameter :: custom_separator = '<'
+    character(*), parameter :: custom_separator_with_spaces = ' < '
+    character(*), parameter :: expected_default_separator = &
+        '-10000.000000,  -1000.000000,   -100.000000,    -10.000000,     -1.000000, ' // &
+        '     1.000000,     10.000000,    100.000000,   1000.000000,  10000.000000'
+    character(*), parameter :: expected_custom_separator = &
+        '-10000.000000< -1000.000000<  -100.000000<   -10.000000<    -1.000000<' // &
+        '     1.000000<    10.000000<   100.000000<  1000.000000< 10000.000000'
+    character(*), parameter :: expected_custom_separator_with_spaces = &
+        '-10000.000000 <  -1000.000000 <   -100.000000 <    -10.000000 <     -1.000000 < ' // &
+        '     1.000000 <     10.000000 <    100.000000 <   1000.000000 <  10000.000000'
+
     real(real32), allocatable :: r32arr(:)
     real(real64), allocatable :: r64arr(:)
-    character(len=*), parameter :: expected_no_separator = &
-    '-10000.000000,  -1000.000000,   -100.000000,    -10.000000,     -1.000000, ' // &
-    '     1.000000,     10.000000,    100.000000,   1000.000000,  10000.000000'
-    character(len=*), parameter :: expected_with_separator = &
-    '-10000.000000< -1000.000000<  -100.000000<   -10.000000<    -1.000000<' // &
-    '     1.000000<    10.000000<   100.000000<  1000.000000< 10000.000000'
-    character(len=*), parameter :: expected_with_separator_space = &
-    '-10000.000000 <  -1000.000000 <   -100.000000 <    -10.000000 <     -1.000000 < ' // &
-    '     1.000000 <     10.000000 <    100.000000 <   1000.000000 <  10000.000000'
 
     allocate(r32arr(10), r64arr(10))
 
     r32arr(:) = [-10000.0, -1000.0, -100.0, -10.0, -1.0, 1.0, 10.0, 100.0, 1000.0, 10000.0]
     r64arr(:) = real(r32arr, real64)
 
-    @assertEqual(expected_no_separator, core_stringify(r32arr))
-    @assertEqual(expected_no_separator, core_stringify(r64arr))
-    @assertEqual(expected_with_separator, core_stringify(r32arr, separator='<'))
-    @assertEqual(expected_with_separator, core_stringify(r64arr, separator='<'))
-    @assertEqual(expected_with_separator_space, core_stringify(r32arr, separator=' < '))
-    @assertEqual(expected_with_separator_space, core_stringify(r64arr, separator=' < '))
+    ! Each value should have a fixed width of 13. Only negative values should have signs.
+    ! The separator should default to ", ".
+    @assertEqual(expected_default_separator, core_stringify(r32arr))
+    @assertEqual(expected_default_separator, core_stringify(r64arr))
 
-end subroutine test_stringify_floating_point_values
+    ! Spaces around the separator should be preserved.
+    @assertEqual(expected_custom_separator, core_stringify(r32arr, separator=custom_separator))
+    @assertEqual(expected_custom_separator, core_stringify(r64arr, separator=custom_separator))
+    @assertEqual(expected_custom_separator_with_spaces, core_stringify(r32arr, separator=custom_separator_with_spaces))
+    @assertEqual(expected_custom_separator_with_spaces, core_stringify(r64arr, separator=custom_separator_with_spaces))
+end subroutine test_stringify_floating_point_array
 
 @test
-subroutine test_stringify_floating_point_scientific_notation
+subroutine test_stringify_floating_point_scientific_notation()
     use, intrinsic :: iso_fortran_env, only: real32, real64
     use funit
     use string_core_utils, only: core_stringify
 
-    real(real32), allocatable :: r32arr(:)
-    real(real64), allocatable :: r64arr(:)
-    character(len=*), parameter :: expected_no_separator = &
+    character(*), parameter :: custom_separator_with_spaces = ' < '
+    character(*), parameter :: expected_default_separator = &
         '-1.000000E+05, -1.000000E+03, -1.000000E+02, -1.000000E+01, -1.000000E+00, ' // &
         ' 1.000000E+00,  1.000000E+01,  1.000000E+02,  1.000000E+03,  1.000000E+05'
-    character(len=*), parameter :: expected_with_separator = &
+    character(*), parameter :: expected_custom_separator_with_spaces = &
         '-1.000000E+05 < -1.000000E+03 < -1.000000E+02 < -1.000000E+01 < -1.000000E+00 < ' // &
         ' 1.000000E+00 <  1.000000E+01 <  1.000000E+02 <  1.000000E+03 <  1.000000E+05'
 
+    real(real32), allocatable :: r32arr(:)
+    real(real64), allocatable :: r64arr(:)
+
     allocate(r32arr(10), r64arr(10))
 
-    r32arr(:) = [-10000.0, -1000.0, -100.0, -10.0, -1.0, 1.0, 10.0, 100.0, 1000.0, 10000.0]
+    r32arr(:) = [-100000.0, -1000.0, -100.0, -10.0, -1.0, 1.0, 10.0, 100.0, 1000.0, 100000.0]
     r64arr(:) = real(r32arr, real64)
 
-    r32arr(1) = -1.0E+5_real32
-    r32arr(10) = 1.0E+5_real32
-    r64arr(1) = -1.0E+5_real64
-    r64arr(10) = 1.0E+5_real64
-
-    @assertEqual(expected_no_separator, core_stringify(r32arr))
-    @assertEqual(expected_no_separator, core_stringify(r64arr))
-    @assertEqual(expected_with_separator, core_stringify(r32arr, separator=' < '))
-    @assertEqual(expected_with_separator, core_stringify(r64arr, separator=' < '))
-
+    ! Scientific notation should be enabled if there is any value with a magnitude >= 1.0E+5.
+    @assertEqual(expected_default_separator, core_stringify(r32arr))
+    @assertEqual(expected_default_separator, core_stringify(r64arr))
+    @assertEqual(expected_custom_separator_with_spaces, core_stringify(r32arr, separator=custom_separator_with_spaces))
+    @assertEqual(expected_custom_separator_with_spaces, core_stringify(r64arr, separator=custom_separator_with_spaces))
 end subroutine test_stringify_floating_point_scientific_notation
 
 @test
-subroutine test_stringify_floating_point_extreme_values
+subroutine test_stringify_floating_point_extreme_values()
     use, intrinsic :: iso_fortran_env, only: real32, real64
     use funit
     use string_core_utils, only: core_stringify
 
-    real(real32), allocatable :: r32arr(:)
-    real(real64), allocatable :: r64arr(:)
-    character(len=*), parameter :: real32_expected_no_separator = &
+    character(*), parameter :: custom_separator_with_spaces = ' < '
+    character(*), parameter :: expected_real32_default_separator = &
         '-3.402823E+38, -1.000000E+03, -1.000000E+02, -1.000000E+01, -1.000000E+00, ' // &
         ' 1.000000E+00,  1.000000E+01,  1.000000E+02,  1.000000E+03,  3.402823E+38'
-    character(len=*), parameter :: real64_expected_no_separator = &
+    character(*), parameter :: expected_real64_default_separator = &
         '-9.999999E+99, -1.000000E+03, -1.000000E+02, -1.000000E+01, -1.000000E+00, ' // &
         ' 1.000000E+00,  1.000000E+01,  1.000000E+02,  1.000000E+03,  9.999999E+99'
-    character(len=*), parameter :: real32_expected_with_separator = &
+    character(*), parameter :: expected_real32_custom_separator_with_spaces = &
         '-3.402823E+38 < -1.000000E+03 < -1.000000E+02 < -1.000000E+01 < -1.000000E+00 < ' // &
         ' 1.000000E+00 <  1.000000E+01 <  1.000000E+02 <  1.000000E+03 <  3.402823E+38'
-    character(len=*), parameter :: real64_expected_with_separator = &
+    character(*), parameter :: expected_real64_custom_separator_with_spaces = &
         '-9.999999E+99 < -1.000000E+03 < -1.000000E+02 < -1.000000E+01 < -1.000000E+00 < ' // &
         ' 1.000000E+00 <  1.000000E+01 <  1.000000E+02 <  1.000000E+03 <  9.999999E+99'
+
+    real(real32), allocatable :: r32arr(:)
+    real(real64), allocatable :: r64arr(:)
 
     allocate(r32arr(10), r64arr(10))
 
@@ -259,27 +284,38 @@ subroutine test_stringify_floating_point_extreme_values
     r64arr(1) = -9.999999E+99_real64 ! Arbitrarily limited by the "es13.6e2" format specification.
     r64arr(10) = 9.999999E+99_real64 ! Arbitrarily limited by the "es13.6e2" format specification.
 
-    @assertEqual(real32_expected_no_separator, core_stringify(r32arr))
-    @assertEqual(real64_expected_no_separator, core_stringify(r64arr))
-    @assertEqual(real32_expected_with_separator, core_stringify(r32arr, separator=' < '))
-    @assertEqual(real64_expected_with_separator, core_stringify(r64arr, separator=' < '))
-
+    ! Extreme values should be handled properly.
+    @assertEqual(expected_real32_default_separator, core_stringify(r32arr))
+    @assertEqual(expected_real64_default_separator, core_stringify(r64arr))
+    @assertEqual(expected_real32_custom_separator_with_spaces, core_stringify(r32arr, separator=custom_separator_with_spaces))
+    @assertEqual(expected_real64_custom_separator_with_spaces, core_stringify(r64arr, separator=custom_separator_with_spaces))
 end subroutine test_stringify_floating_point_extreme_values
 
 @test
-subroutine test_stringify_logical_values
+subroutine test_stringify_logical_array()
     use funit
     use string_core_utils, only: core_stringify
 
+    character(*), parameter :: custom_separator = '.or.'
+    character(*), parameter :: custom_separator_with_spaces = ' .or. '
+    character(*), parameter :: expected_default_separator = &
+        'T, F, T, F, T, F, T, F, T, F'
+    character(*), parameter :: expected_custom_separator = &
+        'T.or.F.or.T.or.F.or.T.or.F.or.T.or.F.or.T.or.F'
+    character(*), parameter :: expected_custom_separator_with_spaces = &
+        'T .or. F .or. T .or. F .or. T .or. F .or. T .or. F .or. T .or. F'
+
     logical, allocatable :: larr(:)
+
     allocate(larr(10))
 
     larr(:) = .true.
     larr(2:10:2) = .false.
 
-    @assertEqual('T, F, T, F, T, F, T, F, T, F', core_stringify(larr))
-    @assertEqual('T.or.F.or.T.or.F.or.T.or.F.or.T.or.F.or.T.or.F', core_stringify(larr, separator=".or."))
-    @assertEqual('T .or. F .or. T .or. F .or. T .or. F .or. T .or. F .or. T .or. F', core_stringify(larr, separator=" .or. "))
+    ! Spaces around each value should be trimmed. The separator should default to ", ".
+    @assertEqual(expected_default_separator, core_stringify(larr))
 
-end subroutine test_stringify_logical_values
-
+    ! Spaces around the separator should be preserved.
+    @assertEqual(expected_custom_separator, core_stringify(larr, separator=custom_separator))
+    @assertEqual(expected_custom_separator_with_spaces, core_stringify(larr, separator=custom_separator_with_spaces))
+end subroutine test_stringify_logical_array


### PR DESCRIPTION
### Tag name (required for release branches):

None

### Originator(s):

kuanchihwang

### Descriptions (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

The `stringify` utility function uses an advanced Fortran language feature: **Polymorphism**. Unfortunately, recent GNU Fortran versions (>= 12) have problems with it. When a character string array is passed as the actual argument to an unlimited polymorphic dummy argument, its array index and length parameter are mishandled.

This compiler bug is perhaps the manifestation of GCC Bugzilla [Bug 100819](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100819). A workaround, which is implemented by this PR, is to use a temporary character string array. As a result, the unit tests no longer need to be guarded by the `__GNUC__` macro.

Additionally, this PR also harmonizes the code style in unit tests.

### Describe any changes made to the build system:

None

### Describe any changes made to the namelist:

None

### List any changes to the defaults for the input datasets (e.g., boundary datasets):

None

### List all files eliminated and why:

None

### List all files added and what they do:

None

### List all existing files that have been modified, and describe the changes:

* `M       .github/workflows/fortran_unit_tests.yml`
  * Avoid hard-coded paths in GitHub Actions
* `M       src/core_utils/string_core_utils.F90`
  * Work around a GNU Fortran bug regarding unlimited polymorphic entities
* `M       src/dynamics/mpas/driver/dyn_mpas_subdriver.F90`
  * Work around a GNU Fortran bug regarding unlimited polymorphic entities
* `M       test/unit/fortran/src/core_utils/test_string_core_utils.pf`
  * Remove condition on GNU Fortran
  * Harmonize code style in unit tests

### Regression tests:

No changes to any existing tests with respect to the last baseline, `sima0_03_000`.
