### PR TITLE
Fix the standard name of `zvir` in the `physconst` module

### DIFF
--- a/src/data/physconst.meta
+++ b/src/data/physconst.meta
@@ -274,7 +274,7 @@
   dimensions = ()
   protected = True
 [ zvir ]
-  standard_name = ratio_of_dry_air_to_water_vapor_gas_constants_minus_one
+  standard_name = ratio_of_water_vapor_to_dry_air_gas_constants_minus_one
   units = 1
   type = real | kind = kind_phys
   dimensions = ()


### PR DESCRIPTION
### Tag name (required for release branches):

None

### Originator(s):

kuanchihwang

### Descriptions (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

`zvir` is defined to be `shr_const_zvir` <sup>[[1]](https://github.com/ESCOMP/CAM-SIMA/blob/sima0_04_000/src/data/physconst.F90#L99)</sup>, which comes from the `shr_const_mod` module <sup>[[2]](https://github.com/ESCOMP/CAM-SIMA/blob/sima0_04_000/src/data/physconst.F90#L24)</sup>. There, the definition of `shr_const_zvir` is actually $R_v/R_d - 1.0$ <sup>[[3]](https://github.com/ESCOMP/CESM_share/blob/share1.1.9/src/shr_const_mod.F90#L31)</sup>.

Apparently, the standard name of `zvir` is inverted (ratio_of_dry_air_to_water_vapor_gas_constants_minus_one vs. ratio_of_water_vapor_to_dry_air_gas_constants_minus_one <sup>[[4]](https://github.com/ESCOMP/ESMStandardNames/blob/0e5ae18a8cf06b51dc2fca9efee2aaf09677609a/standard_names.xml#L116)</sup>).

### Describe any changes made to the build system:

None

### Describe any changes made to the namelist:

None

### List any changes to the defaults for the input datasets (e.g., boundary datasets):

None

### List all files eliminated and why:

None

### List all files added and what they do:

None

### List all existing files that have been modified, and describe the changes:

* `M       src/data/physconst.meta`
  * Fix the standard name of `zvir`

### Regression tests:

No changes to any existing tests. Note that however:

* `SMS_Ln2.ne5_ne5_mg37.FPHYStest.derecho_gnu.cam-outfrq_hack_shallow_derecho`
  * Since the `sima0_04_000` tag, this test always fails due to non-deterministic results in the `CMFMC`, `ZMDLF`, and `SHDLF` variables
