### PR TITLE
Check initial value attribute(s)

### DIFF
--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -349,7 +349,7 @@
               units="flag" type="logical">
       <long_name>flag indicating if dynamical core energy is not consistent with CAM physics and to perform adjustment of temperature and temperature tendency</long_name>
       <initial_value>.false.</initial_value>
-      <initial_value dycore="SE,MPAS">.true.</initial_value>
+      <initial_value dyn="SE,MPAS">.true.</initial_value>
     </variable>
     <!-- Timestep properties -->
     <variable local_name="is_first_timestep"
@@ -392,7 +392,7 @@
               standard_name="dycore_calculates_geopotential_using_logarithms"
               units="flag" type="logical" access="protected">
       <initial_value>.false.</initial_value>
-      <initial_value dycore="SE,FV">.true.</initial_value>
+      <initial_value dyn="SE,FV">.true.</initial_value>
     </variable>
     <ddt type="physics_state">
       <data>air_temperature</data>

--- a/src/data/registry_v1_0.xsd
+++ b/src/data/registry_v1_0.xsd
@@ -96,7 +96,7 @@
 
   <xs:attribute name="access"                  type="access_type"/>
   <xs:attribute name="allocatable"             type="allocation_type"/>
-  <xs:attribute name="dycore"                  type="dycore_type"/>
+  <xs:attribute name="dyn"                     type="dycore_type"/>
   <xs:attribute name="extends"                 type="fortran_id_type"/>
   <xs:attribute name="kind"                    type="fortran_id_type"/>
   <xs:attribute name="local_name"              type="fortran_id_type"/>
@@ -130,7 +130,10 @@
   <xs:complexType name="initial_value">
     <xs:simpleContent>
       <xs:extension base="xs:string">
-        <xs:attribute ref="dycore" use="optional" default=""/>
+	<!--- If adding a new attribute, also modify generate_registry_data.py
+		to check the attribute
+	-->
+        <xs:attribute ref="dyn" use="optional" default=""/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -192,7 +195,7 @@
   <xs:complexType name="data_type">
     <xs:simpleContent>
       <xs:extension base="standard_name_type">
-        <xs:attribute ref="dycore" use="optional" default=""/>
+        <xs:attribute ref="dyn" use="optional" default=""/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>

--- a/test/unit/python/sample_files/physics_types_complete.F90
+++ b/test/unit/python/sample_files/physics_types_complete.F90
@@ -29,7 +29,7 @@ module physics_types_complete
 !! \htmlinclude physics_base.html
   type, bind(C) :: physics_base
     ! ncol: Number of horizontal columns
-    integer                    :: ncol = 0
+    integer                    :: ncol = 1
     ! pver: Number of vertical layers
     integer                    :: pver = 0
   end type physics_base
@@ -197,7 +197,7 @@ CONTAINS
       phys_state%q(:,:,ix_cld_liq) = nan
     end if
     if (set_init_val) then
-      phys_state%ncol = 0
+      phys_state%ncol = 1
     end if
     if (set_init_val) then
       phys_state%pver = 0

--- a/test/unit/python/sample_files/physics_types_simple.F90
+++ b/test/unit/python/sample_files/physics_types_simple.F90
@@ -26,7 +26,7 @@ module physics_types_simple
 !> \section arg_table_physics_types_simple  Argument Table
 !! \htmlinclude physics_types_simple.html
   ! ncol: Number of horizontal columns
-  integer,         public,          protected :: ncol = 1
+  integer,         public,          protected :: ncol = 0
   ! latitude: Latitude
   real(kind_phys), public, pointer, protected :: latitude(:) => NULL()
   ! longitude: Longitude
@@ -65,7 +65,7 @@ CONTAINS
     end if
 
     if (set_init_val) then
-      ncol = 1
+      ncol = 0
     end if
     if (associated(latitude)) then
       if (reallocate) then

--- a/test/unit/python/sample_files/physics_types_simple.F90
+++ b/test/unit/python/sample_files/physics_types_simple.F90
@@ -26,7 +26,7 @@ module physics_types_simple
 !> \section arg_table_physics_types_simple  Argument Table
 !! \htmlinclude physics_types_simple.html
   ! ncol: Number of horizontal columns
-  integer,         public,          protected :: ncol = 0
+  integer,         public,          protected :: ncol = 1
   ! latitude: Latitude
   real(kind_phys), public, pointer, protected :: latitude(:) => NULL()
   ! longitude: Longitude
@@ -65,7 +65,7 @@ CONTAINS
     end if
 
     if (set_init_val) then
-      ncol = 0
+      ncol = 1
     end if
     if (associated(latitude)) then
       if (reallocate) then

--- a/test/unit/python/sample_files/reg_good_complete.xml
+++ b/test/unit/python/sample_files/reg_good_complete.xml
@@ -9,6 +9,8 @@
               units="count" type="integer" access="protected">
       <long_name>Number of horizontal columns</long_name>
       <initial_value>0</initial_value>
+      <initial_value dyn='SE'>1</initial_value>
+      <initial_value dyn='FV,MPAS'>2</initial_value>
     </variable>
     <variable local_name="pver" standard_name="vertical_layer_dimension"
               units="count" type="integer" access="protected">

--- a/test/unit/python/sample_files/reg_good_ddt.xml
+++ b/test/unit/python/sample_files/reg_good_ddt.xml
@@ -31,9 +31,9 @@
       <initial_value>rair/cpair</initial_value>
     </variable>
     <ddt type="physics_state">
-      <data dycore="FV,EUL,SE">horizontal_dimension</data>
-      <data dycore="SE">latitude</data>
-      <data dycore="FV">longitude</data>
+      <data dyn="FV,EUL,SE">horizontal_dimension</data>
+      <data dyn="SE">latitude</data>
+      <data dyn="FV">longitude</data>
     </ddt>
     <variable local_name="phys_state"
               standard_name="physics_state_due_to_dynamics"

--- a/test/unit/python/sample_files/reg_good_mf.xml
+++ b/test/unit/python/sample_files/reg_good_mf.xml
@@ -31,9 +31,9 @@
       <initial_value>rair/cpair</initial_value>
     </variable>
     <ddt type="physics_state">
-      <data dycore="FV,EUL,SE">horizontal_dimension</data>
-      <data dycore="SE">latitude</data>
-      <data dycore="FV">longitude</data>
+      <data dyn="FV,EUL,SE">horizontal_dimension</data>
+      <data dyn="SE">latitude</data>
+      <data dyn="FV">longitude</data>
     </ddt>
     <variable local_name="phys_state"
               standard_name="physics_state_due_to_dynamics"

--- a/test/unit/python/sample_files/reg_good_simple.xml
+++ b/test/unit/python/sample_files/reg_good_simple.xml
@@ -7,7 +7,7 @@
               units="count" type="integer" access="protected">
       <long_name>Number of horizontal columns</long_name>
       <initial_value>0</initial_value>
-      <initial_value dyn="SE,FV">1</initial_value>
+      <initial_value dyn="SE">1</initial_value>
     </variable>
     <variable local_name="latitude" standard_name="latitude"
               units="radians" type="real" kind="kind_phys"

--- a/test/unit/python/sample_files/reg_good_simple.xml
+++ b/test/unit/python/sample_files/reg_good_simple.xml
@@ -7,6 +7,7 @@
               units="count" type="integer" access="protected">
       <long_name>Number of horizontal columns</long_name>
       <initial_value>0</initial_value>
+      <initial_value dyn="SE,FV">1</initial_value>
     </variable>
     <variable local_name="latitude" standard_name="latitude"
               units="radians" type="real" kind="kind_phys"

--- a/test/unit/python/test_registry.py
+++ b/test/unit/python/test_registry.py
@@ -812,10 +812,10 @@ class RegistryTest(unittest.TestCase):
                         new_ddt = ET.SubElement(obj, "ddt")
                         new_ddt.set("type", dtype)
                         data_elem = ET.SubElement(new_ddt, "data")
-                        data_elem.set("dycore", "EUL")
+                        data_elem.set("dyn", "EUL")
                         data_elem.text = 'latitude'
                         data_elem = ET.SubElement(new_ddt, "data")
-                        data_elem.set("dycore", "EUL")
+                        data_elem.set("dyn", "EUL")
                         data_elem.text = 'longitude'
                         break
                     # End if


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): peverwhee

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

Adds logic to check the initial_value `dycore` attribute, if present, against the dycore. Hopefully also will be "easy" to add additional attributes in the future.

The logic is:
- Will pick the initial_value entry with the "most" attribute matches (which, right now, just means it'll pick the default if the dycore doesn't match other entries or if there are no dycore-specific entries)
- Will error if there is a "tie" (multiple entries have the same number of attribute matches)

Describe any changes made to build system:
**M   src/data/generate_registry_data.py**
- check dycore attribute for initial_value, if present
- also update "dycore" to "dyn"

**M src/data/registry.xml**
- update "dycore" to "dyn"

**M src/data/registry_v1_0.xsd**
- update "dycore" to "dyn"

Describe any changes made to the namelist: none

List any changes to the defaults for the input datasets (e.g. boundary datasets): none

List all files eliminated and why: none

List all files added and what they do: none

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
**M  test/unit/python/sample_files/*.xml**
- add additional options for dycore initial_value attribute

**M test/unit/python/sample_files/*.F90**
- update expected files corresponding to .xml updates

**M test/unit/python/test_registry.py**
- change "dycore" to "dyn"

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima: all PASS

derecho/gnu/aux_sima: all PASS

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
