### PR TITLE
Check for and add missing error code handling for PIO calls

### DIFF
--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -1995,6 +1995,9 @@ subroutine set_phis(dyn_in)
          call endrun(subname//': dimension ncol not found in bnd_topo file')
       end if
       ierr = pio_inq_dimlen(fh_topo, ncol_did, ncol_size)
+      if (ierr /= PIO_NOERR) then
+         call endrun(subname//': dimension ncol does not have a value in bnd_topo file')
+      end if
       if (ncol_size /= dyn_cols) then
          if (masterproc) then
             write(iulog,*) subname//': ncol_size=', ncol_size, ' : dyn_cols=', dyn_cols

--- a/src/utils/cam_pio_utils.F90
+++ b/src/utils/cam_pio_utils.F90
@@ -940,6 +940,7 @@ CONTAINS
             strt = 1     ! cnt set by cam_pio_var_info
             exists = use_scam_limits(File, strt, cnt,filedims)
          end if
+         ! Internal PIO error handling is in effect, so need to check return codes
          if (ndims == 3) then
             ierr = pio_inq_dimname(File, dimids(3), tmpname)
             if (trim(tmpname) /= 'time') then

--- a/src/utils/cam_pio_utils.F90
+++ b/src/utils/cam_pio_utils.F90
@@ -940,7 +940,7 @@ CONTAINS
             strt = 1     ! cnt set by cam_pio_var_info
             exists = use_scam_limits(File, strt, cnt,filedims)
          end if
-         ! Internal PIO error handling is in effect, so need to check return codes
+         ! Internal PIO error handling is in effect, so no need to check return codes
          if (ndims == 3) then
             ierr = pio_inq_dimname(File, dimids(3), tmpname)
             if (trim(tmpname) /= 'time') then


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): cacraig

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
Closes #175: Check PIO return codes

  - src/dynamics/none/dyn_grid.F90---------     No PIO function return codes found that weren't checked
- src/dynamics/utils/hycoef.F90------------ No PIO function return codes found that weren't checked
- src/dynamics/se/native_mapping.F90---- No PIO function return codes found that weren't checked
- src/dynamics/se/dyn_comp.F90---------- Put in one check (was probably unnecessary, but won't hurt)
- src/dynamics/se/dyn_grid.F90------------ No PIO function return codes found that weren't checked
- src/history/cam_history_support.F90----- No PIO function return codes found that weren't checked
- src/cpl/nuopc/atm_comp_nuopc.F90----- No PIO function return codes found that weren't checked
- src/cpl/nuopc/atm_stream_ndep.F90-----  No PIO function return codes found that weren't checked
- src/utils/cam_pio_utils.F90----------------    Added a comment before one block which did not check, but it was doing internal PIO checking
- src/utils/cam_grid_support.F90----------- No PIO function return codes found that weren't checked
- src/utils/cam_time_coord.F90-------------    No PIO function return codes found that weren't checked
- src/physics/utils/solar_parms_data.F90--- No PIO function return codes found that weren't checked


Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes:  
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
M       src/dynamics/se/dyn_comp.F90
             - added a check, which was probably unnecessary, but does no harm
             
M       src/utils/cam_pio_utils.F90
              - added comment before a block of code which is not being checked as PIO is doing internal checking

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
