### PR TITLE
Add CI workflows and implement unit tests for MPAS dynamical core

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pf linguist-language=Fortran-Free-Form

--- a/.github/workflows/mpas_dynamical_core_ci.yml
+++ b/.github/workflows/mpas_dynamical_core_ci.yml
@@ -1,0 +1,95 @@
+name: MPAS Dynamical Core CI
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      # Only run this workflow if something changes in MPAS dynamical core. Skip otherwise.
+      - 'src/dynamics/mpas/**'
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - 'staging/**'
+      - development
+      - main
+    paths:
+      # Only run this workflow if something changes in MPAS dynamical core. Skip otherwise.
+      - 'src/dynamics/mpas/**'
+  workflow_dispatch:
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }} - ${{ github.ref }}
+
+jobs:
+  unit-tests:
+    name: Build and run unit tests (GCC ${{ matrix.gcc-version }})
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        gcc-version:
+          - '12'
+          - '13'
+          - '14'
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-${{ matrix.gcc-version }}
+      CXX: g++-${{ matrix.gcc-version }}
+      FC: gfortran-${{ matrix.gcc-version }}
+      PFUNIT_BUILD_TYPE: Release
+      PFUNIT_PATH: ${{ github.workspace }}/pFUnit
+      PFUNIT_REFERENCE: 'v4.12.0'
+      UNIT_TESTS_BUILD_TYPE: Debug
+      UNIT_TESTS_PATH: ${{ github.workspace }}/src/dynamics/mpas
+    steps:
+      - name: Checkout CAM-SIMA
+        uses: actions/checkout@v5
+
+      # pFUnit takes a while to build. Cache it if possible to save time on consecutive workflow runs.
+      - name: Cache pFUnit
+        id: cache-pfunit
+        uses: actions/cache@v4
+        with:
+          key: cache-pfunit-${{ env.PFUNIT_REFERENCE }}-gcc-v${{ matrix.gcc-version }}
+          path: ${{ env.PFUNIT_PATH }}/install
+
+      # If there is a cache hit, just use the cached pFUnit and skip this step.
+      - name: Checkout pFUnit
+        if: ${{ steps.cache-pfunit.outputs.cache-hit != 'true' }}
+        uses: actions/checkout@v5
+        with:
+          repository: Goddard-Fortran-Ecosystem/pFUnit
+          ref: ${{ env.PFUNIT_REFERENCE }}
+          path: pFUnit
+
+      # If there is a cache hit, just use the cached pFUnit and skip this step.
+      - name: Build pFUnit
+        if: ${{ steps.cache-pfunit.outputs.cache-hit != 'true' }}
+        run: |
+          cmake -D CMAKE_BUILD_TYPE="$PFUNIT_BUILD_TYPE" -D CMAKE_INSTALL_PREFIX="$PFUNIT_PATH/install" -B "$PFUNIT_PATH/build" -S "$PFUNIT_PATH"
+          cmake --build "$PFUNIT_PATH/build" --config "$PFUNIT_BUILD_TYPE"
+          cmake --install "$PFUNIT_PATH/build" --config "$PFUNIT_BUILD_TYPE" --prefix "$PFUNIT_PATH/install"
+
+      - name: Build unit tests
+        run: |
+          cmake -D CMAKE_BUILD_TYPE="$UNIT_TESTS_BUILD_TYPE" -D CMAKE_PREFIX_PATH="$PFUNIT_PATH/install" -B "$UNIT_TESTS_PATH/build" -S "$UNIT_TESTS_PATH"
+          cmake --build "$UNIT_TESTS_PATH/build" --config "$UNIT_TESTS_BUILD_TYPE"
+
+      - name: Run unit tests
+        run: |
+          ctest --build-config "$UNIT_TESTS_BUILD_TYPE" --output-log "$UNIT_TESTS_PATH/build/unit-tests.log" --output-on-failure --test-dir "$UNIT_TESTS_PATH/build" --verbose
+
+      - name: Upload unit tests log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: ignore
+          name: unit-tests-log-gcc-v${{ matrix.gcc-version }}
+          path: ${{ env.UNIT_TESTS_PATH }}/build/unit-tests.log
+          retention-days: 7

--- a/src/dynamics/mpas/CMakeLists.txt
+++ b/src/dynamics/mpas/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.21)
+
+# `mpas_dynamical_core_procedures` has not been integrated into the CMake build of any top level projects yet,
+# and this CMakeLists.txt file is currently for unit testing purposes only.
+# Therefore, making a change to this CMakeLists.txt file will not impact the build of a parent project at this time.
+project(mpas_dynamical_core_procedures
+    VERSION
+        0.1.0
+    DESCRIPTION
+        "Standardized computational and utility procedures in MPAS dynamical core"
+    LANGUAGES
+        Fortran
+)
+
+add_library(mpas_dynamical_core_procedures)
+target_sources(mpas_dynamical_core_procedures
+    PRIVATE
+        driver/dyn_mpas_procedures.F90
+        dyn_procedures.F90
+)
+target_include_directories(mpas_dynamical_core_procedures
+    INTERFACE
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_compile_options(mpas_dynamical_core_procedures
+    PRIVATE
+        $<$<AND:$<CONFIG:Debug>,$<Fortran_COMPILER_ID:GNU>>:-fbacktrace -fcheck=all -ffpe-trap=invalid,overflow,zero -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -std=f2018 -Wall -Wextra -Wpedantic>
+        $<$<AND:$<CONFIG:Debug>,$<Fortran_COMPILER_ID:Intel>>:-check all -fp-model=precise -stand f18 -traceback -warn all>
+        $<$<AND:$<CONFIG:Debug>,$<Fortran_COMPILER_ID:IntelLLVM>>:-check all -fp-model=precise -stand f18 -traceback -warn all>
+)
+
+# Enable testing only when this project is at the top level.
+# Otherwise, if this project is under a parent project, respect its choice of whether to enable testing.
+if(PROJECT_IS_TOP_LEVEL)
+    include(CTest)
+    enable_testing()
+endif(PROJECT_IS_TOP_LEVEL)
+
+if(BUILD_TESTING)
+    add_subdirectory(tests/unit)
+endif(BUILD_TESTING)

--- a/src/dynamics/mpas/driver/dyn_mpas_procedures.F90
+++ b/src/dynamics/mpas/driver/dyn_mpas_procedures.F90
@@ -95,6 +95,22 @@ contains
 
         real(real32) :: error_tolerance
 
+        if (a /= a .or. b /= b) then
+            ! NaN does not equal to anything, including itself.
+            almost_equal = .false.
+
+            return
+        end if
+
+        if (abs(a) > huge(a) .or. abs(b) > huge(b)) then
+            ! Infinity of the same sign equals to each other.
+            ! Infinity of different signs does not equal to each other.
+            ! Infinity does not equal to anything that is finite.
+            almost_equal = (a == b)
+
+            return
+        end if
+
         if (present(relative_tolerance)) then
             error_tolerance = relative_tolerance * max(abs(a), abs(b))
         else
@@ -103,15 +119,11 @@ contains
 
         if (present(absolute_tolerance)) then
             error_tolerance = max(absolute_tolerance, error_tolerance)
+        else
+            error_tolerance = max(epsilon(1.0_real32), error_tolerance)
         end if
 
-        if (abs(a - b) <= error_tolerance) then
-            almost_equal = .true.
-
-            return
-        end if
-
-        almost_equal = .false.
+        almost_equal = (abs(a - b) <= error_tolerance)
     end function almost_equal_real32
 
     !> Test `a` and `b` for approximate equality, where `a` and `b` are both reals.
@@ -125,6 +137,22 @@ contains
 
         real(real64) :: error_tolerance
 
+        if (a /= a .or. b /= b) then
+            ! NaN does not equal to anything, including itself.
+            almost_equal = .false.
+
+            return
+        end if
+
+        if (abs(a) > huge(a) .or. abs(b) > huge(b)) then
+            ! Infinity of the same sign equals to each other.
+            ! Infinity of different signs does not equal to each other.
+            ! Infinity does not equal to anything that is finite.
+            almost_equal = (a == b)
+
+            return
+        end if
+
         if (present(relative_tolerance)) then
             error_tolerance = relative_tolerance * max(abs(a), abs(b))
         else
@@ -133,15 +161,11 @@ contains
 
         if (present(absolute_tolerance)) then
             error_tolerance = max(absolute_tolerance, error_tolerance)
+        else
+            error_tolerance = max(epsilon(1.0_real64), error_tolerance)
         end if
 
-        if (abs(a - b) <= error_tolerance) then
-            almost_equal = .true.
-
-            return
-        end if
-
-        almost_equal = .false.
+        almost_equal = (abs(a - b) <= error_tolerance)
     end function almost_equal_real64
 
     !> Clamp/Limit the value of `x` to the range of [`xmin`, `xmax`], where `x`, `xmin`, and `xmax` are all integers.

--- a/src/dynamics/mpas/dyn_comp_impl.F90
+++ b/src/dynamics/mpas/dyn_comp_impl.F90
@@ -593,7 +593,7 @@ contains
             use cam_constituents, only: num_advected
             use cam_logfile, only: debugout_verbose
             use dyn_grid, only: ncells_solve
-            use dyn_procedures, only: reverse
+            use dyn_procedures, only: qv_of_sh, reverse
             use dyn_tests_utils, only: vc_height
             use inic_analytic, only: dyn_set_inic_col
             use vert_coord, only: pver
@@ -647,8 +647,8 @@ contains
                 call dyn_debug_print(debugout_verbose, 'Conversion is needed and applied for water vapor mixing ratio')
 
                 ! Convert specific humidity to water vapor mixing ratio.
-                scalars(index_qv, :, 1:ncells_solve) = &
-                    scalars(index_qv, :, 1:ncells_solve) / (1.0_kind_dyn_mpas - scalars(index_qv, :, 1:ncells_solve))
+                scalars(index_qv, :, 1:ncells_solve) = real(qv_of_sh( &
+                    real(scalars(index_qv, :, 1:ncells_solve), kind_r8)), kind_dyn_mpas)
             end if
 
             deallocate(buffer_3d_real)

--- a/src/dynamics/mpas/dyn_comp_impl.F90
+++ b/src/dynamics/mpas/dyn_comp_impl.F90
@@ -330,6 +330,8 @@ contains
         use shr_kind_mod, only: kind_r8 => shr_kind_r8
         ! Module(s) from external libraries.
         use pio, only: file_desc_t, pio_file_is_open
+        ! Module(s) from MPAS.
+        use dyn_mpas_procedures, only: almost_equal
 
         type(file_desc_t), pointer, intent(in) :: pio_file
 
@@ -373,7 +375,9 @@ contains
             surface_geometric_height(:) = surface_geopotential(:) / constant_g
 
             ! Surface geometric height in MPAS should match the values in topography file.
-            if (any(abs(real(zgrid(1, 1:ncells_solve), kind_r8) - surface_geometric_height(:)) > error_tolerance)) then
+            if (.not. all(almost_equal( &
+                real(zgrid(1, 1:ncells_solve), kind_r8), surface_geometric_height, &
+                relative_tolerance=error_tolerance))) then
                 call endrun('Surface geometric height in MPAS is not consistent with topography data', subname, __LINE__)
             end if
 
@@ -383,7 +387,9 @@ contains
             call dyn_debug_print(debugout_verbose, 'Topography file is not used for consistency check')
 
             ! Surface geometric height in MPAS should be zero.
-            if (any(abs(real(zgrid(1, 1:ncells_solve), kind_r8)) > error_tolerance)) then
+            if (.not. all(almost_equal( &
+                real(zgrid(1, 1:ncells_solve), kind_r8), 0.0_kind_r8, &
+                relative_tolerance=error_tolerance))) then
                 call endrun('Surface geometric height in MPAS is not zero', subname, __LINE__)
             end if
         end if

--- a/src/dynamics/mpas/dyn_coupling_impl.F90
+++ b/src/dynamics/mpas/dyn_coupling_impl.F90
@@ -361,10 +361,11 @@ contains
         !> (KCW, 2024-07-30)
         subroutine update_shared_variables(i)
             ! Module(s) from CAM-SIMA.
-            use dyn_mpas_procedures, only: clamp
             use dyn_procedures, only: dp_by_hydrostatic_equation, omega_of_w_rho, p_by_equation_of_state, t_of_tm_qv
             use dynconst, only: constant_g => gravit, constant_rd => rair, constant_rv => rh2o
             use vert_coord, only: pver, pverp
+            ! Module(s) from MPAS.
+            use dyn_mpas_procedures, only: clamp
 
             integer, intent(in) :: i
 

--- a/src/dynamics/mpas/dyn_coupling_impl.F90
+++ b/src/dynamics/mpas/dyn_coupling_impl.F90
@@ -489,6 +489,7 @@ contains
             use cam_thermo, only: cam_thermo_dry_air_update, cam_thermo_water_update
             use cam_thermo_formula, only: energy_formula_dycore_mpas
             use dyn_comp, only: mpas_dynamical_core
+            use dyn_procedures, only: exner_function
             use dynconst, only: constant_g => gravit
             use physics_types, only: cappav, cp_or_cv_dycore, cpairv, lagrangian_vertical, phys_state, rairv, zvirv
             use runtime_obj, only: cam_runtime_opts
@@ -553,7 +554,7 @@ contains
             ! the paragraph below equation 1.5.1c in doi:10.1007/978-94-009-3027-8.
             ! Also note that `cappav` is updated externally by `cam_thermo_dry_air_update`.
             do i = 1, ncells_solve
-                phys_state % exner(i, :) = (phys_state % ps(i) / phys_state % pmid(i, :)) ** cappav(i, :)
+                phys_state % exner(i, :) = 1.0_kind_r8 / exner_function(cappav(i, :), phys_state % ps(i), phys_state % pmid(i, :))
             end do
 
             ! Note that constituents become moist after this.

--- a/src/dynamics/mpas/dyn_procedures.F90
+++ b/src/dynamics/mpas/dyn_procedures.F90
@@ -28,6 +28,11 @@ module dyn_procedures
     ! Utility procedures.
     public :: reverse
     public :: sec_to_hour_min_sec
+
+    interface exner_function
+        module procedure exner_function_of_cpd_p0_rd_p
+        module procedure exner_function_of_kappa_p0_p
+    end interface exner_function
 contains
     !> Compute the pressure `p` from the density `rho` and the temperature `t` by equation of state. Essentially,
     !> \( P = \rho R T \). Equation of state may take other forms, such as \( P_d = \rho_d R_d T \), \( P = \rho R_d T_v \),
@@ -69,14 +74,24 @@ contains
     end function t_by_equation_of_state
 
     !> Compute the Exner function `pi` from the pressure `p`. Essentially, \( \Pi = (\frac{P}{P_0})^{\frac{R_d}{C_{pd}}} \).
-    pure elemental function exner_function(constant_cpd, constant_p0, constant_rd, p) result(pi)
+    pure elemental function exner_function_of_cpd_p0_rd_p(constant_cpd, constant_p0, constant_rd, p) result(pi)
         use, intrinsic :: iso_fortran_env, only: real64
 
         real(real64), intent(in) :: constant_cpd, constant_p0, constant_rd, p
         real(real64) :: pi
 
         pi = (p / constant_p0) ** (constant_rd / constant_cpd)
-    end function exner_function
+    end function exner_function_of_cpd_p0_rd_p
+
+    !> Compute the Exner function `pi` from the pressure `p`. Essentially, \( \Pi = (\frac{P}{P_0})^{\kappa} \).
+    pure elemental function exner_function_of_kappa_p0_p(constant_kappa, constant_p0, p) result(pi)
+        use, intrinsic :: iso_fortran_env, only: real64
+
+        real(real64), intent(in) :: constant_kappa, constant_p0, p
+        real(real64) :: pi
+
+        pi = (p / constant_p0) ** constant_kappa
+    end function exner_function_of_kappa_p0_p
 
     !> Compute the pressure difference `dp` from the density `rho` and the height difference `dz` by hydrostatic equation.
     !> Essentially, \( \mathrm{d} P = -\rho g \mathrm{d} z \).

--- a/src/dynamics/mpas/dyn_procedures.F90
+++ b/src/dynamics/mpas/dyn_procedures.F90
@@ -363,12 +363,14 @@ contains
     !> Convert second(s) to hour(s), minute(s), and second(s).
     !> (KCW, 2024-02-07)
     pure function sec_to_hour_min_sec(sec) result(hour_min_sec)
-        integer, intent(in) :: sec
-        integer :: hour_min_sec(3)
+        use, intrinsic :: iso_fortran_env, only: int32
 
-        ! These are all intended to be integer arithmetics.
-        hour_min_sec(1) = sec / 3600
-        hour_min_sec(2) = sec / 60 - hour_min_sec(1) * 60
-        hour_min_sec(3) = sec - hour_min_sec(1) * 3600 - hour_min_sec(2) * 60
+        integer(int32), intent(in) :: sec
+        integer(int32) :: hour_min_sec(3)
+
+        ! These are all intended to be integer arithmetic.
+        hour_min_sec(1) = sec / 3600_int32
+        hour_min_sec(2) = sec / 60_int32 - hour_min_sec(1) * 60_int32
+        hour_min_sec(3) = sec - hour_min_sec(1) * 3600_int32 - hour_min_sec(2) * 60_int32
     end function sec_to_hour_min_sec
 end module dyn_procedures

--- a/src/dynamics/mpas/tests/unit/CMakeLists.txt
+++ b/src/dynamics/mpas/tests/unit/CMakeLists.txt
@@ -1,0 +1,27 @@
+find_package(PFUNIT REQUIRED)
+
+add_pfunit_ctest(test_dyn_mpas_procedures
+    TEST_SOURCES
+        test_dyn_mpas_procedures.pf
+    LINK_LIBRARIES
+        mpas_dynamical_core_procedures
+)
+target_compile_options(test_dyn_mpas_procedures
+    PRIVATE
+        $<$<AND:$<CONFIG:Debug>,$<Fortran_COMPILER_ID:GNU>>:-fbacktrace -fcheck=all -ffpe-trap=invalid,overflow,zero -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -std=f2018 -Wall -Wextra -Wpedantic>
+        $<$<AND:$<CONFIG:Debug>,$<Fortran_COMPILER_ID:Intel>>:-check all -fp-model=precise -stand f18 -traceback -warn all>
+        $<$<AND:$<CONFIG:Debug>,$<Fortran_COMPILER_ID:IntelLLVM>>:-check all -fp-model=precise -stand f18 -traceback -warn all>
+)
+
+add_pfunit_ctest(test_dyn_procedures
+    TEST_SOURCES
+        test_dyn_procedures.pf
+    LINK_LIBRARIES
+        mpas_dynamical_core_procedures
+)
+target_compile_options(test_dyn_procedures
+    PRIVATE
+        $<$<AND:$<CONFIG:Debug>,$<Fortran_COMPILER_ID:GNU>>:-fbacktrace -fcheck=all -ffpe-trap=invalid,overflow,zero -fno-unsafe-math-optimizations -frounding-math -fsignaling-nans -std=f2018 -Wall -Wextra -Wpedantic>
+        $<$<AND:$<CONFIG:Debug>,$<Fortran_COMPILER_ID:Intel>>:-check all -fp-model=precise -stand f18 -traceback -warn all>
+        $<$<AND:$<CONFIG:Debug>,$<Fortran_COMPILER_ID:IntelLLVM>>:-check all -fp-model=precise -stand f18 -traceback -warn all>
+)

--- a/src/dynamics/mpas/tests/unit/test_dyn_mpas_procedures.pf
+++ b/src/dynamics/mpas/tests/unit/test_dyn_mpas_procedures.pf
@@ -1,0 +1,1055 @@
+! Copyright (C) 2025 University Corporation for Atmospheric Research (UCAR)
+! SPDX-License-Identifier: Apache-2.0
+
+!> This module contains a suite of unit tests for the `dyn_mpas_procedures` module. Currently, unit testing
+!> is a separate capability in CAM-SIMA. It is compiled and run independently of CIME by CMake and pFUnit.
+!>
+!> For computational procedures, if the test data are exact, tolerance should be chosen based on the number of
+!> units in the last place (ULP). Otherwise, tolerance should be chosen based on significant figures.
+!> For utility procedures, standard unit testing practices apply.
+module test_dyn_mpas_procedures
+    implicit none
+
+    private
+    public :: test_almost_divisible_by_properties_real32
+    public :: test_almost_divisible_by_properties_real64
+    public :: test_almost_divisible_by_inexact_arithmetic_real32
+    public :: test_almost_divisible_by_inexact_arithmetic_real64
+    public :: test_almost_divisible_by_precision_limits_real32
+    public :: test_almost_divisible_by_precision_limits_real64
+    public :: test_almost_equal_by_properties_real32
+    public :: test_almost_equal_by_properties_real64
+    public :: test_almost_equal_by_optional_tolerance_real32
+    public :: test_almost_equal_by_optional_tolerance_real64
+    public :: test_almost_equal_by_extreme_values_real32
+    public :: test_almost_equal_by_extreme_values_real64
+    public :: test_clamp_by_properties_int32
+    public :: test_clamp_by_properties_int64
+    public :: test_clamp_by_properties_real32
+    public :: test_clamp_by_properties_real64
+    public :: test_clamp_by_extreme_values_int32
+    public :: test_clamp_by_extreme_values_int64
+    public :: test_clamp_by_extreme_values_real32
+    public :: test_clamp_by_extreme_values_real64
+    public :: test_index_unique_by_empty_arrays
+    public :: test_index_unique_by_character_arrays
+    public :: test_index_unique_by_integer_arrays_int32
+    public :: test_index_unique_by_integer_arrays_int64
+    public :: test_index_unique_by_logical_arrays
+    public :: test_index_unique_by_real_arrays_real32
+    public :: test_index_unique_by_real_arrays_real64
+contains
+    @test
+    subroutine test_almost_divisible_by_properties_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_mpas_procedures, only: almost_divisible
+        use funit
+
+        ! Division of zero.
+        @assertTrue(almost_divisible(0.0_real32, 1776.0_real32))
+        @assertTrue(almost_divisible(0.0_real32, -1776.0_real32))
+
+        ! Division by one.
+        @assertTrue(almost_divisible(1776.0_real32, 1.0_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, 1.0_real32))
+        @assertTrue(almost_divisible(1776.0_real32, -1.0_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, -1.0_real32))
+
+        ! Division by itself and by factors of 10.
+        @assertTrue(almost_divisible(1776.0_real32, 1776.0_real32))
+        @assertTrue(almost_divisible(1776.0_real32, 177.6_real32))
+        @assertTrue(almost_divisible(1776.0_real32, 17.76_real32))
+        @assertTrue(almost_divisible(1776.0_real32, 1.776_real32))
+        @assertTrue(almost_divisible(1776.0_real32, 0.1776_real32))
+        @assertTrue(almost_divisible(1776.0_real32, 0.01776_real32))
+        @assertTrue(almost_divisible(1776.0_real32, 0.001776_real32))
+
+        @assertTrue(almost_divisible(-1776.0_real32, 1776.0_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, 177.6_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, 17.76_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, 1.776_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, 0.1776_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, 0.01776_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, 0.001776_real32))
+
+        @assertTrue(almost_divisible(1776.0_real32, -1776.0_real32))
+        @assertTrue(almost_divisible(1776.0_real32, -177.6_real32))
+        @assertTrue(almost_divisible(1776.0_real32, -17.76_real32))
+        @assertTrue(almost_divisible(1776.0_real32, -1.776_real32))
+        @assertTrue(almost_divisible(1776.0_real32, -0.1776_real32))
+        @assertTrue(almost_divisible(1776.0_real32, -0.01776_real32))
+        @assertTrue(almost_divisible(1776.0_real32, -0.001776_real32))
+
+        @assertTrue(almost_divisible(-1776.0_real32, -1776.0_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, -177.6_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, -17.76_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, -1.776_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, -0.1776_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, -0.01776_real32))
+        @assertTrue(almost_divisible(-1776.0_real32, -0.001776_real32))
+    end subroutine test_almost_divisible_by_properties_real32
+
+    @test
+    subroutine test_almost_divisible_by_properties_real64()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_mpas_procedures, only: almost_divisible
+        use funit
+
+        ! Division of zero.
+        @assertTrue(almost_divisible(0.0_real64, 1776.0_real64))
+        @assertTrue(almost_divisible(0.0_real64, -1776.0_real64))
+
+        ! Division by one.
+        @assertTrue(almost_divisible(1776.0_real64, 1.0_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, 1.0_real64))
+        @assertTrue(almost_divisible(1776.0_real64, -1.0_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, -1.0_real64))
+
+        ! Division by itself and by factors of 10.
+        @assertTrue(almost_divisible(1776.0_real64, 1776.0_real64))
+        @assertTrue(almost_divisible(1776.0_real64, 177.6_real64))
+        @assertTrue(almost_divisible(1776.0_real64, 17.76_real64))
+        @assertTrue(almost_divisible(1776.0_real64, 1.776_real64))
+        @assertTrue(almost_divisible(1776.0_real64, 0.1776_real64))
+        @assertTrue(almost_divisible(1776.0_real64, 0.01776_real64))
+        @assertTrue(almost_divisible(1776.0_real64, 0.001776_real64))
+
+        @assertTrue(almost_divisible(-1776.0_real64, 1776.0_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, 177.6_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, 17.76_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, 1.776_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, 0.1776_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, 0.01776_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, 0.001776_real64))
+
+        @assertTrue(almost_divisible(1776.0_real64, -1776.0_real64))
+        @assertTrue(almost_divisible(1776.0_real64, -177.6_real64))
+        @assertTrue(almost_divisible(1776.0_real64, -17.76_real64))
+        @assertTrue(almost_divisible(1776.0_real64, -1.776_real64))
+        @assertTrue(almost_divisible(1776.0_real64, -0.1776_real64))
+        @assertTrue(almost_divisible(1776.0_real64, -0.01776_real64))
+        @assertTrue(almost_divisible(1776.0_real64, -0.001776_real64))
+
+        @assertTrue(almost_divisible(-1776.0_real64, -1776.0_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, -177.6_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, -17.76_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, -1.776_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, -0.1776_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, -0.01776_real64))
+        @assertTrue(almost_divisible(-1776.0_real64, -0.001776_real64))
+    end subroutine test_almost_divisible_by_properties_real64
+
+    @test
+    subroutine test_almost_divisible_by_inexact_arithmetic_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_mpas_procedures, only: almost_divisible
+        use funit
+
+        integer :: i
+        real(real32) :: a, b
+
+        a = 0.0_real32
+        b = 1.776_real32
+
+        ! Test a few repeated additions. Cannot test too many iterations because rounding errors accumulate over time.
+        do i = 1, 10
+            a = a + b
+
+            @assertTrue(almost_divisible(a, b))
+        end do
+
+        ! Test multiplications.
+        do i = 1, 10 ** 6
+            a = real(i, real32) * b
+
+            @assertTrue(almost_divisible(a, b))
+        end do
+    end subroutine test_almost_divisible_by_inexact_arithmetic_real32
+
+    @test
+    subroutine test_almost_divisible_by_inexact_arithmetic_real64()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_mpas_procedures, only: almost_divisible
+        use funit
+
+        integer :: i
+        real(real64) :: a, b
+
+        a = 0.0_real64
+        b = 1.776_real64
+
+        ! Test a few repeated additions. Cannot test too many iterations because rounding errors accumulate over time.
+        do i = 1, 10
+            a = a + b
+
+            @assertTrue(almost_divisible(a, b))
+        end do
+
+        ! Test multiplications.
+        do i = 1, 10 ** 6
+            a = real(i, real64) * b
+
+            @assertTrue(almost_divisible(a, b))
+        end do
+    end subroutine test_almost_divisible_by_inexact_arithmetic_real64
+
+    @test
+    subroutine test_almost_divisible_by_precision_limits_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_mpas_procedures, only: almost_divisible
+        use funit
+
+        @assertFalse(almost_divisible(1776.0_real32, 1776.1_real32))
+        @assertFalse(almost_divisible(1776.0_real32, 1776.01_real32))
+        @assertFalse(almost_divisible(1776.0_real32, 1776.001_real32))
+        ! Precision limit should be exceeded below.
+        @assertTrue(almost_divisible(1776.0_real32, 1776.0001_real32))
+
+        @assertFalse(almost_divisible(1776.1_real32, 1776.0_real32))
+        @assertFalse(almost_divisible(1776.01_real32, 1776.0_real32))
+        @assertFalse(almost_divisible(1776.001_real32, 1776.0_real32))
+        ! Precision limit should be exceeded below.
+        @assertTrue(almost_divisible(1776.0001_real32, 1776.0_real32))
+    end subroutine test_almost_divisible_by_precision_limits_real32
+
+    @test
+    subroutine test_almost_divisible_by_precision_limits_real64()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_mpas_procedures, only: almost_divisible
+        use funit
+
+        @assertFalse(almost_divisible(1776.0_real64, 1776.1_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.01_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.001_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.0001_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.00001_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.000001_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.0000001_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.00000001_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.000000001_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.0000000001_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.00000000001_real64))
+        @assertFalse(almost_divisible(1776.0_real64, 1776.000000000001_real64))
+        ! Precision limit should be exceeded below.
+        @assertTrue(almost_divisible(1776.0_real64, 1776.0000000000001_real64))
+
+        @assertFalse(almost_divisible(1776.1_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.01_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.001_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.0001_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.00001_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.000001_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.0000001_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.00000001_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.000000001_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.0000000001_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.00000000001_real64, 1776.0_real64))
+        @assertFalse(almost_divisible(1776.000000000001_real64, 1776.0_real64))
+        ! Precision limit should be exceeded below.
+        @assertTrue(almost_divisible(1776.0000000000001_real64, 1776.0_real64))
+    end subroutine test_almost_divisible_by_precision_limits_real64
+
+    @test
+    subroutine test_almost_equal_by_properties_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_mpas_procedures, only: almost_equal
+        use funit
+
+        real(real32) :: a, b
+
+        ! Identical numbers.
+        @assertTrue(almost_equal(-1776.74_real32, -1776.74_real32))
+        @assertTrue(almost_equal(-2.0_real32, -2.0_real32))
+        @assertTrue(almost_equal(-1.0_real32, -1.0_real32))
+        @assertTrue(almost_equal(-0.0_real32, -0.0_real32))
+        @assertTrue(almost_equal(0.0_real32, 0.0_real32))
+        @assertTrue(almost_equal(1.0_real32, 1.0_real32))
+        @assertTrue(almost_equal(2.0_real32, 2.0_real32))
+        @assertTrue(almost_equal(1776.74_real32, 1776.74_real32))
+
+        ! Numbers with the same magnitude but different signs.
+        @assertFalse(almost_equal(-1776.74_real32, 1776.74_real32))
+        @assertFalse(almost_equal(-2.0_real32, 2.0_real32))
+        @assertFalse(almost_equal(-1.0_real32, 1.0_real32))
+        @assertTrue(almost_equal(-0.0_real32, 0.0_real32))
+        @assertTrue(almost_equal(0.0_real32, -0.0_real32))
+        @assertFalse(almost_equal(1.0_real32, -1.0_real32))
+        @assertFalse(almost_equal(2.0_real32, -2.0_real32))
+        @assertFalse(almost_equal(1776.74_real32, -1776.74_real32))
+
+        ! Numbers with the same sign but different magnitude.
+        @assertFalse(almost_equal(-1776.74_real32, -1776.75_real32))
+        @assertFalse(almost_equal(-2.0_real32, -3.0_real32))
+        @assertFalse(almost_equal(-1.0_real32, -2.0_real32))
+        @assertFalse(almost_equal(-0.0_real32, -1.0_real32))
+        @assertFalse(almost_equal(0.0_real32, 1.0_real32))
+        @assertFalse(almost_equal(1.0_real32, 2.0_real32))
+        @assertFalse(almost_equal(2.0_real32, 3.0_real32))
+        @assertFalse(almost_equal(1776.74_real32, 1776.75_real32))
+
+        ! Numbers with different magnitude and signs.
+        @assertFalse(almost_equal(-1776.74_real32, 1776.75_real32))
+        @assertFalse(almost_equal(-2.0_real32, 3.0_real32))
+        @assertFalse(almost_equal(-1.0_real32, 2.0_real32))
+        @assertFalse(almost_equal(-0.0_real32, 1.0_real32))
+        @assertFalse(almost_equal(0.0_real32, -1.0_real32))
+        @assertFalse(almost_equal(1.0_real32, -2.0_real32))
+        @assertFalse(almost_equal(2.0_real32, -3.0_real32))
+        @assertFalse(almost_equal(1776.74_real32, -1776.75_real32))
+
+        ! Numbers that differ slightly around default tolerance.
+        a = 1.0_real32
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+
+        a = 1000.0_real32
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+
+        a = 1000000.0_real32
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+
+        a = -1.0_real32
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+
+        a = -1000.0_real32
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+
+        a = -1000000.0_real32
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+    end subroutine test_almost_equal_by_properties_real32
+
+    @test
+    subroutine test_almost_equal_by_properties_real64()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_mpas_procedures, only: almost_equal
+        use funit
+
+        real(real64) :: a, b
+
+        ! Identical numbers.
+        @assertTrue(almost_equal(-1776.74_real64, -1776.74_real64))
+        @assertTrue(almost_equal(-2.0_real64, -2.0_real64))
+        @assertTrue(almost_equal(-1.0_real64, -1.0_real64))
+        @assertTrue(almost_equal(-0.0_real64, -0.0_real64))
+        @assertTrue(almost_equal(0.0_real64, 0.0_real64))
+        @assertTrue(almost_equal(1.0_real64, 1.0_real64))
+        @assertTrue(almost_equal(2.0_real64, 2.0_real64))
+        @assertTrue(almost_equal(1776.74_real64, 1776.74_real64))
+
+        ! Numbers with the same magnitude but different signs.
+        @assertFalse(almost_equal(-1776.74_real64, 1776.74_real64))
+        @assertFalse(almost_equal(-2.0_real64, 2.0_real64))
+        @assertFalse(almost_equal(-1.0_real64, 1.0_real64))
+        @assertTrue(almost_equal(-0.0_real64, 0.0_real64))
+        @assertTrue(almost_equal(0.0_real64, -0.0_real64))
+        @assertFalse(almost_equal(1.0_real64, -1.0_real64))
+        @assertFalse(almost_equal(2.0_real64, -2.0_real64))
+        @assertFalse(almost_equal(1776.74_real64, -1776.74_real64))
+
+        ! Numbers with the same sign but different magnitude.
+        @assertFalse(almost_equal(-1776.74_real64, -1776.75_real64))
+        @assertFalse(almost_equal(-2.0_real64, -3.0_real64))
+        @assertFalse(almost_equal(-1.0_real64, -2.0_real64))
+        @assertFalse(almost_equal(-0.0_real64, -1.0_real64))
+        @assertFalse(almost_equal(0.0_real64, 1.0_real64))
+        @assertFalse(almost_equal(1.0_real64, 2.0_real64))
+        @assertFalse(almost_equal(2.0_real64, 3.0_real64))
+        @assertFalse(almost_equal(1776.74_real64, 1776.75_real64))
+
+        ! Numbers with different magnitude and signs.
+        @assertFalse(almost_equal(-1776.74_real64, 1776.75_real64))
+        @assertFalse(almost_equal(-2.0_real64, 3.0_real64))
+        @assertFalse(almost_equal(-1.0_real64, 2.0_real64))
+        @assertFalse(almost_equal(-0.0_real64, 1.0_real64))
+        @assertFalse(almost_equal(0.0_real64, -1.0_real64))
+        @assertFalse(almost_equal(1.0_real64, -2.0_real64))
+        @assertFalse(almost_equal(2.0_real64, -3.0_real64))
+        @assertFalse(almost_equal(1776.74_real64, -1776.75_real64))
+
+        ! Numbers that differ slightly around default tolerance.
+        a = 1.0_real64
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+
+        a = 1000.0_real64
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+
+        a = 1000000.0_real64
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+
+        a = -1.0_real64
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+
+        a = -1000.0_real64
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+
+        a = -1000000.0_real64
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a + spacing(a)
+        @assertTrue(almost_equal(a, b))
+        b = a - spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+        b = a + spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+    end subroutine test_almost_equal_by_properties_real64
+
+    @test
+    subroutine test_almost_equal_by_optional_tolerance_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_mpas_procedures, only: almost_equal
+        use funit
+
+        @assertTrue(almost_equal(0.9_real32, 1.0_real32, absolute_tolerance=0.11_real32))
+        @assertFalse(almost_equal(0.9_real32, 1.0_real32, absolute_tolerance=0.09_real32))
+
+        @assertTrue(almost_equal(90.0_real32, 100.0_real32, relative_tolerance=0.11_real32))
+        @assertFalse(almost_equal(90.0_real32, 100.0_real32, relative_tolerance=0.09_real32))
+
+        ! The larger tolerance should prevail.
+        @assertTrue(almost_equal(0.9_real32, 1.0_real32, absolute_tolerance=0.11_real32, relative_tolerance=0.0_real32))
+        @assertFalse(almost_equal(0.9_real32, 1.0_real32, absolute_tolerance=0.09_real32, relative_tolerance=0.0_real32))
+        @assertTrue(almost_equal(0.9_real32, 1.0_real32, absolute_tolerance=0.0_real32, relative_tolerance=0.11_real32))
+        @assertFalse(almost_equal(0.9_real32, 1.0_real32, absolute_tolerance=0.0_real32, relative_tolerance=0.09_real32))
+    end subroutine test_almost_equal_by_optional_tolerance_real32
+
+    @test
+    subroutine test_almost_equal_by_optional_tolerance_real64()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_mpas_procedures, only: almost_equal
+        use funit
+
+        @assertTrue(almost_equal(0.9_real64, 1.0_real64, absolute_tolerance=0.11_real64))
+        @assertFalse(almost_equal(0.9_real64, 1.0_real64, absolute_tolerance=0.09_real64))
+
+        @assertTrue(almost_equal(90.0_real64, 100.0_real64, relative_tolerance=0.11_real64))
+        @assertFalse(almost_equal(90.0_real64, 100.0_real64, relative_tolerance=0.09_real64))
+
+        ! The larger tolerance should prevail.
+        @assertTrue(almost_equal(0.9_real64, 1.0_real64, absolute_tolerance=0.11_real64, relative_tolerance=0.0_real64))
+        @assertFalse(almost_equal(0.9_real64, 1.0_real64, absolute_tolerance=0.09_real64, relative_tolerance=0.0_real64))
+        @assertTrue(almost_equal(0.9_real64, 1.0_real64, absolute_tolerance=0.0_real64, relative_tolerance=0.11_real64))
+        @assertFalse(almost_equal(0.9_real64, 1.0_real64, absolute_tolerance=0.0_real64, relative_tolerance=0.09_real64))
+    end subroutine test_almost_equal_by_optional_tolerance_real64
+
+    @test
+    subroutine test_almost_equal_by_extreme_values_real32()
+        use, intrinsic :: ieee_arithmetic, only: ieee_negative_inf, ieee_positive_inf, ieee_quiet_nan, &
+                                                 ieee_support_inf, ieee_support_nan, &
+                                                 ieee_value
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_mpas_procedures, only: almost_equal
+        use funit
+
+        real(real32) :: a, b
+
+        ! Comparisons based on relative tolerance break down near infernal zero.
+        ! In this case, absolute tolerance should prevail.
+        @assertTrue(almost_equal(0.0_real32, epsilon(1.0_real32)))
+        @assertTrue(almost_equal(0.0_real32, -epsilon(1.0_real32)))
+        @assertTrue(almost_equal(0.0_real32, tiny(0.0_real32)))
+        @assertTrue(almost_equal(0.0_real32, -tiny(0.0_real32)))
+        @assertFalse(almost_equal(0.0_real32, epsilon(1.0_real32), absolute_tolerance=tiny(0.0_real32)))
+        @assertFalse(almost_equal(0.0_real32, -epsilon(1.0_real32), absolute_tolerance=tiny(0.0_real32)))
+        @assertTrue(almost_equal(0.0_real32, tiny(0.0_real32), absolute_tolerance=tiny(0.0_real32)))
+        @assertTrue(almost_equal(0.0_real32, -tiny(0.0_real32), absolute_tolerance=tiny(0.0_real32)))
+
+        ! Comparisons near maximum and minimum values.
+        a = huge(0.0_real32)
+        @assertTrue(almost_equal(a, a))
+        @assertTrue(almost_equal(-a, -a))
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        @assertTrue(almost_equal(-a, -b))
+        b = a - spacing(a) * 2.0_real32
+        @assertFalse(almost_equal(a, b))
+        @assertFalse(almost_equal(-a, -b))
+
+        if (ieee_support_nan(0.0_real32)) then
+            ! NaN does not equal to anything, including itself.
+            @assertFalse(almost_equal(ieee_value(0.0_real32, ieee_quiet_nan), ieee_value(0.0_real32, ieee_quiet_nan)))
+            @assertFalse(almost_equal(0.0_real32, ieee_value(0.0_real32, ieee_quiet_nan)))
+
+            if (ieee_support_inf(0.0_real32)) then
+                @assertFalse(almost_equal(ieee_value(0.0_real32, ieee_negative_inf), ieee_value(0.0_real32, ieee_quiet_nan)))
+                @assertFalse(almost_equal(ieee_value(0.0_real32, ieee_positive_inf), ieee_value(0.0_real32, ieee_quiet_nan)))
+            end if
+        end if
+
+        if (ieee_support_inf(0.0_real32)) then
+            ! Infinity of the same sign equals to each other.
+            @assertTrue(almost_equal(ieee_value(0.0_real32, ieee_negative_inf), ieee_value(0.0_real32, ieee_negative_inf)))
+            @assertTrue(almost_equal(ieee_value(0.0_real32, ieee_positive_inf), ieee_value(0.0_real32, ieee_positive_inf)))
+
+            ! Infinity of different signs does not equal to each other.
+            @assertFalse(almost_equal(ieee_value(0.0_real32, ieee_negative_inf), ieee_value(0.0_real32, ieee_positive_inf)))
+
+            ! Infinity does not equal to anything that is finite.
+            @assertFalse(almost_equal(0.0_real32, ieee_value(0.0_real32, ieee_negative_inf)))
+            @assertFalse(almost_equal(0.0_real32, ieee_value(0.0_real32, ieee_positive_inf)))
+        end if
+    end subroutine test_almost_equal_by_extreme_values_real32
+
+    @test
+    subroutine test_almost_equal_by_extreme_values_real64()
+        use, intrinsic :: ieee_arithmetic, only: ieee_negative_inf, ieee_positive_inf, ieee_quiet_nan, &
+                                                 ieee_support_inf, ieee_support_nan, &
+                                                 ieee_value
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_mpas_procedures, only: almost_equal
+        use funit
+
+        real(real64) :: a, b
+
+        ! Comparisons based on relative tolerance break down near infernal zero.
+        ! In this case, absolute tolerance should prevail.
+        @assertTrue(almost_equal(0.0_real64, epsilon(1.0_real64)))
+        @assertTrue(almost_equal(0.0_real64, -epsilon(1.0_real64)))
+        @assertTrue(almost_equal(0.0_real64, tiny(0.0_real64)))
+        @assertTrue(almost_equal(0.0_real64, -tiny(0.0_real64)))
+        @assertFalse(almost_equal(0.0_real64, epsilon(1.0_real64), absolute_tolerance=tiny(0.0_real64)))
+        @assertFalse(almost_equal(0.0_real64, -epsilon(1.0_real64), absolute_tolerance=tiny(0.0_real64)))
+        @assertTrue(almost_equal(0.0_real64, tiny(0.0_real64), absolute_tolerance=tiny(0.0_real64)))
+        @assertTrue(almost_equal(0.0_real64, -tiny(0.0_real64), absolute_tolerance=tiny(0.0_real64)))
+
+        ! Comparisons near maximum and minimum values.
+        a = huge(0.0_real64)
+        @assertTrue(almost_equal(a, a))
+        @assertTrue(almost_equal(-a, -a))
+        b = a - spacing(a)
+        @assertTrue(almost_equal(a, b))
+        @assertTrue(almost_equal(-a, -b))
+        b = a - spacing(a) * 2.0_real64
+        @assertFalse(almost_equal(a, b))
+        @assertFalse(almost_equal(-a, -b))
+
+        if (ieee_support_nan(0.0_real64)) then
+            ! NaN does not equal to anything, including itself.
+            @assertFalse(almost_equal(ieee_value(0.0_real64, ieee_quiet_nan), ieee_value(0.0_real64, ieee_quiet_nan)))
+            @assertFalse(almost_equal(0.0_real64, ieee_value(0.0_real64, ieee_quiet_nan)))
+
+            if (ieee_support_inf(0.0_real64)) then
+                @assertFalse(almost_equal(ieee_value(0.0_real64, ieee_negative_inf), ieee_value(0.0_real64, ieee_quiet_nan)))
+                @assertFalse(almost_equal(ieee_value(0.0_real64, ieee_positive_inf), ieee_value(0.0_real64, ieee_quiet_nan)))
+            end if
+        end if
+
+        if (ieee_support_inf(0.0_real64)) then
+            ! Infinity of the same sign equals to each other.
+            @assertTrue(almost_equal(ieee_value(0.0_real64, ieee_negative_inf), ieee_value(0.0_real64, ieee_negative_inf)))
+            @assertTrue(almost_equal(ieee_value(0.0_real64, ieee_positive_inf), ieee_value(0.0_real64, ieee_positive_inf)))
+
+            ! Infinity of different signs does not equal to each other.
+            @assertFalse(almost_equal(ieee_value(0.0_real64, ieee_negative_inf), ieee_value(0.0_real64, ieee_positive_inf)))
+
+            ! Infinity does not equal to anything that is finite.
+            @assertFalse(almost_equal(0.0_real64, ieee_value(0.0_real64, ieee_negative_inf)))
+            @assertFalse(almost_equal(0.0_real64, ieee_value(0.0_real64, ieee_positive_inf)))
+        end if
+    end subroutine test_almost_equal_by_extreme_values_real64
+
+    @test
+    subroutine test_clamp_by_properties_int32()
+        use, intrinsic :: iso_fortran_env, only: int32
+        use dyn_mpas_procedures, only: clamp
+        use funit
+
+        @assertEqual(-3_int32, clamp(-5_int32, -3_int32, 3_int32))
+        @assertEqual(-3_int32, clamp(-4_int32, -3_int32, 3_int32))
+        @assertEqual(-3_int32, clamp(-3_int32, -3_int32, 3_int32))
+        @assertEqual(-2_int32, clamp(-2_int32, -3_int32, 3_int32))
+        @assertEqual(-1_int32, clamp(-1_int32, -3_int32, 3_int32))
+        @assertEqual(0_int32, clamp(0_int32, -3_int32, 3_int32))
+        @assertEqual(1_int32, clamp(1_int32, -3_int32, 3_int32))
+        @assertEqual(2_int32, clamp(2_int32, -3_int32, 3_int32))
+        @assertEqual(3_int32, clamp(3_int32, -3_int32, 3_int32))
+        @assertEqual(3_int32, clamp(4_int32, -3_int32, 3_int32))
+        @assertEqual(3_int32, clamp(5_int32, -3_int32, 3_int32))
+
+        ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+        @assertEqual(3_int32, clamp(-5_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(-4_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(-3_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(-2_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(-1_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(0_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(1_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(2_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(3_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(4_int32, 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(5_int32, 3_int32, -3_int32))
+    end subroutine test_clamp_by_properties_int32
+
+    @test
+    subroutine test_clamp_by_properties_int64()
+        use, intrinsic :: iso_fortran_env, only: int64
+        use dyn_mpas_procedures, only: clamp
+        use funit
+
+        @assertEqual(-3_int64, clamp(-5_int64, -3_int64, 3_int64))
+        @assertEqual(-3_int64, clamp(-4_int64, -3_int64, 3_int64))
+        @assertEqual(-3_int64, clamp(-3_int64, -3_int64, 3_int64))
+        @assertEqual(-2_int64, clamp(-2_int64, -3_int64, 3_int64))
+        @assertEqual(-1_int64, clamp(-1_int64, -3_int64, 3_int64))
+        @assertEqual(0_int64, clamp(0_int64, -3_int64, 3_int64))
+        @assertEqual(1_int64, clamp(1_int64, -3_int64, 3_int64))
+        @assertEqual(2_int64, clamp(2_int64, -3_int64, 3_int64))
+        @assertEqual(3_int64, clamp(3_int64, -3_int64, 3_int64))
+        @assertEqual(3_int64, clamp(4_int64, -3_int64, 3_int64))
+        @assertEqual(3_int64, clamp(5_int64, -3_int64, 3_int64))
+
+        ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+        @assertEqual(3_int64, clamp(-5_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(-4_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(-3_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(-2_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(-1_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(0_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(1_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(2_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(3_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(4_int64, 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(5_int64, 3_int64, -3_int64))
+    end subroutine test_clamp_by_properties_int64
+
+    @test
+    subroutine test_clamp_by_properties_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_mpas_procedures, only: clamp
+        use funit
+
+        @assertEqual(-3.0_real32, clamp(-5.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(-3.0_real32, clamp(-4.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(-3.0_real32, clamp(-3.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(-2.0_real32, clamp(-2.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(-1.0_real32, clamp(-1.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(0.0_real32, clamp(0.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(1.0_real32, clamp(1.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(2.0_real32, clamp(2.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(3.0_real32, clamp(3.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(3.0_real32, clamp(4.0_real32, -3.0_real32, 3.0_real32))
+        @assertEqual(3.0_real32, clamp(5.0_real32, -3.0_real32, 3.0_real32))
+
+        ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+        @assertEqual(3.0_real32, clamp(-5.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(-4.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(-3.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(-2.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(-1.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(0.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(1.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(2.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(3.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(4.0_real32, 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(5.0_real32, 3.0_real32, -3.0_real32))
+    end subroutine test_clamp_by_properties_real32
+
+    @test
+    subroutine test_clamp_by_properties_real64()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_mpas_procedures, only: clamp
+        use funit
+
+        @assertEqual(-3.0_real64, clamp(-5.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(-3.0_real64, clamp(-4.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(-3.0_real64, clamp(-3.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(-2.0_real64, clamp(-2.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(-1.0_real64, clamp(-1.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(0.0_real64, clamp(0.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(1.0_real64, clamp(1.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(2.0_real64, clamp(2.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(3.0_real64, clamp(3.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(3.0_real64, clamp(4.0_real64, -3.0_real64, 3.0_real64))
+        @assertEqual(3.0_real64, clamp(5.0_real64, -3.0_real64, 3.0_real64))
+
+        ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+        @assertEqual(3.0_real64, clamp(-5.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(-4.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(-3.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(-2.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(-1.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(0.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(1.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(2.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(3.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(4.0_real64, 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(5.0_real64, 3.0_real64, -3.0_real64))
+    end subroutine test_clamp_by_properties_real64
+
+    @test
+    subroutine test_clamp_by_extreme_values_int32()
+        use, intrinsic :: iso_fortran_env, only: int32
+        use dyn_mpas_procedures, only: clamp
+        use funit
+
+        @assertEqual(-3_int32, clamp(-huge(0_int32), -3_int32, 3_int32))
+        @assertEqual(3_int32, clamp(huge(0_int32), -3_int32, 3_int32))
+
+        ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+        @assertEqual(3_int32, clamp(-huge(0_int32), 3_int32, -3_int32))
+        @assertEqual(3_int32, clamp(huge(0_int32), 3_int32, -3_int32))
+    end subroutine test_clamp_by_extreme_values_int32
+
+    @test
+    subroutine test_clamp_by_extreme_values_int64()
+        use, intrinsic :: iso_fortran_env, only: int64
+        use dyn_mpas_procedures, only: clamp
+        use funit
+
+        @assertEqual(-3_int64, clamp(-huge(0_int64), -3_int64, 3_int64))
+        @assertEqual(3_int64, clamp(huge(0_int64), -3_int64, 3_int64))
+
+        ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+        @assertEqual(3_int64, clamp(-huge(0_int64), 3_int64, -3_int64))
+        @assertEqual(3_int64, clamp(huge(0_int64), 3_int64, -3_int64))
+    end subroutine test_clamp_by_extreme_values_int64
+
+    @test
+    subroutine test_clamp_by_extreme_values_real32()
+        use, intrinsic :: ieee_arithmetic, only: ieee_negative_inf, ieee_positive_inf, &
+                                                 ieee_support_inf, &
+                                                 ieee_value
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_mpas_procedures, only: clamp
+        use funit
+
+        @assertEqual(-3.0_real32, clamp(-huge(0.0_real32), -3.0_real32, 3.0_real32))
+        @assertEqual(3.0_real32, clamp(huge(0.0_real32), -3.0_real32, 3.0_real32))
+
+        ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+        @assertEqual(3.0_real32, clamp(-huge(0.0_real32), 3.0_real32, -3.0_real32))
+        @assertEqual(3.0_real32, clamp(huge(0.0_real32), 3.0_real32, -3.0_real32))
+
+        if (ieee_support_inf(0.0_real32)) then
+            @assertEqual(-3.0_real32, clamp(ieee_value(0.0_real32, ieee_negative_inf), -3.0_real32, 3.0_real32))
+            @assertEqual(3.0_real32, clamp(ieee_value(0.0_real32, ieee_positive_inf), -3.0_real32, 3.0_real32))
+
+            ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+            @assertEqual(3.0_real32, clamp(ieee_value(0.0_real32, ieee_negative_inf), 3.0_real32, -3.0_real32))
+            @assertEqual(3.0_real32, clamp(ieee_value(0.0_real32, ieee_positive_inf), 3.0_real32, -3.0_real32))
+        end if
+    end subroutine test_clamp_by_extreme_values_real32
+
+    @test
+    subroutine test_clamp_by_extreme_values_real64()
+        use, intrinsic :: ieee_arithmetic, only: ieee_negative_inf, ieee_positive_inf, &
+                                                 ieee_support_inf, &
+                                                 ieee_value
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_mpas_procedures, only: clamp
+        use funit
+
+        @assertEqual(-3.0_real64, clamp(-huge(0.0_real64), -3.0_real64, 3.0_real64))
+        @assertEqual(3.0_real64, clamp(huge(0.0_real64), -3.0_real64, 3.0_real64))
+
+        ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+        @assertEqual(3.0_real64, clamp(-huge(0.0_real64), 3.0_real64, -3.0_real64))
+        @assertEqual(3.0_real64, clamp(huge(0.0_real64), 3.0_real64, -3.0_real64))
+
+        if (ieee_support_inf(0.0_real64)) then
+            @assertEqual(-3.0_real64, clamp(ieee_value(0.0_real64, ieee_negative_inf), -3.0_real64, 3.0_real64))
+            @assertEqual(3.0_real64, clamp(ieee_value(0.0_real64, ieee_positive_inf), -3.0_real64, 3.0_real64))
+
+            ! In the case of wrong usage where `xmin` > `xmax`, the function always returns `xmin`.
+            @assertEqual(3.0_real64, clamp(ieee_value(0.0_real64, ieee_negative_inf), 3.0_real64, -3.0_real64))
+            @assertEqual(3.0_real64, clamp(ieee_value(0.0_real64, ieee_positive_inf), 3.0_real64, -3.0_real64))
+        end if
+    end subroutine test_clamp_by_extreme_values_real64
+
+    @test
+    subroutine test_index_unique_by_empty_arrays()
+        use, intrinsic :: iso_fortran_env, only: int32, int64, real32, real64
+        use dyn_mpas_procedures, only: index_unique
+        use funit
+
+        character(128), allocatable :: test_data_carr(:)
+        integer(int32), allocatable :: test_data_i32arr(:)
+        integer(int64), allocatable :: test_data_i64arr(:)
+        logical, allocatable :: test_data_larr(:)
+        real(real32), allocatable :: test_data_r32arr(:)
+        real(real64), allocatable :: test_data_r64arr(:)
+
+        integer, allocatable :: test_result(:)
+
+        allocate(test_data_carr(0))
+        allocate(test_data_i32arr(0))
+        allocate(test_data_i64arr(0))
+        allocate(test_data_larr(0))
+        allocate(test_data_r32arr(0))
+        allocate(test_data_r64arr(0))
+
+        test_result = index_unique(test_data_carr)
+        @assertTrue(allocated(test_result))
+        @assertEqual(0, size(test_result))
+
+        test_result = index_unique(test_data_i32arr)
+        @assertTrue(allocated(test_result))
+        @assertEqual(0, size(test_result))
+
+        test_result = index_unique(test_data_i64arr)
+        @assertTrue(allocated(test_result))
+        @assertEqual(0, size(test_result))
+
+        test_result = index_unique(test_data_larr)
+        @assertTrue(allocated(test_result))
+        @assertEqual(0, size(test_result))
+
+        test_result = index_unique(test_data_r32arr)
+        @assertTrue(allocated(test_result))
+        @assertEqual(0, size(test_result))
+
+        test_result = index_unique(test_data_r64arr)
+        @assertTrue(allocated(test_result))
+        @assertEqual(0, size(test_result))
+    end subroutine test_index_unique_by_empty_arrays
+
+    @test
+    subroutine test_index_unique_by_character_arrays()
+        use dyn_mpas_procedures, only: index_unique
+        use funit
+
+        character(*), parameter :: test_data_letters(*) = [ character(1) :: &
+            'T', 'H', 'E', &
+            'Q', 'U', 'I', 'C', 'K', &
+            'B', 'R', 'O', 'W', 'N', &
+            'F', 'O', 'X', &
+            'J', 'U', 'M', 'P', 'S', &
+            'O', 'V', 'E', 'R', &
+            'T', 'H', 'E', &
+            'L', 'A', 'Z', 'Y', &
+            'D', 'O', 'G' &
+        ]
+        character(*), parameter :: test_data_words(*) = [ character(128) :: &
+            'Mercury', &
+            'Mercury', 'Venus', &
+            'Mercury', 'Venus', 'Earth', &
+            'Mercury', 'Venus', 'Earth', 'Mars', &
+            'Mercury', 'Venus', 'Earth', 'Mars', 'Jupiter', &
+            'Mercury', 'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn', &
+            'Mercury', 'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus', &
+            'Mercury', 'Venus', 'Earth', 'Mars', 'Jupiter', 'Saturn', 'Uranus', 'Neptune' &
+        ]
+        integer, parameter :: expected_result_letters(*) = [ &
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 20, 21, 23, 29, 30, 31, 32, 33, 35 &
+        ]
+        integer, parameter :: expected_result_words(*) = [ &
+            1, 3, 6, 10, 15, 21, 28, 36 &
+        ]
+
+        integer, allocatable :: test_result(:)
+
+        test_result = index_unique(test_data_letters)
+        @assertEqual(expected_result_letters, test_result)
+
+        test_result = index_unique(test_data_words)
+        @assertEqual(expected_result_words, test_result)
+    end subroutine test_index_unique_by_character_arrays
+
+    @test
+    subroutine test_index_unique_by_integer_arrays_int32()
+        use, intrinsic :: iso_fortran_env, only: int32
+        use dyn_mpas_procedures, only: index_unique
+        use funit
+
+        integer(int32), parameter :: test_data(*) = [ &
+            1_int32, 7_int32, 7_int32, 6_int32, 0_int32, 7_int32, 0_int32, 4_int32 &
+        ]
+        integer, parameter :: expected_result(*) = [ &
+            1, 2, 4, 5, 8 &
+        ]
+
+        integer, allocatable :: test_result(:)
+
+        test_result = index_unique(test_data)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(test_data + 10_int32)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(-test_data)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(-test_data - 10_int32)
+        @assertEqual(expected_result, test_result)
+    end subroutine test_index_unique_by_integer_arrays_int32
+
+    @test
+    subroutine test_index_unique_by_integer_arrays_int64()
+        use, intrinsic :: iso_fortran_env, only: int64
+        use dyn_mpas_procedures, only: index_unique
+        use funit
+
+        integer(int64), parameter :: test_data(*) = [ &
+            1_int64, 7_int64, 7_int64, 6_int64, 0_int64, 7_int64, 0_int64, 4_int64 &
+        ]
+        integer, parameter :: expected_result(*) = [ &
+            1, 2, 4, 5, 8 &
+        ]
+
+        integer, allocatable :: test_result(:)
+
+        test_result = index_unique(test_data)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(test_data + 10_int64)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(-test_data)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(-test_data - 10_int64)
+        @assertEqual(expected_result, test_result)
+    end subroutine test_index_unique_by_integer_arrays_int64
+
+    @test
+    subroutine test_index_unique_by_logical_arrays()
+        use dyn_mpas_procedures, only: index_unique
+        use funit
+
+        logical, parameter :: test_data(*) = [ &
+            .false., .false., .true., .false., .false., .true. &
+        ]
+        integer, parameter :: expected_result(*) = [ &
+            1, 3 &
+        ]
+
+        integer, allocatable :: test_result(:)
+
+        test_result = index_unique(test_data)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(.not. test_data)
+        @assertEqual(expected_result, test_result)
+    end subroutine test_index_unique_by_logical_arrays
+
+    @test
+    subroutine test_index_unique_by_real_arrays_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_mpas_procedures, only: index_unique
+        use funit
+
+        real(real32), parameter :: test_data(*) = [ &
+            1.0_real32, 7.0_real32, 7.0_real32, 6.0_real32, 0.0_real32, 7.0_real32, 0.0_real32, 4.0_real32 &
+        ]
+        integer, parameter :: expected_result(*) = [ &
+            1, 2, 4, 5, 8 &
+        ]
+
+        integer, allocatable :: test_result(:)
+
+        test_result = index_unique(test_data)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(test_data + 10.0_real32)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(-test_data)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(-test_data - 10.0_real32)
+        @assertEqual(expected_result, test_result)
+    end subroutine test_index_unique_by_real_arrays_real32
+
+    @test
+    subroutine test_index_unique_by_real_arrays_real64()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_mpas_procedures, only: index_unique
+        use funit
+
+        real(real64), parameter :: test_data(*) = [ &
+            1.0_real64, 7.0_real64, 7.0_real64, 6.0_real64, 0.0_real64, 7.0_real64, 0.0_real64, 4.0_real64 &
+        ]
+        integer, parameter :: expected_result(*) = [ &
+            1, 2, 4, 5, 8 &
+        ]
+
+        integer, allocatable :: test_result(:)
+
+        test_result = index_unique(test_data)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(test_data + 10.0_real64)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(-test_data)
+        @assertEqual(expected_result, test_result)
+
+        test_result = index_unique(-test_data - 10.0_real64)
+        @assertEqual(expected_result, test_result)
+    end subroutine test_index_unique_by_real_arrays_real64
+end module test_dyn_mpas_procedures

--- a/src/dynamics/mpas/tests/unit/test_dyn_procedures.pf
+++ b/src/dynamics/mpas/tests/unit/test_dyn_procedures.pf
@@ -1,0 +1,1566 @@
+! Copyright (C) 2025 University Corporation for Atmospheric Research (UCAR)
+! SPDX-License-Identifier: Apache-2.0
+
+!> This module contains a suite of unit tests for the `dyn_procedures` module. Currently, unit testing
+!> is a separate capability in CAM-SIMA. It is compiled and run independently of CIME by CMake and pFUnit.
+!>
+!> For computational procedures, if the test data are exact, tolerance should be chosen based on the number of
+!> units in the last place (ULP). Otherwise, tolerance should be chosen based on significant figures.
+!> For utility procedures, standard unit testing practices apply.
+module test_dyn_procedures
+    implicit none
+
+    private
+    public :: print_error_statistics
+    public :: store_error_statistics
+    public :: test_equation_of_state_family_by_known_values
+    public :: test_equation_of_state_family_by_typical_values
+    public :: test_exner_function_family_by_known_values
+    public :: test_exner_function_family_by_typical_values
+    public :: test_hydrostatic_equation_family_by_known_values
+    public :: test_hydrostatic_equation_family_by_typical_values
+    public :: test_hypsometric_equation_family_by_known_values
+    public :: test_hypsometric_equation_family_by_typical_values
+    public :: test_poisson_equation_family_by_known_values
+    public :: test_poisson_equation_family_by_typical_values
+    public :: test_omega_of_w_rho_and_vice_versa_by_known_values
+    public :: test_omega_of_w_rho_and_vice_versa_by_typical_values
+    public :: test_qv_of_sh_and_vice_versa_by_known_values
+    public :: test_qv_of_sh_and_vice_versa_by_typical_values
+    public :: test_t_of_theta_rhod_qv_and_vice_versa_by_known_values
+    public :: test_t_of_theta_rhod_qv_and_vice_versa_by_typical_values
+    public :: test_t_of_tm_qv_and_vice_versa_by_known_values
+    public :: test_t_of_tm_qv_and_vice_versa_by_typical_values
+    public :: test_tm_of_tv_qv_and_vice_versa_by_known_values
+    public :: test_tm_of_tv_qv_and_vice_versa_by_typical_values
+    public :: test_reverse_by_empty_arrays
+    public :: test_reverse_by_single_element_arrays
+    public :: test_reverse_by_multiple_element_arrays
+    public :: test_sec_to_hour_min_sec_by_positive_time
+    public :: test_sec_to_hour_min_sec_by_negative_time
+    public :: test_sec_to_hour_min_sec_by_extreme_time
+
+    !> Error statistics for each applicable test. `ulp_error_count(i)` contains the number of sample values having accuracy of
+    !> `i - 1` <= ULP < `i`. Each applicable test should call `store_error_statistics` to collect error statistics.
+    !> Do not modify it directly.
+    integer, allocatable :: ulp_error_count(:)
+contains
+    @after
+    subroutine print_error_statistics()
+        use, intrinsic :: iso_fortran_env, only: output_unit, real64
+
+        integer :: i
+
+        ! No data have been collected.
+        if (.not. allocated(ulp_error_count)) then
+            return
+        end if
+
+        ! Invalid data.
+        if (any(ulp_error_count < 0) .or. &
+            sum(ulp_error_count) == 0) then
+            ! Discard data without printing.
+            deallocate(ulp_error_count)
+
+            return
+        end if
+
+        write(output_unit, '(a, a, i0, a)') &
+            new_line(''), &
+            'Error statistics (N = ', sum(ulp_error_count), '):'
+
+        do i = 1, size(ulp_error_count)
+            write(output_unit, '(f6.2, a, i0, a, i0, a, i0, a)') &
+                real(ulp_error_count(i), real64) / real(sum(ulp_error_count), real64) * 100.0_real64, &
+                '% of sample values (', ulp_error_count(i), ') have accuracy of ', &
+                i - 1, ' <= ULP < ', i, '.'
+        end do
+
+        ! Discard data after printing.
+        deallocate(ulp_error_count)
+    end subroutine print_error_statistics
+
+    subroutine store_error_statistics(expected, actual, number_of_ulp)
+        use, intrinsic :: iso_fortran_env, only: real64
+
+        integer, intent(in) :: number_of_ulp
+        real(real64), intent(in) :: expected, actual
+
+        integer :: i
+        real(real64) :: absolute_error, ulp
+
+        ! Allocate data storage on the first call.
+        if (.not. allocated(ulp_error_count)) then
+            allocate(ulp_error_count(number_of_ulp + 1))
+
+            ulp_error_count(:) = 0
+        end if
+
+        ! Throughout each test, the same storage size should be requested in terms of the number of ULP.
+        ! If not, data storage will be reallocated and old data will be lost.
+        if (size(ulp_error_count) /= number_of_ulp + 1) then
+            deallocate(ulp_error_count)
+            allocate(ulp_error_count(number_of_ulp + 1))
+
+            ulp_error_count(:) = 0
+        end if
+
+        absolute_error = abs(actual - expected)
+        ulp = spacing(expected)
+
+        do i = 1, size(ulp_error_count)
+            if (absolute_error >= ulp * real(i - 1, real64) .and. &
+                absolute_error <  ulp * real(i, real64)) then
+                ulp_error_count(i) = ulp_error_count(i) + 1
+
+                exit
+            end if
+        end do
+    end subroutine store_error_statistics
+
+    @test
+    subroutine test_equation_of_state_family_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: p_by_equation_of_state, &
+                                  rho_by_equation_of_state, &
+                                  t_by_equation_of_state
+        use funit
+
+        real(real64), parameter :: constant_rd = 287.04_real64
+
+        ! Significant figures and relative tolerance to pass the test.
+        integer, parameter :: significant_figures = 12
+        real(real64), parameter :: relative_tolerance = 5.0_real64 * (10.0_real64 ** real(-significant_figures, real64))
+        real(real64), parameter :: expected_p(*) = [ &
+            100000.0_real64, &
+            101325.0_real64 &
+        ]
+        real(real64), parameter :: expected_rho(*) = [ &
+            1.27542925337_real64, &
+            1.20416026587_real64 &
+        ]
+        real(real64), parameter :: expected_t(*) = [ &
+            273.15_real64, &
+            293.15_real64 &
+        ]
+
+        integer :: i
+        real(real64) :: p, rho, t
+
+        do i = 1, size(expected_p)
+            rho = rho_by_equation_of_state(constant_rd, expected_p(i), expected_t(i))
+            @assertEqual(expected_rho(i), rho, expected_rho(i) * relative_tolerance)
+
+            p = p_by_equation_of_state(constant_rd, expected_rho(i), expected_t(i))
+            @assertEqual(expected_p(i), p, expected_p(i) * relative_tolerance)
+
+            t = t_by_equation_of_state(constant_rd, expected_p(i), expected_rho(i))
+            @assertEqual(expected_t(i), t, expected_t(i) * relative_tolerance)
+        end do
+    end subroutine test_equation_of_state_family_by_known_values
+
+    @test
+    subroutine test_equation_of_state_family_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: p_by_equation_of_state, &
+                                  rho_by_equation_of_state, &
+                                  t_by_equation_of_state
+        use funit
+
+        real(real64), parameter :: constant_rd = 287.04_real64
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 3
+
+        integer :: i, j
+        real(real64) :: p, rho, t
+        real(real64), allocatable :: expected_p(:), expected_rho(:, :), expected_t(:)
+
+        call generate_test_data()
+
+        do i = 1, size(expected_p)
+            do j = 1, size(expected_t)
+                rho = rho_by_equation_of_state(constant_rd, expected_p(i), expected_t(j))
+                @assertEqual(expected_rho(i, j), rho, spacing(expected_rho(i, j)) * ulp_tolerance)
+                call store_error_statistics(expected_rho(i, j), rho, ulp_tolerance)
+
+                p = p_by_equation_of_state(constant_rd, expected_rho(i, j), expected_t(j))
+                @assertEqual(expected_p(i), p, spacing(expected_p(i)) * ulp_tolerance)
+                call store_error_statistics(expected_p(i), p, ulp_tolerance)
+
+                t = t_by_equation_of_state(constant_rd, expected_p(i), expected_rho(i, j))
+                @assertEqual(expected_t(j), t, spacing(expected_t(j)) * ulp_tolerance)
+                call store_error_statistics(expected_t(j), t, ulp_tolerance)
+            end do
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: constant_rd_real128 = 287.04_real128
+
+            real(real128), parameter :: interval_p = 1.0_real128
+            real(real128), parameter :: interval_t = 1.0_real128
+            real(real128), parameter :: range_p(2) = [1000.0_real128, 105000.0_real128]
+            real(real128), parameter :: range_t(2) = [223.15_real128, 323.15_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: expected_p_real128(:), expected_rho_real128(:, :), expected_t_real128(:)
+
+            n = nint((range_p(2) - range_p(1)) / interval_p) + 1
+
+            allocate(expected_p_real128(n))
+            expected_p_real128(:) = [(range_p(1) + real(i - 1, real128) * interval_p, i = 1, n)]
+            expected_p = real(expected_p_real128, real64)
+
+            n = nint((range_t(2) - range_t(1)) / interval_t) + 1
+
+            allocate(expected_t_real128(n))
+            expected_t_real128(:) = [(range_t(1) + real(i - 1, real128) * interval_t, i = 1, n)]
+            expected_t = real(expected_t_real128, real64)
+
+            allocate(expected_rho_real128(size(expected_p_real128), size(expected_t_real128)))
+
+            do i = 1, size(expected_t_real128)
+                expected_rho_real128(:, i) = &
+                    expected_p_real128(:) / (constant_rd_real128 * expected_t_real128(i))
+            end do
+
+            expected_rho = real(expected_rho_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_equation_of_state_family_by_typical_values
+
+    @test
+    subroutine test_exner_function_family_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: exner_function
+        use funit
+
+        real(real64), parameter :: constant_cpd = 1004.64_real64
+        real(real64), parameter :: constant_p0 = 100000.0_real64
+        real(real64), parameter :: constant_rd = 287.04_real64
+        real(real64), parameter :: constant_kappa = constant_rd / constant_cpd
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 4
+        real(real64), parameter :: p(*) = [ &
+            constant_p0, &
+            47829.69_real64, &
+            20971.52_real64, &
+            8235.43_real64, &
+            2799.36_real64, &
+            781.25_real64, &
+            163.84_real64, &
+            21.87_real64, &
+            1.28_real64, &
+            0.01_real64, & ! The only test value here that needs 4 ULP of tolerance.
+            0.0_real64 &
+        ]
+        real(real64), parameter :: expected_pi(*) = [ &
+            1.0_real64, &
+            0.81_real64, &
+            0.64_real64, &
+            0.49_real64, &
+            0.36_real64, &
+            0.25_real64, &
+            0.16_real64, &
+            0.09_real64, &
+            0.04_real64, &
+            0.01_real64, & ! The only test value here that needs 4 ULP of tolerance.
+            0.0_real64 &
+        ]
+
+        integer :: i
+        real(real64) :: pi
+
+        do i = 1, size(p)
+            pi = exner_function(constant_cpd, constant_p0, constant_rd, p(i))
+            @assertEqual(expected_pi(i), pi, spacing(expected_pi(i)) * ulp_tolerance)
+
+            pi = exner_function(constant_kappa, constant_p0, p(i))
+            @assertEqual(expected_pi(i), pi, spacing(expected_pi(i)) * ulp_tolerance)
+        end do
+    end subroutine test_exner_function_family_by_known_values
+
+    @test
+    subroutine test_exner_function_family_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: exner_function
+        use funit
+
+        real(real64), parameter :: constant_cpd = 1004.64_real64
+        real(real64), parameter :: constant_p0 = 100000.0_real64
+        real(real64), parameter :: constant_rd = 287.04_real64
+        real(real64), parameter :: constant_kappa = constant_rd / constant_cpd
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 2
+
+        integer :: i
+        real(real64) :: pi
+        real(real64), allocatable :: p(:)
+        real(real64), allocatable :: expected_pi(:)
+
+        call generate_test_data()
+
+        do i = 1, size(p)
+            pi = exner_function(constant_cpd, constant_p0, constant_rd, p(i))
+            @assertTrue(pi >= 0.0_real64 .and. pi <= 1.0_real64)
+            @assertEqual(expected_pi(i), pi, spacing(expected_pi(i)) * ulp_tolerance)
+            call store_error_statistics(expected_pi(i), pi, ulp_tolerance)
+
+            pi = exner_function(constant_kappa, constant_p0, p(i))
+            @assertTrue(pi >= 0.0_real64 .and. pi <= 1.0_real64)
+            @assertEqual(expected_pi(i), pi, spacing(expected_pi(i)) * ulp_tolerance)
+            call store_error_statistics(expected_pi(i), pi, ulp_tolerance)
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: constant_cpd_real128 = 1004.64_real128
+            real(real128), parameter :: constant_p0_real128 = 100000.0_real128
+            real(real128), parameter :: constant_rd_real128 = 287.04_real128
+            real(real128), parameter :: constant_kappa_real128 = constant_rd_real128 / constant_cpd_real128
+
+            real(real128), parameter :: interval_p = 1.0_real128
+            real(real128), parameter :: range_p(2) = [1000.0_real128, constant_p0_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: p_real128(:)
+            real(real128), allocatable :: expected_pi_real128(:)
+
+            n = nint((range_p(2) - range_p(1)) / interval_p) + 1
+
+            allocate(p_real128(n))
+            p_real128(:) = [(range_p(1) + real(i - 1, real128) * interval_p, i = 1, n)]
+            p = real(p_real128, real64)
+
+            allocate(expected_pi_real128(size(p_real128)))
+            expected_pi_real128(:) = (p_real128(:) / constant_p0_real128) ** constant_kappa_real128
+            expected_pi = real(expected_pi_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_exner_function_family_by_typical_values
+
+    @test
+    subroutine test_hydrostatic_equation_family_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: dp_by_hydrostatic_equation
+        use funit
+
+        real(real64), parameter :: constant_g = 9.80665_real64
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 1
+        real(real64), parameter :: dz(*) = [ &
+            0.0_real64, &
+            1.0_real64, &
+            10.0_real64, &
+            100.0_real64, &
+            1000.0_real64 &
+        ]
+        real(real64), parameter :: rho = 1.2_real64
+        real(real64), parameter :: expected_dp(*) = [ &
+            0.0_real64, &
+            -11.76798_real64, &
+            -117.6798_real64, &
+            -1176.798_real64, &
+            -11767.98_real64 &
+        ]
+
+        integer :: i
+        real(real64) :: dp
+
+        do i = 1, size(dz)
+            dp = dp_by_hydrostatic_equation(constant_g, rho, dz(i))
+            @assertEqual(expected_dp(i), dp, spacing(expected_dp(i)) * ulp_tolerance)
+
+            ! This function should work both ways. `dz` can be positive or negative.
+            dp = dp_by_hydrostatic_equation(constant_g, rho, -dz(i))
+            @assertEqual(-expected_dp(i), dp, spacing(-expected_dp(i)) * ulp_tolerance)
+        end do
+    end subroutine test_hydrostatic_equation_family_by_known_values
+
+    @test
+    subroutine test_hydrostatic_equation_family_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: dp_by_hydrostatic_equation
+        use funit
+
+        real(real64), parameter :: constant_g = 9.80665_real64
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 2
+
+        integer :: i, j
+        real(real64) :: dp
+        real(real64), allocatable :: dz(:), rho(:)
+        real(real64), allocatable :: expected_dp(:, :)
+
+        call generate_test_data()
+
+        do i = 1, size(dz)
+            do j = 1, size(rho)
+                dp = dp_by_hydrostatic_equation(constant_g, rho(j), dz(i))
+                @assertEqual(expected_dp(i, j), dp, spacing(expected_dp(i, j)) * ulp_tolerance)
+                call store_error_statistics(expected_dp(i, j), dp, ulp_tolerance)
+
+                ! This function should work both ways. `dz` can be positive or negative.
+                dp = dp_by_hydrostatic_equation(constant_g, rho(j), -dz(i))
+                @assertEqual(-expected_dp(i, j), dp, spacing(-expected_dp(i, j)) * ulp_tolerance)
+                call store_error_statistics(-expected_dp(i, j), dp, ulp_tolerance)
+            end do
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: constant_g_real128 = 9.80665_real128
+
+            real(real128), parameter :: interval_dz = 1.0_real128
+            real(real128), parameter :: interval_rho = 0.01_real128
+            real(real128), parameter :: range_dz(2) = [0.0_real128, 1000.0_real128]
+            real(real128), parameter :: range_rho(2) = [0.01_real128, 1.5_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: dz_real128(:), rho_real128(:)
+            real(real128), allocatable :: expected_dp_real128(:, :)
+
+            n = nint((range_dz(2) - range_dz(1)) / interval_dz) + 1
+
+            allocate(dz_real128(n))
+            dz_real128(:) = [(range_dz(1) + real(i - 1, real128) * interval_dz, i = 1, n)]
+            dz = real(dz_real128, real64)
+
+            n = nint((range_rho(2) - range_rho(1)) / interval_rho) + 1
+
+            allocate(rho_real128(n))
+            rho_real128(:) = [(range_rho(1) + real(i - 1, real128) * interval_rho, i = 1, n)]
+            rho = real(rho_real128, real64)
+
+            allocate(expected_dp_real128(size(dz_real128), size(rho_real128)))
+
+            do i = 1, size(rho_real128)
+                expected_dp_real128(:, i) = -rho_real128(i) * constant_g_real128 * dz_real128(:)
+            end do
+
+            expected_dp = real(expected_dp_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_hydrostatic_equation_family_by_typical_values
+
+    @test
+    subroutine test_hypsometric_equation_family_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: p_by_hypsometric_equation
+        use funit
+
+        real(real64), parameter :: constant_g = 9.80665_real64
+        real(real64), parameter :: constant_rd = 287.04_real64
+
+        ! Significant figures and relative tolerance to pass the test.
+        integer, parameter :: significant_figures = 12
+        real(real64), parameter :: relative_tolerance = 5.0_real64 * (10.0_real64 ** real(-significant_figures, real64))
+        real(real64), parameter :: tv = 288.15_real64
+        real(real64), parameter :: z2(*) = [ &
+            0.0_real64, &
+            1.0_real64, &
+            10.0_real64, &
+            100.0_real64, &
+            1000.0_real64, &
+            8434.13153319_real64 & ! Scale height.
+        ]
+        real(real64), parameter :: expected_p2(*) = [ &
+            101325.0_real64, &
+            101312.987027_real64, &
+            101204.934342_real64, &
+            100130.725493_real64, &
+            89996.1885025_real64, &
+            101325.0_real64 * exp(-1.0_real64) & ! e-folding pressure at scale height.
+        ]
+
+        integer :: i
+        real(real64) :: p1, p2, z1
+
+        do i = 1, size(z2)
+            p1 = expected_p2(1)
+            z1 = z2(1)
+
+            p2 = p_by_hypsometric_equation(constant_g, constant_rd, p1, z1, tv, z2(i))
+            @assertEqual(expected_p2(i), p2, expected_p2(i) * relative_tolerance)
+
+            ! This function should work both ways. `z1` can be above or below `z2`.
+            p1 = expected_p2(size(expected_p2))
+            z1 = z2(size(z2))
+
+            p2 = p_by_hypsometric_equation(constant_g, constant_rd, p1, z1, tv, z2(i))
+            @assertEqual(expected_p2(i), p2, expected_p2(i) * relative_tolerance)
+        end do
+    end subroutine test_hypsometric_equation_family_by_known_values
+
+    @test
+    subroutine test_hypsometric_equation_family_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: p_by_hypsometric_equation
+        use funit
+
+        real(real64), parameter :: constant_g = 9.80665_real64
+        real(real64), parameter :: constant_rd = 287.04_real64
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 5
+
+        integer :: i, j
+        real(real64) :: p1, p2, z1
+        real(real64), allocatable :: tv(:), z2(:)
+        real(real64), allocatable :: expected_p2(:, :)
+
+        call generate_test_data()
+
+        do i = 1, size(tv)
+            do j = 1, size(z2)
+                p1 = expected_p2(i, 1)
+                z1 = z2(1)
+
+                p2 = p_by_hypsometric_equation(constant_g, constant_rd, p1, z1, tv(i), z2(j))
+                @assertEqual(expected_p2(i, j), p2, spacing(expected_p2(i, j)) * ulp_tolerance)
+                call store_error_statistics(expected_p2(i, j), p2, ulp_tolerance)
+
+                ! This function should work both ways. `z1` can be above or below `z2`.
+                p1 = expected_p2(i, size(expected_p2, 2))
+                z1 = z2(size(z2))
+
+                p2 = p_by_hypsometric_equation(constant_g, constant_rd, p1, z1, tv(i), z2(j))
+                @assertEqual(expected_p2(i, j), p2, spacing(expected_p2(i, j)) * ulp_tolerance)
+                call store_error_statistics(expected_p2(i, j), p2, ulp_tolerance)
+            end do
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: constant_g_real128 = 9.80665_real128
+            real(real128), parameter :: constant_rd_real128 = 287.04_real128
+
+            real(real128), parameter :: p1_real128 = 101325.0_real128
+            real(real128), parameter :: z1_real128 = 0.0_real128
+
+            real(real128), parameter :: interval_t = 1.0_real128
+            real(real128), parameter :: interval_z = 1.0_real128
+            real(real128), parameter :: range_t(2) = [223.15_real128, 323.15_real128]
+            real(real128), parameter :: range_z(2) = [0.0_real128, 10000.0_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: tv_real128(:), z2_real128(:)
+            real(real128), allocatable :: expected_p2_real128(:, :)
+
+            n = nint((range_t(2) - range_t(1)) / interval_t) + 1
+
+            allocate(tv_real128(n))
+            tv_real128(:) = [(range_t(1) + real(i - 1, real128) * interval_t, i = 1, n)]
+            tv = real(tv_real128, real64)
+
+            n = nint((range_z(2) - range_z(1)) / interval_z) + 1
+
+            allocate(z2_real128(n))
+            z2_real128(:) = [(range_z(1) + real(i - 1, real128) * interval_z, i = 1, n)]
+            z2 = real(z2_real128, real64)
+
+            allocate(expected_p2_real128(size(tv_real128), size(z2_real128)))
+
+            do i = 1, size(z2_real128)
+                expected_p2_real128(:, i) = &
+                    p1_real128 * exp(-(z2_real128(i) - z1_real128) * constant_g_real128 / (constant_rd_real128 * tv_real128(:)))
+            end do
+
+            expected_p2 = real(expected_p2_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_hypsometric_equation_family_by_typical_values
+
+    @test
+    subroutine test_poisson_equation_family_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: t_by_poisson_equation, &
+                                  theta_by_poisson_equation
+        use funit
+
+        real(real64), parameter :: constant_cpd = 1004.64_real64
+        real(real64), parameter :: constant_p0 = 100000.0_real64
+        real(real64), parameter :: constant_rd = 287.04_real64
+
+        ! Significant figures and relative tolerance to pass the test.
+        integer, parameter :: significant_figures = 12
+        real(real64), parameter :: relative_tolerance = 5.0_real64 * (10.0_real64 ** real(-significant_figures, real64))
+        real(real64), parameter :: p(*) = [ &
+            constant_p0, &
+            92500.0_real64, &
+            85000.0_real64, &
+            70000.0_real64, &
+            50000.0_real64, &
+            40000.0_real64, &
+            30000.0_real64, &
+            25000.0_real64, &
+            20000.0_real64, &
+            15000.0_real64, &
+            10000.0_real64 &
+        ]
+        real(real64), parameter :: expected_theta = 323.15_real64
+        real(real64), parameter :: expected_t(*) = [ &
+            expected_theta, &
+            316.031497918_real64, &
+            308.487903492_real64, &
+            291.841102569_real64, &
+            265.091370294_real64, &
+            248.717884395_real64, &
+            229.092163183_real64, &
+            217.463823625_real64, &
+            204.032074241_real64, &
+            187.932401243_real64, &
+            167.374724259_real64 &
+        ]
+
+        integer :: i
+        real(real64) :: t, theta
+
+        do i = 1, size(p)
+            t = t_by_poisson_equation(constant_cpd, constant_p0, constant_rd, expected_theta, p(i))
+            @assertEqual(expected_t(i), t, expected_t(i) * relative_tolerance)
+
+            theta = theta_by_poisson_equation(constant_cpd, constant_p0, constant_rd, t, p(i))
+            @assertEqual(expected_theta, theta, expected_theta * relative_tolerance)
+        end do
+    end subroutine test_poisson_equation_family_by_known_values
+
+    @test
+    subroutine test_poisson_equation_family_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: t_by_poisson_equation, &
+                                  theta_by_poisson_equation
+        use funit
+
+        real(real64), parameter :: constant_cpd = 1004.64_real64
+        real(real64), parameter :: constant_p0 = 100000.0_real64
+        real(real64), parameter :: constant_rd = 287.04_real64
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 2
+
+        integer :: i, j
+        real(real64) :: t, theta
+        real(real64), allocatable :: p(:)
+        real(real64), allocatable :: expected_t(:, :), expected_theta(:)
+
+        call generate_test_data()
+
+        do i = 1, size(p)
+            do j = 1, size(expected_theta)
+                t = t_by_poisson_equation(constant_cpd, constant_p0, constant_rd, expected_theta(j), p(i))
+                @assertEqual(expected_t(i, j), t, spacing(expected_t(i, j)) * ulp_tolerance)
+                call store_error_statistics(expected_t(i, j), t, ulp_tolerance)
+
+                theta = theta_by_poisson_equation(constant_cpd, constant_p0, constant_rd, expected_t(i, j), p(i))
+                @assertEqual(expected_theta(j), theta, spacing(expected_theta(j)) * ulp_tolerance)
+                call store_error_statistics(expected_theta(j), theta, ulp_tolerance)
+            end do
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: constant_cpd_real128 = 1004.64_real128
+            real(real128), parameter :: constant_p0_real128 = 100000.0_real128
+            real(real128), parameter :: constant_rd_real128 = 287.04_real128
+
+            real(real128), parameter :: interval_p = 1.0_real128
+            real(real128), parameter :: interval_t = 1.0_real128
+            real(real128), parameter :: range_p(2) = [10000.0_real128, constant_p0_real128]
+            real(real128), parameter :: range_t(2) = [223.15_real128, 323.15_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: p_real128(:)
+            real(real128), allocatable :: expected_t_real128(:, :), expected_theta_real128(:)
+
+            n = nint((range_p(2) - range_p(1)) / interval_p) + 1
+
+            allocate(p_real128(n))
+            p_real128(:) = [(range_p(1) + real(i - 1, real128) * interval_p, i = 1, n)]
+            p = real(p_real128, real64)
+
+            n = nint((range_t(2) - range_t(1)) / interval_t) + 1
+
+            allocate(expected_theta_real128(n))
+            expected_theta_real128(:) = [(range_t(1) + real(i - 1, real128) * interval_t, i = 1, n)]
+            expected_theta = real(expected_theta_real128, real64)
+
+            allocate(expected_t_real128(size(p_real128), size(expected_theta_real128)))
+
+            do i = 1, size(expected_theta_real128)
+                expected_t_real128(:, i) = &
+                    expected_theta_real128(i) * &
+                    ((p_real128(:) / constant_p0_real128) ** (constant_rd_real128 / constant_cpd_real128))
+            end do
+
+            expected_t = real(expected_t_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_poisson_equation_family_by_typical_values
+
+    @test
+    subroutine test_omega_of_w_rho_and_vice_versa_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: omega_of_w_rho, &
+                                  w_of_omega_rho
+        use funit
+
+        real(real64), parameter :: constant_g = 9.80665_real64
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 1
+        real(real64), parameter :: rho = 1.2_real64
+        real(real64), parameter :: expected_omega(*) = [ &
+            0.0_real64, &
+            -117.6798_real64, &
+            -235.3596_real64, &
+            -353.0394_real64, &
+            -470.7192_real64, &
+            -588.399_real64 &
+        ]
+        real(real64), parameter :: expected_w(*) = [ &
+            0.0_real64, &
+            10.0_real64, &
+            20.0_real64, &
+            30.0_real64, &
+            40.0_real64, &
+            50.0_real64 &
+        ]
+
+        integer :: i
+        real(real64) :: omega, w
+
+        do i = 1, size(expected_omega)
+            omega = omega_of_w_rho(constant_g, expected_w(i), rho)
+            @assertEqual(expected_omega(i), omega, spacing(expected_omega(i)) * ulp_tolerance)
+
+            w = w_of_omega_rho(constant_g, expected_omega(i), rho)
+            @assertEqual(expected_w(i), w, spacing(expected_w(i)) * ulp_tolerance)
+
+            ! This function should work both ways. `omega` and `w` can be positive or negative.
+            omega = omega_of_w_rho(constant_g, -expected_w(i), rho)
+            @assertEqual(-expected_omega(i), omega, spacing(-expected_omega(i)) * ulp_tolerance)
+
+            w = w_of_omega_rho(constant_g, -expected_omega(i), rho)
+            @assertEqual(-expected_w(i), w, spacing(-expected_w(i)) * ulp_tolerance)
+        end do
+    end subroutine test_omega_of_w_rho_and_vice_versa_by_known_values
+
+    @test
+    subroutine test_omega_of_w_rho_and_vice_versa_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: omega_of_w_rho, &
+                                  w_of_omega_rho
+        use funit
+
+        real(real64), parameter :: constant_g = 9.80665_real64
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 3
+
+        integer :: i, j
+        real(real64) :: omega, w
+        real(real64), allocatable :: rho(:)
+        real(real64), allocatable :: expected_omega(:, :), expected_w(:)
+
+        call generate_test_data()
+
+        do i = 1, size(rho)
+            do j = 1, size(expected_w)
+                omega = omega_of_w_rho(constant_g, expected_w(j), rho(i))
+                @assertEqual(expected_omega(i, j), omega, spacing(expected_omega(i, j)) * ulp_tolerance)
+                call store_error_statistics(expected_omega(i, j), omega, ulp_tolerance)
+
+                w = w_of_omega_rho(constant_g, expected_omega(i, j), rho(i))
+                @assertEqual(expected_w(j), w, spacing(expected_w(j)) * ulp_tolerance)
+                call store_error_statistics(expected_w(j), w, ulp_tolerance)
+
+                ! This function should work both ways. `omega` and `w` can be positive or negative.
+                omega = omega_of_w_rho(constant_g, -expected_w(j), rho(i))
+                @assertEqual(-expected_omega(i, j), omega, spacing(-expected_omega(i, j)) * ulp_tolerance)
+                call store_error_statistics(-expected_omega(i, j), omega, ulp_tolerance)
+
+                w = w_of_omega_rho(constant_g, -expected_omega(i, j), rho(i))
+                @assertEqual(-expected_w(j), w, spacing(-expected_w(j)) * ulp_tolerance)
+                call store_error_statistics(-expected_w(j), w, ulp_tolerance)
+            end do
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: constant_g_real128 = 9.80665_real128
+
+            real(real128), parameter :: interval_rho = 0.01_real128
+            real(real128), parameter :: interval_w = 0.1_real128
+            real(real128), parameter :: range_rho(2) = [0.01_real128, 1.5_real128]
+            real(real128), parameter :: range_w(2) = [0.0_real128, 50.0_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: rho_real128(:)
+            real(real128), allocatable :: expected_omega_real128(:, :), expected_w_real128(:)
+
+            n = nint((range_rho(2) - range_rho(1)) / interval_rho) + 1
+
+            allocate(rho_real128(n))
+            rho_real128(:) = [(range_rho(1) + real(i - 1, real128) * interval_rho, i = 1, n)]
+            rho = real(rho_real128, real64)
+
+            n = nint((range_w(2) - range_w(1)) / interval_w) + 1
+
+            allocate(expected_w_real128(n))
+            expected_w_real128(:) = [(range_w(1) + real(i - 1, real128) * interval_w, i = 1, n)]
+            expected_w = real(expected_w_real128, real64)
+
+            allocate(expected_omega_real128(size(rho_real128), size(expected_w_real128)))
+
+            do i = 1, size(expected_w_real128)
+                expected_omega_real128(:, i) = -rho_real128(:) * constant_g_real128 * expected_w_real128(i)
+            end do
+
+            expected_omega = real(expected_omega_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_omega_of_w_rho_and_vice_versa_by_typical_values
+
+    @test
+    subroutine test_qv_of_sh_and_vice_versa_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: qv_of_sh, &
+                                  sh_of_qv
+        use funit
+
+        ! Significant figures and relative tolerance to pass the test.
+        integer, parameter :: significant_figures = 12
+        real(real64), parameter :: relative_tolerance = 5.0_real64 * (10.0_real64 ** real(-significant_figures, real64))
+        real(real64), parameter :: expected_qv(*) = [ &
+            0.0_real64, &
+            0.005_real64, &
+            0.01_real64, &
+            0.015_real64, &
+            0.02_real64, &
+            0.025_real64, &
+            0.03_real64, &
+            0.035_real64, &
+            0.04_real64 &
+        ]
+        real(real64), parameter :: expected_sh(*) = [ &
+            0.0_real64, &
+            0.00497512437811_real64, &
+            0.00990099009901_real64, &
+            0.0147783251232_real64, &
+            0.0196078431373_real64, &
+            0.0243902439024_real64, &
+            0.0291262135922_real64, &
+            0.0338164251208_real64, &
+            0.0384615384615_real64 &
+        ]
+
+        integer :: i
+        real(real64) :: qv, sh
+
+        do i = 1, size(expected_qv)
+            qv = qv_of_sh(expected_sh(i))
+            @assertEqual(expected_qv(i), qv, expected_qv(i) * relative_tolerance)
+
+            sh = sh_of_qv(qv)
+            @assertEqual(expected_sh(i), sh, expected_sh(i) * relative_tolerance)
+        end do
+    end subroutine test_qv_of_sh_and_vice_versa_by_known_values
+
+    @test
+    subroutine test_qv_of_sh_and_vice_versa_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: qv_of_sh, &
+                                  sh_of_qv
+        use funit
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 2
+
+        integer :: i
+        real(real64) :: qv, sh
+        real(real64), allocatable :: expected_qv(:), expected_sh(:)
+
+        call generate_test_data()
+
+        do i = 1, size(expected_qv)
+            qv = qv_of_sh(expected_sh(i))
+            @assertEqual(expected_qv(i), qv, spacing(expected_qv(i)) * ulp_tolerance)
+            call store_error_statistics(expected_qv(i), qv, ulp_tolerance)
+
+            sh = sh_of_qv(qv)
+            @assertEqual(expected_sh(i), sh, spacing(expected_sh(i)) * ulp_tolerance)
+            call store_error_statistics(expected_sh(i), sh, ulp_tolerance)
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: interval_q = 0.000001_real128
+            real(real128), parameter :: range_q(2) = [0.0_real128, 0.04_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: expected_qv_real128(:), expected_sh_real128(:)
+
+            n = nint((range_q(2) - range_q(1)) / interval_q) + 1
+
+            allocate(expected_qv_real128(n))
+            expected_qv_real128(:) = [(range_q(1) + real(i - 1, real128) * interval_q, i = 1, n)]
+            expected_qv = real(expected_qv_real128, real64)
+
+            allocate(expected_sh_real128(size(expected_qv_real128)))
+            expected_sh_real128(:) = expected_qv_real128(:) / (1.0_real128 + expected_qv_real128(:))
+            expected_sh = real(expected_sh_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_qv_of_sh_and_vice_versa_by_typical_values
+
+    @test
+    subroutine test_t_of_theta_rhod_qv_and_vice_versa_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: t_of_theta_rhod_qv, &
+                                  theta_of_t_rhod_qv
+        use funit
+
+        real(real64), parameter :: constant_cpd = 1004.64_real64
+        real(real64), parameter :: constant_p0 = 100000.0_real64
+        real(real64), parameter :: constant_rd = 287.04_real64
+        real(real64), parameter :: constant_rv = 461.52_real64
+
+        ! Significant figures and relative tolerance to pass the test.
+        integer, parameter :: significant_figures = 12
+        real(real64), parameter :: relative_tolerance = 5.0_real64 * (10.0_real64 ** real(-significant_figures, real64))
+        real(real64), parameter :: qv = 0.02_real64
+        real(real64), parameter :: rhod = 1.2_real64
+        real(real64), parameter :: expected_t(*) = [ &
+            223.15_real64, &
+            233.15_real64, &
+            243.15_real64, &
+            253.15_real64, &
+            263.15_real64, &
+            273.15_real64, &
+            283.15_real64, &
+            293.15_real64, &
+            303.15_real64, &
+            313.15_real64, &
+            323.15_real64 &
+        ]
+        real(real64), parameter :: expected_theta(*) = [ &
+            238.407973718_real64, &
+            245.991287517_real64, &
+            253.482206290_real64, &
+            260.885589838_real64, &
+            268.205861297_real64, &
+            275.447061415_real64, &
+            282.612894352_real64, &
+            289.706766573_real64, &
+            296.731820076_real64, &
+            303.690960945_real64, &
+            310.586884004_real64 &
+        ]
+
+        integer :: i
+        real(real64) :: t, theta
+
+        do i = 1, size(expected_t)
+            t = t_of_theta_rhod_qv(constant_cpd, constant_p0, constant_rd, constant_rv, expected_theta(i), rhod, qv)
+            @assertEqual(expected_t(i), t, expected_t(i) * relative_tolerance)
+
+            theta = theta_of_t_rhod_qv(constant_cpd, constant_p0, constant_rd, constant_rv, expected_t(i), rhod, qv)
+            @assertEqual(expected_theta(i), theta, expected_theta(i) * relative_tolerance)
+        end do
+    end subroutine test_t_of_theta_rhod_qv_and_vice_versa_by_known_values
+
+    @test
+    subroutine test_t_of_theta_rhod_qv_and_vice_versa_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: t_of_theta_rhod_qv, &
+                                  theta_of_t_rhod_qv
+        use funit
+
+        real(real64), parameter :: constant_cpd = 1004.64_real64
+        real(real64), parameter :: constant_p0 = 100000.0_real64
+        real(real64), parameter :: constant_rd = 287.04_real64
+        real(real64), parameter :: constant_rv = 461.52_real64
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 6
+
+        integer :: i, j, k
+        real(real64) :: t, theta
+        real(real64), allocatable :: qv(:), rhod(:)
+        real(real64), allocatable :: expected_t(:), expected_theta(:, :, :)
+
+        call generate_test_data()
+
+        do i = 1, size(qv)
+            do j = 1, size(rhod)
+                do k = 1, size(expected_t)
+                    t = t_of_theta_rhod_qv( &
+                        constant_cpd, constant_p0, constant_rd, constant_rv, expected_theta(i, j, k), rhod(j), qv(i))
+                    @assertEqual(expected_t(k), t, spacing(expected_t(k)) * ulp_tolerance)
+                    call store_error_statistics(expected_t(k), t, ulp_tolerance)
+
+                    theta = theta_of_t_rhod_qv( &
+                        constant_cpd, constant_p0, constant_rd, constant_rv, expected_t(k), rhod(j), qv(i))
+                    @assertEqual(expected_theta(i, j, k), theta, spacing(expected_theta(i, j, k)) * ulp_tolerance)
+                    call store_error_statistics(expected_theta(i, j, k), theta, ulp_tolerance)
+                end do
+            end do
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: constant_cpd_real128 = 1004.64_real128
+            real(real128), parameter :: constant_p0_real128 = 100000.0_real128
+            real(real128), parameter :: constant_rd_real128 = 287.04_real128
+            real(real128), parameter :: constant_rv_real128 = 461.52_real128
+            real(real128), parameter :: constant_cvd_real128 = constant_cpd_real128 - constant_rd_real128
+
+            real(real128), parameter :: interval_q = 0.0001_real128
+            real(real128), parameter :: interval_rho = 0.01_real128
+            real(real128), parameter :: interval_t = 1.0_real128
+            real(real128), parameter :: range_q(2) = [0.0_real128, 0.04_real128]
+            real(real128), parameter :: range_rho(2) = [0.01_real128, 1.5_real128]
+            real(real128), parameter :: range_t(2) = [223.15_real128, 323.15_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: qv_real128(:), rhod_real128(:)
+            real(real128), allocatable :: expected_t_real128(:), expected_theta_real128(:, :, :)
+
+            n = nint((range_q(2) - range_q(1)) / interval_q) + 1
+
+            allocate(qv_real128(n))
+            qv_real128(:) = [(range_q(1) + real(i - 1, real128) * interval_q, i = 1, n)]
+            qv = real(qv_real128, real64)
+
+            n = nint((range_rho(2) - range_rho(1)) / interval_rho) + 1
+
+            allocate(rhod_real128(n))
+            rhod_real128(:) = [(range_rho(1) + real(i - 1, real128) * interval_rho, i = 1, n)]
+            rhod = real(rhod_real128, real64)
+
+            n = nint((range_t(2) - range_t(1)) / interval_t) + 1
+
+            allocate(expected_t_real128(n))
+            expected_t_real128(:) = [(range_t(1) + real(i - 1, real128) * interval_t, i = 1, n)]
+            expected_t = real(expected_t_real128, real64)
+
+            allocate(expected_theta_real128(size(qv_real128), size(rhod_real128), size(expected_t_real128)))
+
+            do i = 1, size(expected_t_real128)
+                do j = 1, size(rhod_real128)
+                    expected_theta_real128(:, j, i) = &
+                        (expected_t_real128(i) ** (constant_cvd_real128 / constant_cpd_real128)) * &
+                        ((constant_p0_real128 / (rhod_real128(j) * constant_rd_real128 * &
+                        (1.0_real128 + constant_rv_real128 / constant_rd_real128 * qv_real128(:)))) ** &
+                        (constant_rd_real128 / constant_cpd_real128))
+                end do
+            end do
+
+            expected_theta = real(expected_theta_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_t_of_theta_rhod_qv_and_vice_versa_by_typical_values
+
+    @test
+    subroutine test_t_of_tm_qv_and_vice_versa_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: t_of_tm_qv, &
+                                  tm_of_t_qv
+        use funit
+
+        real(real64), parameter :: constant_rd = 287.04_real64
+        real(real64), parameter :: constant_rv = 461.52_real64
+
+        ! Significant figures and relative tolerance to pass the test.
+        integer, parameter :: significant_figures = 12
+        real(real64), parameter :: relative_tolerance = 5.0_real64 * (10.0_real64 ** real(-significant_figures, real64))
+        real(real64), parameter :: qv = 0.02_real64
+        real(real64), parameter :: expected_t(*) = [ &
+            223.15_real64, &
+            233.15_real64, &
+            243.15_real64, &
+            253.15_real64, &
+            263.15_real64, &
+            273.15_real64, &
+            283.15_real64, &
+            293.15_real64, &
+            303.15_real64, &
+            313.15_real64, &
+            323.15_real64 &
+        ]
+        real(real64), parameter :: expected_tm(*) = [ &
+            230.325877090_real64, &
+            240.647448997_real64, &
+            250.969020903_real64, &
+            261.290592809_real64, &
+            271.612164716_real64, &
+            281.933736622_real64, &
+            292.255308528_real64, &
+            302.576880435_real64, &
+            312.898452341_real64, &
+            323.220024247_real64, &
+            333.541596154_real64 &
+        ]
+
+        integer :: i
+        real(real64) :: t, tm
+
+        do i = 1, size(expected_t)
+            t = t_of_tm_qv(constant_rd, constant_rv, expected_tm(i), qv)
+            @assertEqual(expected_t(i), t, expected_t(i) * relative_tolerance)
+
+            tm = tm_of_t_qv(constant_rd, constant_rv, t, qv)
+            @assertEqual(expected_tm(i), tm, expected_tm(i) * relative_tolerance)
+        end do
+    end subroutine test_t_of_tm_qv_and_vice_versa_by_known_values
+
+    @test
+    subroutine test_t_of_tm_qv_and_vice_versa_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: t_of_tm_qv, &
+                                  tm_of_t_qv
+        use funit
+
+        real(real64), parameter :: constant_rd = 287.04_real64
+        real(real64), parameter :: constant_rv = 461.52_real64
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 2
+
+        integer :: i, j
+        real(real64) :: t, tm
+        real(real64), allocatable :: qv(:)
+        real(real64), allocatable :: expected_t(:), expected_tm(:, :)
+
+        call generate_test_data()
+
+        do i = 1, size(qv)
+            do j = 1, size(expected_t)
+                t = t_of_tm_qv(constant_rd, constant_rv, expected_tm(i, j), qv(i))
+                @assertEqual(expected_t(j), t, spacing(expected_t(j)) * ulp_tolerance)
+                call store_error_statistics(expected_t(j), t, ulp_tolerance)
+
+                tm = tm_of_t_qv(constant_rd, constant_rv, expected_t(j), qv(i))
+                @assertEqual(expected_tm(i, j), tm, spacing(expected_tm(i, j)) * ulp_tolerance)
+                call store_error_statistics(expected_tm(i, j), tm, ulp_tolerance)
+            end do
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: constant_rd_real128 = 287.04_real128
+            real(real128), parameter :: constant_rv_real128 = 461.52_real128
+
+            real(real128), parameter :: interval_q = 0.0001_real128
+            real(real128), parameter :: interval_t = 1.0_real128
+            real(real128), parameter :: range_q(2) = [0.0_real128, 0.04_real128]
+            real(real128), parameter :: range_t(2) = [223.15_real128, 323.15_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: qv_real128(:)
+            real(real128), allocatable :: expected_t_real128(:), expected_tm_real128(:, :)
+
+            n = nint((range_q(2) - range_q(1)) / interval_q) + 1
+
+            allocate(qv_real128(n))
+            qv_real128(:) = [(range_q(1) + real(i - 1, real128) * interval_q, i = 1, n)]
+            qv = real(qv_real128, real64)
+
+            n = nint((range_t(2) - range_t(1)) / interval_t) + 1
+
+            allocate(expected_t_real128(n))
+            expected_t_real128(:) = [(range_t(1) + real(i - 1, real128) * interval_t, i = 1, n)]
+            expected_t = real(expected_t_real128, real64)
+
+            allocate(expected_tm_real128(size(qv_real128), size(expected_t_real128)))
+
+            do i = 1, size(expected_t_real128)
+                expected_tm_real128(:, i) = &
+                    expected_t_real128(i) * (1.0_real128 + constant_rv_real128 / constant_rd_real128 * qv_real128(:))
+            end do
+
+            expected_tm = real(expected_tm_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_t_of_tm_qv_and_vice_versa_by_typical_values
+
+    @test
+    subroutine test_tm_of_tv_qv_and_vice_versa_by_known_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: tm_of_tv_qv, &
+                                  tv_of_tm_qv
+        use funit
+
+        ! Significant figures and relative tolerance to pass the test.
+        integer, parameter :: significant_figures = 12
+        real(real64), parameter :: relative_tolerance = 5.0_real64 * (10.0_real64 ** real(-significant_figures, real64))
+        real(real64), parameter :: qv = 0.02_real64
+        real(real64), parameter :: expected_tm(*) = [ &
+            230.325877090_real64, &
+            240.647448997_real64, &
+            250.969020903_real64, &
+            261.290592809_real64, &
+            271.612164716_real64, &
+            281.933736622_real64, &
+            292.255308528_real64, &
+            302.576880435_real64, &
+            312.898452341_real64, &
+            323.220024247_real64, &
+            333.541596154_real64 &
+        ]
+        real(real64), parameter :: expected_tv(*) = [ &
+            225.809683422_real64, &
+            235.928871566_real64, &
+            246.048059709_real64, &
+            256.167247852_real64, &
+            266.286435996_real64, &
+            276.405624139_real64, &
+            286.524812282_real64, &
+            296.644000426_real64, &
+            306.763188570_real64, &
+            316.882376713_real64, &
+            327.001564857_real64 &
+        ]
+
+        integer :: i
+        real(real64) :: tm, tv
+
+        do i = 1, size(expected_tm)
+            tm = tm_of_tv_qv(expected_tv(i), qv)
+            @assertEqual(expected_tm(i), tm, expected_tm(i) * relative_tolerance)
+
+            tv = tv_of_tm_qv(expected_tm(i), qv)
+            @assertEqual(expected_tv(i), tv, expected_tv(i) * relative_tolerance)
+        end do
+    end subroutine test_tm_of_tv_qv_and_vice_versa_by_known_values
+
+    @test
+    subroutine test_tm_of_tv_qv_and_vice_versa_by_typical_values()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: tm_of_tv_qv, &
+                                  tv_of_tm_qv
+        use funit
+
+        ! Tolerance, in the number of units in the last place (ULP), to pass the test.
+        integer, parameter :: ulp_tolerance = 2
+
+        integer :: i, j
+        real(real64) :: tm, tv
+        real(real64), allocatable :: qv(:)
+        real(real64), allocatable :: expected_tm(:), expected_tv(:, :)
+
+        call generate_test_data()
+
+        do i = 1, size(qv)
+            do j = 1, size(expected_tm)
+                tm = tm_of_tv_qv(expected_tv(i, j), qv(i))
+                @assertEqual(expected_tm(j), tm, spacing(expected_tm(j)) * ulp_tolerance)
+                call store_error_statistics(expected_tm(j), tm, ulp_tolerance)
+
+                tv = tv_of_tm_qv(expected_tm(j), qv(i))
+                @assertEqual(expected_tv(i, j), tv, spacing(expected_tv(i, j)) * ulp_tolerance)
+                call store_error_statistics(expected_tv(i, j), tv, ulp_tolerance)
+            end do
+        end do
+    contains
+        ! Generate test data in quadruple precision, truncate back to double precision at last, and regard them as true answers.
+        subroutine generate_test_data()
+            use, intrinsic :: iso_fortran_env, only: real128
+
+            real(real128), parameter :: interval_q = 0.0001_real128
+            real(real128), parameter :: interval_t = 1.0_real128
+            real(real128), parameter :: range_q(2) = [0.0_real128, 0.04_real128]
+            real(real128), parameter :: range_t(2) = [223.15_real128, 323.15_real128]
+
+            integer :: i, n
+            real(real128), allocatable :: qv_real128(:)
+            real(real128), allocatable :: expected_tm_real128(:), expected_tv_real128(:, :)
+
+            n = nint((range_q(2) - range_q(1)) / interval_q) + 1
+
+            allocate(qv_real128(n))
+            qv_real128(:) = [(range_q(1) + real(i - 1, real128) * interval_q, i = 1, n)]
+            qv = real(qv_real128, real64)
+
+            n = nint((range_t(2) - range_t(1)) / interval_t) + 1
+
+            allocate(expected_tm_real128(n))
+            expected_tm_real128(:) = [(range_t(1) + real(i - 1, real128) * interval_t, i = 1, n)]
+            expected_tm = real(expected_tm_real128, real64)
+
+            allocate(expected_tv_real128(size(qv_real128), size(expected_tm_real128)))
+
+            do i = 1, size(expected_tm_real128)
+                expected_tv_real128(:, i) = &
+                    expected_tm_real128(i) / (1.0_real64 + qv_real128(:))
+            end do
+
+            expected_tv = real(expected_tv_real128, real64)
+        end subroutine generate_test_data
+    end subroutine test_tm_of_tv_qv_and_vice_versa_by_typical_values
+
+    @test
+    subroutine test_reverse_by_empty_arrays()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: reverse
+        use funit
+
+        real(real64), allocatable :: array(:), reversed(:)
+
+        allocate(array(0))
+
+        reversed = reverse(array)
+
+        @assertTrue(allocated(reversed))
+        @assertEqual(0, size(reversed))
+    end subroutine test_reverse_by_empty_arrays
+
+    @test
+    subroutine test_reverse_by_single_element_arrays()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: reverse
+        use funit
+
+        real(real64), parameter :: expected(*) = [ &
+            1.0_real64 &
+        ]
+
+        real(real64), allocatable :: array(:), reversed(:)
+
+        allocate(array(1))
+
+        array(1) = 1.0_real64
+        reversed = reverse(array)
+
+        @assertTrue(allocated(reversed))
+        @assertEqual(expected, reversed)
+    end subroutine test_reverse_by_single_element_arrays
+
+    @test
+    subroutine test_reverse_by_multiple_element_arrays()
+        use, intrinsic :: iso_fortran_env, only: real64
+        use dyn_procedures, only: reverse
+        use funit
+
+        real(real64), parameter :: expected(*) = [ &
+            5.0_real64, &
+            4.0_real64, &
+            3.0_real64, &
+            2.0_real64, &
+            1.0_real64 &
+        ]
+
+        real(real64), allocatable :: array(:), reversed(:)
+
+        allocate(array(5))
+
+        array(1) = 1.0_real64
+        array(2) = 2.0_real64
+        array(3) = 3.0_real64
+        array(4) = 4.0_real64
+        array(5) = 5.0_real64
+        reversed = reverse(array)
+
+        @assertTrue(allocated(reversed))
+        @assertEqual(expected, reversed)
+    end subroutine test_reverse_by_multiple_element_arrays
+
+    @test
+    subroutine test_sec_to_hour_min_sec_by_positive_time()
+        use, intrinsic :: iso_fortran_env, only: int32
+        use dyn_procedures, only: sec_to_hour_min_sec
+        use funit
+
+        integer(int32) :: sec
+        integer(int32) :: hour_min_sec(3)
+        integer(int32) :: expected(3)
+
+        sec = 0_int32
+        expected(:) = [0_int32, 0_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        ! Test if carries are performed correctly from `sec` to `min`.
+
+        sec = 59_int32
+        expected(:) = [0_int32, 0_int32, 59_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 60_int32
+        expected(:) = [0_int32, 1_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 61_int32
+        expected(:) = [0_int32, 1_int32, 1_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 119_int32
+        expected(:) = [0_int32, 1_int32, 59_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 120_int32
+        expected(:) = [0_int32, 2_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 121_int32
+        expected(:) = [0_int32, 2_int32, 1_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        ! Test if carries are performed correctly from `min` to `hour`.
+
+        sec = 3599_int32
+        expected(:) = [0_int32, 59_int32, 59_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 3600_int32
+        expected(:) = [1_int32, 0_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 3601_int32
+        expected(:) = [1_int32, 0_int32, 1_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 7199_int32
+        expected(:) = [1_int32, 59_int32, 59_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 7200_int32
+        expected(:) = [2_int32, 0_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = 7201_int32
+        expected(:) = [2_int32, 0_int32, 1_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+    end subroutine test_sec_to_hour_min_sec_by_positive_time
+
+    @test
+    subroutine test_sec_to_hour_min_sec_by_negative_time()
+        use, intrinsic :: iso_fortran_env, only: int32
+        use dyn_procedures, only: sec_to_hour_min_sec
+        use funit
+
+        integer(int32) :: sec
+        integer(int32) :: hour_min_sec(3)
+        integer(int32) :: expected(3)
+
+        sec = 0_int32
+        expected(:) = [0_int32, 0_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        ! Test if carries are performed correctly from `sec` to `min`.
+
+        sec = -59_int32
+        expected(:) = [0_int32, 0_int32, -59_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -60_int32
+        expected(:) = [0_int32, -1_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -61_int32
+        expected(:) = [0_int32, -1_int32, -1_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -119_int32
+        expected(:) = [0_int32, -1_int32, -59_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -120_int32
+        expected(:) = [0_int32, -2_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -121_int32
+        expected(:) = [0_int32, -2_int32, -1_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        ! Test if carries are performed correctly from `min` to `hour`.
+
+        sec = -3599_int32
+        expected(:) = [0_int32, -59_int32, -59_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -3600_int32
+        expected(:) = [-1_int32, 0_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -3601_int32
+        expected(:) = [-1_int32, 0_int32, -1_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -7199_int32
+        expected(:) = [-1_int32, -59_int32, -59_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -7200_int32
+        expected(:) = [-2_int32, 0_int32, 0_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        sec = -7201_int32
+        expected(:) = [-2_int32, 0_int32, -1_int32]
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+    end subroutine test_sec_to_hour_min_sec_by_negative_time
+
+    @test
+    subroutine test_sec_to_hour_min_sec_by_extreme_time()
+        use, intrinsic :: iso_fortran_env, only: int32
+        use dyn_procedures, only: sec_to_hour_min_sec
+        use funit
+
+        integer(int32) :: sec
+        integer(int32) :: hour_min_sec(3)
+        integer(int32) :: expected(3)
+
+        ! Maximum value of a 32-bit signed integer: 2147483647.
+        sec = huge(0_int32)
+        expected(:) = [596523_int32, 14_int32, 7_int32] ! About 68 years.
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+
+        ! Minimum value of a 32-bit signed integer: -2147483647. It it not -2147483648
+        ! because according to the Fortran standard, numbers have symmetric ranges.
+        sec = -huge(0_int32)
+        expected(:) = [-596523_int32, -14_int32, -7_int32] ! About 68 years.
+        hour_min_sec(:) = sec_to_hour_min_sec(sec)
+        @assertEqual(expected, hour_min_sec)
+    end subroutine test_sec_to_hour_min_sec_by_extreme_time
+end module test_dyn_procedures


### PR DESCRIPTION
### Tag name (required for release branches):

None

### Originator(s):

kuanchihwang

### Descriptions (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

This PR introduces continuous integration (CI) workflows and implements unit tests for MPAS dynamical core. Additionally, pFUnit files (`*.pf`) are now correctly rendered as Fortran source code on GitHub.

Beyond verifying correctness and reliability, the unit tests also report the numerical accuracy of each computational procedure in terms of units in the last place (ULP) away from the exact answers. For example, below is the output for equation of state:

```
2:  Start: <test_dyn_procedures_suite.test_equation_of_state_family_by_typical_values>
2: .
2: Error statistics (N = 31512303):
2:  63.81% of sample values (20107401) have accuracy of 0 <= ULP < 1.
2:  34.31% of sample values (10810918) have accuracy of 1 <= ULP < 2.
2:   1.88% of sample values (593637) have accuracy of 2 <= ULP < 3.
2:   0.00% of sample values (347) have accuracy of 3 <= ULP < 4.
2:    end: <test_dyn_procedures_suite.test_equation_of_state_family_by_typical_values>
```

Whenever changes are made in the path of MPAS dynamical core (`src/dynamics/mpas/*`), the CI workflows automatically build and run the unit tests with various versions of GCC. Test results are collected as artifacts and retained for 7 days for reference.

### Describe any changes made to the build system:

None

### Describe any changes made to the namelist:

None

### List any changes to the defaults for the input datasets (e.g., boundary datasets):

None

### List all files eliminated and why:

None

### List all files added and what they do:

```
A       .gitattributes
  * Make GitHub Linguist recognize `*.pf` files as Fortran source code
A       .github/workflows/mpas_dynamical_core_ci.yml
  * Add CI workflow for MPAS dynamical core
A       src/dynamics/mpas/CMakeLists.txt
A       src/dynamics/mpas/tests/unit/CMakeLists.txt
A       src/dynamics/mpas/tests/unit/test_dyn_mpas_procedures.pf
A       src/dynamics/mpas/tests/unit/test_dyn_procedures.pf
  * Implement unit tests for MPAS dynamical core
```

### List all existing files that have been modified, and describe the changes:

```
M       src/dynamics/mpas/driver/dyn_mpas_procedures.F90
  * Add support for comparing NaN and Inf with `almost_equal`
M       src/dynamics/mpas/dyn_comp_impl.F90
  * Use `almost_equal` for checking topography data
  * Use `qv_of_sh` for converting specific humidity to water vapor mixing ratio
M       src/dynamics/mpas/dyn_coupling_impl.F90
  * Use `exner_function` for improved readability in dynamics-physics coupling
  * Sort `use` statements
M       src/dynamics/mpas/dyn_procedures.F90
  * New interface for `exner_function`
  * Explicitly specify integers to be `int32` in `sec_to_hour_min_sec`
```

### Regression tests:

No changes to any existing tests. All tests pass with respect to the last baseline, `sima0_07_000`.