### PR TITLE
sima0_08_001: update framework and atmospheric physics hashes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "ccpp-framework"]
         path          = ccpp_framework
         url           = https://github.com/NCAR/ccpp-framework
-        fxtag         = 2025-06-03-dev
+        fxtag         = 2025-10-01-dev
         fxrequired    = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/NCAR/ccpp-framework
 [submodule "history"]
@@ -20,7 +20,7 @@
 [submodule "ncar-physics"]
         path          = src/physics/ncar_ccpp
 	url           = https://github.com/ESCOMP/atmospheric_physics
-	fxtag         = atmos_phys0_18_000
+	fxtag         = 72632b99489221ab452dbc2f276cf0e8efcd3063
         fxrequired    = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 [submodule "rrtmgp-data"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "ncar-physics"]
         path          = src/physics/ncar_ccpp
 	url           = https://github.com/ESCOMP/atmospheric_physics
-	fxtag         = 72632b99489221ab452dbc2f276cf0e8efcd3063
+	fxtag         = 73fce2706c1f70e1ba63ff4bb3dcb80323bb9cc6
         fxrequired    = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 [submodule "rrtmgp-data"]

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_se_cslam_analy_ic_cam4/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_se_cslam_analy_ic_cam4/user_nl_cam
@@ -2,29 +2,28 @@ hist_add_inst_fields;h1: T, Q, U, V, PS
 hist_output_frequency;h1: 1*nsteps
 hist_write_nstep0;h1: .true.
 analytic_ic_type=held_suarez_1994
+hist_precision;h1: REAL64
+hist_max_frames;h1: 1
 
 ! history fields for CAM4 Hack shallow convection
-hist_output_frequency;h2: 1*nsteps
-hist_max_frames;h2: 1
-hist_add_inst_fields;h2:CMFDT,CMFDQ,CMFDLIQ,CMFDICE,CMFDQR,DQP,ICWMRSH,CMFSL,CMFLQ,FREQSH,EVAPTCM,FZSNTCM,EVSNTCM,HKNTPRPD,HKNTSNPD,HKFLXPRC,HKFLXSNW,HKEIHEAT,EVAPQCM,PRECSH,CMFMCSH
-hist_precision;h2: REAL64
+hist_add_inst_fields;h1:CMFDT,CMFDQ,CMFDLIQ,CMFDICE,CMFDQR,DQP,ICWMRSH,CMFSL,CMFLQ,FREQSH,EVAPTCM,FZSNTCM,EVSNTCM,HKNTPRPD,HKNTSNPD,HKFLXPRC,HKFLXSNW,HKEIHEAT,EVAPQCM,PRECSH,CMFMCSH
 
 ! history fields for CAM4 RK microphysics
-hist_add_inst_fields;h2:DQSED,DISED,DLSED,HSED,PRECSED,SNOWSED,RAINSED
-hist_add_inst_fields;h2:SH_CLD,DP_CLD,CONCLD,AST
-hist_add_inst_fields;h2:FICE,REPARTICE,REPARTLIQ,HREPART
-hist_add_inst_fields;h2:FWAUT,FSAUT,FRACW,FSACW,FSACI,PCSNOW,CME,CMEICE,CMELIQ
-hist_add_inst_fields;h2:ICE2PR,LIQ2PR,HPROGCLD,HEVAP,HMELT,HCME,HFREEZ
-hist_add_inst_fields;h2:PRODPREC,EVAPPREC,EVAPSNOW,LS_FLXPRC,LS_FLXSNW,PRACWO,PSACWO,PSACIO
-hist_add_inst_fields;h2:CLDLIQSTR,CLDICESTR,CLDLIQCON,CLDICECON
-hist_add_inst_fields;h2:IWC,LWC,ICIMR,ICWMR,REI,REL
+hist_add_inst_fields;h1:DQSED,DISED,DLSED,HSED,PRECSED,SNOWSED,RAINSED
+hist_add_inst_fields;h1:SH_CLD,DP_CLD,CONCLD,AST
+hist_add_inst_fields;h1:FICE,REPARTICE,REPARTLIQ,HREPART
+hist_add_inst_fields;h1:FWAUT,FSAUT,FRACW,FSACW,FSACI,PCSNOW,CME,CMEICE,CMELIQ
+hist_add_inst_fields;h1:ICE2PR,LIQ2PR,HPROGCLD,HEVAP,HMELT,HCME,HFREEZ
+hist_add_inst_fields;h1:PRODPREC,EVAPPREC,EVAPSNOW,LS_FLXPRC,LS_FLXSNW,PRACWO,PSACWO,PSACIO
+hist_add_inst_fields;h1:CLDLIQSTR,CLDICESTR,CLDLIQCON,CLDICECON
+hist_add_inst_fields;h1:IWC,LWC,ICIMR,ICWMR,REI,REL
 
 ! history fields for CAM4 boundary layer scheme (HB + diffusion solver)
-hist_add_inst_fields;h2:HB_ri,USTAR,obklen,PBLH
-hist_add_inst_fields;h2:KVH,KVM,CGS,TKE,TPERT,QPERT
-hist_add_inst_fields;h2:QT,SL,SLV,SLFLX,QTFLX,UFLX,VFLX
-hist_add_inst_fields;h2:sl_aft_PBL,qt_aft_PBL,slv_aft_PBL,u_aft_PBL,v_aft_PBL,qv_aft_PBL,ql_aft_PBL,qi_aft_PBL,t_aft_PBL,rh_aft_PBL
-hist_add_inst_fields;h2:slflx_PBL,qtflx_PBL,uflx_PBL,vflx_PBL,slflx_cg_PBL,qtflx_cg_PBL,uflx_cg_PBL,vflx_cg_PBL
-hist_add_inst_fields;h2:slten_PBL,qtten_PBL,uten_PBL,vten_PBL,qvten_PBL,qlten_PBL,qiten_PBL,tten_PBL,rhten_PBL
-hist_add_inst_fields;h2:qt_pre_PBL,sl_pre_PBL,slv_pre_PBL,u_pre_PBL,v_pre_PBL,qv_pre_PBL,ql_pre_PBL,qi_pre_PBL,t_pre_PBL,rh_pre_PBL
-hist_add_inst_fields;h2:DTV,DUV,DVV,DTVKE
+hist_add_inst_fields;h1:HB_ri,USTAR,obklen,PBLH
+hist_add_inst_fields;h1:KVH,KVM,CGS,TKE,TPERT,QPERT
+hist_add_inst_fields;h1:QT,SL,SLV,SLFLX,QTFLX,UFLX,VFLX
+hist_add_inst_fields;h1:sl_aft_PBL,qt_aft_PBL,slv_aft_PBL,u_aft_PBL,v_aft_PBL,qv_aft_PBL,ql_aft_PBL,qi_aft_PBL,t_aft_PBL,rh_aft_PBL
+hist_add_inst_fields;h1:slflx_PBL,qtflx_PBL,uflx_PBL,vflx_PBL,slflx_cg_PBL,qtflx_cg_PBL,uflx_cg_PBL,vflx_cg_PBL
+hist_add_inst_fields;h1:slten_PBL,qtten_PBL,uten_PBL,vten_PBL,qvten_PBL,qlten_PBL,qiten_PBL,tten_PBL,rhten_PBL
+hist_add_inst_fields;h1:qt_pre_PBL,sl_pre_PBL,slv_pre_PBL,u_pre_PBL,v_pre_PBL,qv_pre_PBL,ql_pre_PBL,qi_pre_PBL,t_pre_PBL,rh_pre_PBL
+hist_add_inst_fields;h1:DTV,DUV,DVV,DTVKE

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_se_cslam_analy_ic_cam4/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_se_cslam_analy_ic_cam4/user_nl_cam
@@ -10,27 +10,21 @@ hist_add_inst_fields;h2:CMFDT,CMFDQ,CMFDLIQ,CMFDICE,CMFDQR,DQP,ICWMRSH,CMFSL,CMF
 hist_precision;h2: REAL64
 
 ! history fields for CAM4 RK microphysics
-hist_output_frequency;h3: 1*nsteps
-hist_max_frames;h3: 1
-hist_add_inst_fields;h3:DQSED,DISED,DLSED,HSED,PRECSED,SNOWSED,RAINSED
-hist_add_inst_fields;h3:SH_CLD,DP_CLD,CONCLD,AST
-hist_add_inst_fields;h3:FICE,REPARTICE,REPARTLIQ,HREPART
-hist_add_inst_fields;h3:FWAUT,FSAUT,FRACW,FSACW,FSACI,PCSNOW,CME,CMEICE,CMELIQ
-hist_add_inst_fields;h3:ICE2PR,LIQ2PR,HPROGCLD,HEVAP,HMELT,HCME,HFREEZ
-hist_add_inst_fields;h3:PRODPREC,EVAPPREC,EVAPSNOW,LS_FLXPRC,LS_FLXSNW,PRACWO,PSACWO,PSACIO
-hist_add_inst_fields;h3:CLDLIQSTR,CLDICESTR,CLDLIQCON,CLDICECON
-hist_add_inst_fields;h3:IWC,LWC,ICIMR,ICWMR,REI,REL
-hist_precision;h3: REAL64
+hist_add_inst_fields;h2:DQSED,DISED,DLSED,HSED,PRECSED,SNOWSED,RAINSED
+hist_add_inst_fields;h2:SH_CLD,DP_CLD,CONCLD,AST
+hist_add_inst_fields;h2:FICE,REPARTICE,REPARTLIQ,HREPART
+hist_add_inst_fields;h2:FWAUT,FSAUT,FRACW,FSACW,FSACI,PCSNOW,CME,CMEICE,CMELIQ
+hist_add_inst_fields;h2:ICE2PR,LIQ2PR,HPROGCLD,HEVAP,HMELT,HCME,HFREEZ
+hist_add_inst_fields;h2:PRODPREC,EVAPPREC,EVAPSNOW,LS_FLXPRC,LS_FLXSNW,PRACWO,PSACWO,PSACIO
+hist_add_inst_fields;h2:CLDLIQSTR,CLDICESTR,CLDLIQCON,CLDICECON
+hist_add_inst_fields;h2:IWC,LWC,ICIMR,ICWMR,REI,REL
 
 ! history fields for CAM4 boundary layer scheme (HB + diffusion solver)
-hist_output_frequency;h4: 1*nsteps
-hist_max_frames;h4: 1
-hist_add_inst_fields;h4:HB_ri,USTAR,obklen,PBLH
-hist_add_inst_fields;h4:KVH,KVM,CGS,TKE,TPERT,QPERT
-hist_add_inst_fields;h4:QT,SL,SLV,SLFLX,QTFLX,UFLX,VFLX
-hist_add_inst_fields;h4:sl_aft_PBL,qt_aft_PBL,slv_aft_PBL,u_aft_PBL,v_aft_PBL,qv_aft_PBL,ql_aft_PBL,qi_aft_PBL,t_aft_PBL,rh_aft_PBL
-hist_add_inst_fields;h4:slflx_PBL,qtflx_PBL,uflx_PBL,vflx_PBL,slflx_cg_PBL,qtflx_cg_PBL,uflx_cg_PBL,vflx_cg_PBL
-hist_add_inst_fields;h4:slten_PBL,qtten_PBL,uten_PBL,vten_PBL,qvten_PBL,qlten_PBL,qiten_PBL,tten_PBL,rhten_PBL
-hist_add_inst_fields;h4:qt_pre_PBL,sl_pre_PBL,slv_pre_PBL,u_pre_PBL,v_pre_PBL,qv_pre_PBL,ql_pre_PBL,qi_pre_PBL,t_pre_PBL,rh_pre_PBL
-hist_add_inst_fields;h4:DTV,DUV,DVV,DTVKE
-hist_precision;h4: REAL64
+hist_add_inst_fields;h2:HB_ri,USTAR,obklen,PBLH
+hist_add_inst_fields;h2:KVH,KVM,CGS,TKE,TPERT,QPERT
+hist_add_inst_fields;h2:QT,SL,SLV,SLFLX,QTFLX,UFLX,VFLX
+hist_add_inst_fields;h2:sl_aft_PBL,qt_aft_PBL,slv_aft_PBL,u_aft_PBL,v_aft_PBL,qv_aft_PBL,ql_aft_PBL,qi_aft_PBL,t_aft_PBL,rh_aft_PBL
+hist_add_inst_fields;h2:slflx_PBL,qtflx_PBL,uflx_PBL,vflx_PBL,slflx_cg_PBL,qtflx_cg_PBL,uflx_cg_PBL,vflx_cg_PBL
+hist_add_inst_fields;h2:slten_PBL,qtten_PBL,uten_PBL,vten_PBL,qvten_PBL,qlten_PBL,qiten_PBL,tten_PBL,rhten_PBL
+hist_add_inst_fields;h2:qt_pre_PBL,sl_pre_PBL,slv_pre_PBL,u_pre_PBL,v_pre_PBL,qv_pre_PBL,ql_pre_PBL,qi_pre_PBL,t_pre_PBL,rh_pre_PBL
+hist_add_inst_fields;h2:DTV,DUV,DVV,DTVKE

--- a/test/existing-test-failures.txt
+++ b/test/existing-test-failures.txt
@@ -1,1 +1,3 @@
-All tests are currently passing
+SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM4.derecho_intel.cam-outfrq_se_cslam_analy_ic_cam4 (NLFAIL)
+SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM4.derecho_gnu.cam-outfrq_se_cslam_analy_ic_cam4   (NLFAIL)
+- NLFAILs due to multiple history files: CAM-SIMA issue #430

--- a/test/existing-test-failures.txt
+++ b/test/existing-test-failures.txt
@@ -1,3 +1,1 @@
-SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM4.derecho_intel.cam-outfrq_se_cslam_analy_ic_cam4 (NLFAIL)
-SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM4.derecho_gnu.cam-outfrq_se_cslam_analy_ic_cam4   (NLFAIL)
-- NLFAILs due to multiple history files: CAM-SIMA issue #430
+All tests are currently passing


### PR DESCRIPTION
Tag name (required for release branches): sima0_08_001
Originator(s): peverwhee, jimmielin

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
Brings in updated framework tag and necessary atmospheric_physics tag (includes fix for using dimension variables output from the register phase as dimensions for interstitial variables)

Also brings in fix for uninitialized variables in HB.
closes #429

Also updates the testmods for CAM4 tests to only output one history file (issue #430)

Describe any changes made to build system: n/a

Describe any changes made to the namelist: n/a

List any changes to the defaults for the input datasets (e.g. boundary datasets): n/a

List all files eliminated and why: n/a

List all files added and what they do: n/a

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

M   .gitmodules
- update ccpp framework tag and atmospheric_physics hash

M   cime_config/testdefs/testmods_dirs/cam/outfrq_se_cslam_analy_ic_cam4/user_nl_cam
- update CAM4 tests to only output one history file

M   ccpp_framework/
M   src/physics/ncar_ccpp
- update submodules

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima: 
SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_hb_vdiff_derecho (Overall: DIFF)
SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM4.derecho_gnu.cam-outfrq_se_cslam_analy_ic_cam4 (Overall: DIFF)
- DIFF for CAM4 and hb diff FPHYStest tests (due to fix from https://github.com/ESCOMP/atmospheric_physics/pull/314)

derecho/gnu/aux_sima: 
SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM4.derecho_intel.cam-outfrq_se_cslam_analy_ic_cam4 (Overall: NLFAIL)
- NLFAIL due to modifying CAM4 history configuration

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
