### PR TITLE
Work around various limitations of GitHub Actions

### DIFF
--- a/.github/workflows/mpas_dynamical_core_ci.yml
+++ b/.github/workflows/mpas_dynamical_core_ci.yml
@@ -211,7 +211,7 @@ jobs:
         id: cache-pfunit
         uses: actions/cache@v4
         with:
-          key: cache-pfunit-${{ env.PFUNIT_REFERENCE }}-gcc-v${{ matrix.gcc-version }}
+          key: cache-pfunit-${{ env.PFUNIT_REFERENCE }}-gcc-v${{ matrix.gcc-version }}-mpas
           path: ${{ env.PFUNIT_PATH }}/install
 
       # If there is a cache hit, just use the cached pFUnit and skip this step.


### PR DESCRIPTION
### Tag name (required for release branches):

None

### Originator(s):

kuanchihwang

### Descriptions (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

The CI workflows of MPAS dynamical core are triggered conditionally when changes are made under the path of `src/dynamics/mpas/*`. This is currently achieved by using the "path filtering" feature of GitHub Actions <sup>[[1]](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore)</sup>.

However, various issues arise when including conditional workflows, like above, as required status checks in branch protection rules.

1. If a workflow is skipped due to path filtering, branch filtering, or a commit message, then checks associated with that workflow will remain in a "Pending" state. A pull request that requires those checks to be successful will be blocked from merging <sup>[[2]](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore)[[3]](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks)</sup>.
2. The `jobs.<job_id>.if` conditional is evaluated before `jobs.<job_id>.strategy.matrix` is applied <sup>[[4]](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idif)</sup>. When a matrix job is set as a required status check, skipping it due to the conditional will also cause a pull request to be blocked from merging.

As a result, the current implementation of MPAS dynamical core CI is problematic, and it is blocking all unrelated PRs from merging.

To work around these limitations, this PR:

1. Avoids using the path filtering feature of GitHub Actions. A custom CI job is added as the replacement to determine if the rest should run.
2. Adds another custom CI job to evaluate and report the overall status of MPAS dynamical core CI for the purpose of inclusion as a required status check.

### Describe any changes made to the build system:

None

### Describe any changes made to the namelist:

None

### List any changes to the defaults for the input datasets (e.g., boundary datasets):

None

### List all files eliminated and why:

None

### List all files added and what they do:

None

### List all existing files that have been modified, and describe the changes:

```
M       .github/workflows/mpas_dynamical_core_ci.yml
  * Work around various limitations of GitHub Actions
  * Make sure cache keys are definitely different
```

### Regression tests:

```
FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape NLCOMP
```

Except for the known failing test above, all the other tests pass with respect to the last baseline, `sima0_08_002`.