### PR TITLE
(will merge as part of #475) Point to correct locations for datm, satm and xatm

### DIFF
--- a/.config_files.xml
+++ b/.config_files.xml
@@ -5,21 +5,21 @@
 <entry_id>
 
   <!-- This is the same as the default entry in
-       cime/config/cesm/config_files.xml except for the value for clm:
-       In a standalone cam checkout, COMP_ROOT_DIR_CAM is $SRCROOT
+       cime/config/cesm/config_files.xml except for the value for cam-sima:
+       In a standalone cam-sima checkout, COMP_ROOT_DIR_CAM is $SRCROOT
        rather than $SRCROOT/components/cam.
        However, because of the way overrides are handled, we need to
        re-specify the full information here rather than just overriding
-       the value for cam.
+       the value for cam-sima.
   -->
   <entry id="COMP_ROOT_DIR_ATM">
     <type>char</type>
     <default_value>unset</default_value>
     <values>
       <value component="cam"      >$SRCROOT</value>
-      <value component="dlnd"      >$CIMEROOT/src/components/data_comps/dlnd</value>
-      <value component="slnd"      >$CIMEROOT/src/components/stub_comps/slnd</value>
-      <value component="xlnd"      >$CIMEROOT/src/components/xcpl_comps/xlnd</value>
+      <value component="datm"     >$SRCROOT/components/cdeps/datm</value>
+      <value component="satm"     >$CIMEROOT/CIME/non_py/src/components/stub_comps_$COMP_INTERFACE/satm</value>
+      <value component="xatm"     >$SRCROOT/components/cmeps/med_test_comps/xatm</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): billsacks, nusbaume

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

This is the same changes that are in ESCOMP/CAM#1492.  To summarize:

Without this change, you couldn't run compsets with some non-CAM atm from a standalone CAM checkout.

Describe any changes made to build system:

M       .config_files.xml
  -  Define locations for data atmosphere (datm), stub atmosphere (satm), and test atmosphere (xatm).

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

M       .config_files.xml
  -  Define locations for data atmosphere (datm), stub atmosphere (satm), and test atmosphere (xatm).

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

derecho/nvhpc/aux_sima:

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
