### PR TITLE
sima0_13_003: Fix model crash in MPAS dynamical core and implement assorted code cleanup

### DIFF
--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -222,4 +222,14 @@
       <option name="comment">Aquaplanet CAM4 test with MPAS dycore at 120 km resolution</option>
     </options>
   </test>
+  <test compset="QPC4" grid="mpasa120_mpasa120" name="SMS_D_Ln9" testmods="cam/outfrq_analy_ic_cam4">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_sima"/>
+      <machine name="derecho" compiler="gnu" category="aux_sima"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">Aquaplanet CAM4 test with MPAS dycore at 120 km resolution in debug mode</option>
+    </options>
+  </test>
 </testlist>

--- a/src/dynamics/mpas/assets/generate_namelist_definition.py
+++ b/src/dynamics/mpas/assets/generate_namelist_definition.py
@@ -151,7 +151,7 @@ def translate_element_tree(reg_xml_et: ET.ElementTree) -> ET.ElementTree:
     '''
 
     # `entry_id_pg` is the root element in namelist definition.
-    entry_id_pg_element = ET.Element('entry_id_pg', {'version': '0.1'})
+    entry_id_pg_element = ET.Element('entry_id_pg', {'version': '2.0'})
 
     comment_element = ET.Comment(
         '\n' +

--- a/src/dynamics/mpas/dyn_comp.F90
+++ b/src/dynamics/mpas/dyn_comp.F90
@@ -23,6 +23,7 @@ module dyn_comp
     public :: dyn_final
 
     public :: dyn_debug_print
+    public :: advected_constituent_index
     public :: kind_dyn_mpas, mpas_dynamical_core
 
     ! NOTE:
@@ -68,6 +69,12 @@ module dyn_comp
             integer, optional, intent(in) :: printer
         end subroutine dyn_debug_print
     end interface
+
+    !> CAM-SIMA holds information about all constituents. However, MPAS dynamical core only knows about the advected ones.
+    !> This array contains the indexes of constituents advected by MPAS dynamical core. For example, if CAM-SIMA has
+    !> 5 constituents in total, and MPAS dynamical core only advects the 1st, 3rd, and 4th ones, then this array
+    !> will be [1, 3, 4].
+    integer, allocatable, protected :: advected_constituent_index(:)
 
     !> The "instance/object" of MPAS dynamical core.
     type(mpas_dynamical_core_type) :: mpas_dynamical_core

--- a/src/dynamics/mpas/dyn_comp_impl.F90
+++ b/src/dynamics/mpas/dyn_comp_impl.F90
@@ -682,7 +682,6 @@ contains
             character(len_cx) :: cerr
             integer :: i, j
             integer :: ierr
-            integer, allocatable :: constituent_index(:)
             integer, pointer :: index_qv
             real(kind_dyn_mpas), pointer :: scalars(:, :, :)
 
@@ -695,18 +694,13 @@ contains
             call check_allocate(ierr, subname, 'buffer_3d_real(ncells_solve, pver, num_advected)', &
                 file='dyn_comp', line=__LINE__, errmsg=trim(adjustl(cerr)))
 
-            allocate(constituent_index(num_advected), errmsg=cerr, stat=ierr)
-            call check_allocate(ierr, subname, 'constituent_index(num_advected)', &
-                file='dyn_comp', line=__LINE__, errmsg=trim(adjustl(cerr)))
-
             call mpas_dynamical_core % get_variable_pointer(index_qv, 'dim', 'index_qv')
             call mpas_dynamical_core % get_variable_pointer(scalars, 'state', 'scalars', time_level=1)
 
             buffer_3d_real(:, :, :) = 0.0_kind_r8
-            constituent_index(:) = [(advected_constituent_index(i), i = 1, num_advected)]
 
             call dyn_set_inic_col(vc_height, lat_rad, lon_rad, global_grid_index, zint=z_int, q=buffer_3d_real, &
-                m_cnst=constituent_index)
+                m_cnst=advected_constituent_index)
 
             do i = 1, ncells_solve
                 ! `j` is indexing into `scalars`, so it is regarded as MPAS scalar index.
@@ -734,7 +728,6 @@ contains
             end if
 
             deallocate(buffer_3d_real)
-            deallocate(constituent_index)
 
             nullify(index_qv)
             nullify(scalars)

--- a/src/dynamics/mpas/dyn_comp_impl.F90
+++ b/src/dynamics/mpas/dyn_comp_impl.F90
@@ -711,9 +711,12 @@ contains
             do i = 1, ncells_solve
                 ! `j` is indexing into `scalars`, so it is regarded as MPAS scalar index.
                 do j = 1, num_advected
+                    scalars(j, :, i) = &
+                        real(buffer_3d_real(i, :, mpas_dynamical_core % map_constituent_index(j)), kind_dyn_mpas)
+
                     ! Vertical index order is reversed between CAM-SIMA and MPAS.
                     scalars(j, :, i) = &
-                        real(reverse(buffer_3d_real(i, :, mpas_dynamical_core % map_constituent_index(j))), kind_dyn_mpas)
+                        reverse(scalars(j, :, i))
                 end do
             end do
 

--- a/src/dynamics/mpas/dyn_comp_impl.F90
+++ b/src/dynamics/mpas/dyn_comp_impl.F90
@@ -128,9 +128,9 @@ contains
     module subroutine dyn_init(cam_runtime_opts, dyn_in, dyn_out)
         ! Module(s) from CAM-SIMA.
         use cam_abortutils, only: check_allocate
-        use cam_constituents, only: const_name, const_is_water_species
-        use cam_constituents, only: num_constituents, num_advected
-        use cam_constituents, only: const_is_advected, readtrace
+        use cam_constituents, only: const_name, const_is_water_species, &
+                                    num_advected, &
+                                    readtrace
         use cam_control_mod, only: initial_run
         use cam_initfiles, only: initial_file_get_id, topo_file_get_id
         use cam_logfile, only: debugout_debug, debugout_info
@@ -160,13 +160,15 @@ contains
         type(file_desc_t), pointer :: pio_init_file
         type(file_desc_t), pointer :: pio_topo_file
 
-        ! Set dycore name in runtime object
-        call cam_runtime_opts%set_dycore('mpas')
-
         call dyn_debug_print(debugout_debug, subname // ' entered')
 
         nullify(pio_init_file)
         nullify(pio_topo_file)
+
+        call dyn_debug_print(debugout_info, 'Inquiring index mapping for advected constituents')
+
+        ! Populate the `advected_constituent_index` lookup table.
+        call dyn_inquire_advected_constituent_index()
 
         allocate(constituent_name(num_advected), errmsg=cerr, stat=ierr)
         call check_allocate(ierr, subname, 'constituent_name(num_advected)', &
@@ -176,11 +178,9 @@ contains
         call check_allocate(ierr, subname, 'is_water_species(num_advected)', &
             file='dyn_comp', line=__LINE__, errmsg=trim(adjustl(cerr)))
 
-        do i = 1, num_constituents
-            if (const_is_advected(i)) then !Skip non-advected consitutents
-                constituent_name(i) = const_name(i)
-                is_water_species(i) = const_is_water_species(i)
-            end if
+        do i = 1, num_advected
+            constituent_name(i) = const_name(advected_constituent_index(i))
+            is_water_species(i) = const_is_water_species(advected_constituent_index(i))
         end do
 
         call dyn_debug_print(debugout_info, 'Defining MPAS scalars and scalar tendencies')
@@ -190,6 +190,9 @@ contains
 
         deallocate(constituent_name)
         deallocate(is_water_species)
+
+        ! Set dycore name in runtime object.
+        call cam_runtime_opts % set_dycore('mpas')
 
         call set_thermodynamic_active_species_mapping()
         call set_thermodynamic_energy_formula()
@@ -252,6 +255,50 @@ contains
 
         call dyn_debug_print(debugout_debug, subname // ' completed')
     end subroutine dyn_init
+
+    !> CAM-SIMA holds information about all constituents. However, MPAS dynamical core only knows about the advected ones.
+    !> Inquire the index mapping for constituents advected by MPAS dynamical core. Save it as the `advected_constituent_index`
+    !> lookup table, which serves as the authoritative source for mapping an index within the set of advected constituents to
+    !> an index within the set of all constituents.
+    !> (KCW, 2026-03-25)
+    subroutine dyn_inquire_advected_constituent_index()
+        ! Module(s) from CAM-SIMA.
+        use cam_abortutils, only: check_allocate
+        use cam_constituents, only: const_is_advected, &
+                                    num_constituents, num_advected
+        use cam_logfile, only: debugout_debug
+        use string_utils, only: stringify
+        ! Module(s) from CESM Share.
+        use shr_kind_mod, only: len_cx => shr_kind_cx
+
+        character(*), parameter :: subname = 'dyn_comp::dyn_inquire_advected_constituent_index'
+        character(len_cx) :: cerr
+        integer :: i, j
+        integer :: ierr
+
+        call dyn_debug_print(debugout_debug, subname // ' entered')
+
+        ! This is a protected module variable.
+        allocate(advected_constituent_index(num_advected), errmsg=cerr, stat=ierr)
+        call check_allocate(ierr, subname, 'advected_constituent_index(num_advected)', &
+            file='dyn_comp', line=__LINE__, errmsg=trim(adjustl(cerr)))
+
+        j = 1
+
+        do i = 1, num_constituents
+            ! Skip non-advected constituents.
+            if (const_is_advected(i)) then
+                advected_constituent_index(j) = i
+
+                j = j + 1
+            end if
+        end do
+
+        call dyn_debug_print(debugout_debug, 'advected_constituent_index = [' // &
+            stringify(advected_constituent_index) // ']')
+
+        call dyn_debug_print(debugout_debug, subname // ' completed')
+    end subroutine dyn_inquire_advected_constituent_index
 
     !> Inform CAM-SIMA about the index mapping between MPAS scalars and CAM-SIMA constituents.
     !> (KCW, 2025-07-17)
@@ -618,8 +665,6 @@ contains
             ! Module(s) from CAM-SIMA.
             use cam_abortutils, only: check_allocate
             use cam_constituents, only: num_advected
-            use cam_constituents, only: num_constituents
-            use cam_constituents, only: const_is_advected
             use cam_logfile, only: debugout_verbose
             use dyn_grid, only: ncells_solve
             use dyn_procedures, only: qv_of_sh, reverse
@@ -658,19 +703,7 @@ contains
             call mpas_dynamical_core % get_variable_pointer(scalars, 'state', 'scalars', time_level=1)
 
             buffer_3d_real(:, :, :) = 0.0_kind_r8
-
-            ! Extract indices for all advected constituents.
-            j = 1
-            do i = 1, num_constituents
-                if (const_is_advected(i)) then
-                    constituent_index(j) = i
-                    if (j == num_advected) then
-                        exit !Break out of loop if no more advected constituents
-                    else
-                        j = j + 1
-                    end if
-                end if
-            end do
+            constituent_index(:) = [(advected_constituent_index(i), i = 1, num_advected)]
 
             call dyn_set_inic_col(vc_height, lat_rad, lon_rad, global_grid_index, zint=z_int, q=buffer_3d_real, &
                 m_cnst=constituent_index)
@@ -931,8 +964,8 @@ contains
     !> (KCW, 2024-05-23)
     subroutine mark_variables_as_initialized()
         ! Module(s) from CAM-SIMA.
-        use cam_constituents, only: num_constituents, num_advected
-        use cam_constituents, only: const_name, const_is_advected
+        use cam_constituents, only: const_name, &
+                                    num_advected
         use cam_logfile, only: debugout_debug
         ! Module(s) from CCPP.
         use phys_vars_init_check, only: mark_as_initialized
@@ -979,10 +1012,8 @@ contains
         call mark_as_initialized('tendency_of_northward_wind_due_to_model_physics')
 
         ! CCPP standard names of constituents.
-        do i = 1, num_constituents
-            if (const_is_advected(i)) then
-                call mark_as_initialized(trim(adjustl(const_name(i))))
-            end if
+        do i = 1, num_advected
+            call mark_as_initialized(trim(adjustl(const_name(advected_constituent_index(i)))))
         end do
 
         ! The variables below are not managed by dynamics interface. They are used by external CCPP physics schemes.

--- a/src/dynamics/mpas/dyn_coupling_impl.F90
+++ b/src/dynamics/mpas/dyn_coupling_impl.F90
@@ -24,16 +24,15 @@ contains
     module subroutine dyn_exchange_constituent_states(direction, exchange, conversion)
         ! Module(s) from CAM-SIMA.
         use cam_abortutils, only: check_allocate, endrun
-        use cam_constituents, only: num_constituents, num_advected
-        use cam_constituents, only: const_is_dry, const_is_water_species, const_is_advected
+        use cam_constituents, only: const_is_dry, const_is_water_species, &
+                                    num_advected
         use cam_logfile, only: debugout_debug, debugout_info
-        use dyn_comp, only: dyn_debug_print, kind_dyn_mpas, mpas_dynamical_core
+        use dyn_comp, only: advected_constituent_index, dyn_debug_print, kind_dyn_mpas, mpas_dynamical_core
         use dyn_grid, only: ncells_solve
         use dyn_procedures, only: reverse
         use physics_types, only: phys_state
         use vert_coord, only: pver
         ! Module(s) from CCPP.
-        use cam_ccpp_cap, only: cam_constituents_array
         use cam_ccpp_cap, only: cam_advected_constituents_array
         use ccpp_kinds, only: kind_phys
         ! Module(s) from CESM Share.
@@ -91,20 +90,11 @@ contains
             'is_water_species(num_advected)', &
             file='dyn_coupling', line=__LINE__, errmsg=trim(adjustl(cerr)))
 
-
-        j = 1
-        do i = 1, num_constituents
+        do i = 1, num_advected
             ! All constituent mixing ratios in MPAS are dry.
             ! Therefore, conversion in between is needed for any constituent mixing ratios that are not dry in CAM-SIMA.
-            if (const_is_advected(i)) then
-                is_conversion_needed(j) = .not. const_is_dry(i)
-                is_water_species(j) = const_is_water_species(i)
-                if (i == num_advected) then
-                    exit !All advected constituents accounted for, so exit loop.
-                else
-                    j = j + 1
-                end if
-            end if
+            is_conversion_needed(i) = .not. const_is_dry(advected_constituent_index(i))
+            is_water_species(i) = const_is_water_species(advected_constituent_index(i))
         end do
 
         allocate(is_water_species_index(count(is_water_species)), errmsg=cerr, stat=ierr)
@@ -264,16 +254,16 @@ contains
         subroutine init_shared_variables()
             ! Module(s) from CAM-SIMA.
             use cam_abortutils, only: check_allocate
-            use cam_constituents, only: num_constituents, num_advected
-            use cam_constituents, only: const_is_water_species, const_is_advected
-            use dyn_comp, only: mpas_dynamical_core
+            use cam_constituents, only: const_is_water_species, &
+                                        num_advected
+            use dyn_comp, only: advected_constituent_index, mpas_dynamical_core
             use vert_coord, only: pver, pverp
             ! Module(s) from CESM Share.
             use shr_kind_mod, only: len_cx => shr_kind_cx
 
             character(*), parameter :: subname = 'dyn_coupling::dynamics_to_physics_coupling::init_shared_variables'
             character(len_cx) :: cerr
-            integer :: i, j
+            integer :: i
             integer :: ierr
             logical, allocatable :: is_water_species(:)
 
@@ -293,16 +283,8 @@ contains
                 'is_water_species(num_advected)', &
                 file='dyn_coupling', line=__LINE__, errmsg=trim(adjustl(cerr)))
 
-            j = 1
-            do i = 1, num_constituents
-                if (const_is_advected(i)) then
-                    is_water_species(j) = const_is_water_species(i)
-                    if (j == num_advected) then
-                        exit !All advected species accounted for, so exit loop
-                    else
-                        j = j + 1
-                    end if
-                end if
+            do i = 1, num_advected
+                is_water_species(i) = const_is_water_species(advected_constituent_index(i))
             end do
 
             allocate(is_water_species_index(count(is_water_species)), errmsg=cerr, stat=ierr)
@@ -512,7 +494,8 @@ contains
         subroutine set_physics_state_external()
             ! Module(s) from CAM-SIMA.
             use cam_abortutils, only: check_allocate, endrun
-            use cam_constituents, only: const_qmin, num_constituents
+            use cam_constituents, only: const_qmin, &
+                                        num_constituents
             use cam_thermo, only: cam_thermo_dry_air_update, cam_thermo_water_update
             use cam_thermo_formula, only: energy_formula_dycore_mpas
             use dyn_comp, only: mpas_dynamical_core

--- a/src/dynamics/mpas/dyn_coupling_impl.F90
+++ b/src/dynamics/mpas/dyn_coupling_impl.F90
@@ -782,7 +782,7 @@ contains
             use dyn_comp, only: mpas_dynamical_core
             use dyn_grid, only: ncells_solve
             use dyn_procedures, only: t_of_theta_rhod_qv, t_of_tm_qv, theta_of_t_rhod_qv, tm_of_t_qv, &
-                                     reverse
+                                      reverse
             use dynconst, only: constant_cpd => cpair, constant_p0 => pref, &
                                 constant_rd => rair, constant_rv => rh2o
             use physics_types, only: dtime_phys, phys_tend

--- a/src/dynamics/mpas/dyn_coupling_impl.F90
+++ b/src/dynamics/mpas/dyn_coupling_impl.F90
@@ -504,7 +504,7 @@ contains
                                         num_constituents
             use cam_thermo, only: cam_thermo_dry_air_update, cam_thermo_water_update
             use cam_thermo_formula, only: energy_formula_dycore_mpas
-            use dyn_comp, only: mpas_dynamical_core
+            use dyn_comp, only: advected_constituent_index, mpas_dynamical_core
             use dyn_procedures, only: exner_function
             use dynconst, only: constant_g => gravit
             use physics_types, only: cappav, cp_or_cv_dycore, cpairv, lagrangian_vertical, phys_state, rairv, zvirv
@@ -585,13 +585,18 @@ contains
                     subname, __LINE__)
             end if
 
+            ! The `mpas_dynamical_core % map_constituent_index` type-bound function maps MPAS scalar index to
+            ! CAM-SIMA *advected* constituent index. Then, the `advected_constituent_index` lookup table maps
+            ! *advected* constituent index to *all* constituent index.
+            i = advected_constituent_index(mpas_dynamical_core % map_constituent_index(index_qv))
+
             ! Set `zi` (i.e., geopotential height at layer interfaces) and `zm` (i.e., geopotential height at layer midpoints).
             ! Note that `rairv` and `zvirv` are updated externally by `cam_thermo_dry_air_update`.
             call geopotential_temp_run( &
                 pver, lagrangian_vertical, pver, 1, pverp, 1, num_constituents, &
                 phys_state % lnpint, phys_state % pint, phys_state % pmid, phys_state % pdel, phys_state % rpdel, phys_state % t, &
-                constituents(:, :, mpas_dynamical_core % map_constituent_index(index_qv)), constituents, &
-                constituent_properties, rairv, constant_g, zvirv, phys_state % zi, phys_state % zm, ncells_solve, ierr, cerr)
+                constituents(:, :, i), constituents, constituent_properties, &
+                rairv, constant_g, zvirv, phys_state % zi, phys_state % zm, ncells_solve, ierr, cerr)
 
             if (ierr /= 0) then
                 call endrun('Failed to set variable "zi" and "zm" externally' // new_line('') // &

--- a/src/dynamics/mpas/dyn_coupling_impl.F90
+++ b/src/dynamics/mpas/dyn_coupling_impl.F90
@@ -127,9 +127,12 @@ contains
                 ! `j` is indexing into `scalars`, so it is regarded as MPAS scalar index.
                 do j = 1, num_advected
                     if (exchange) then
+                        scalars(j, :, i) = &
+                            real(constituents(i, :, mpas_dynamical_core % map_constituent_index(j)), kind_dyn_mpas)
+
                         ! Vertical index order is reversed between CAM-SIMA and MPAS.
                         scalars(j, :, i) = &
-                            real(reverse(constituents(i, :, mpas_dynamical_core % map_constituent_index(j))), kind_dyn_mpas)
+                            reverse(scalars(j, :, i))
                     end if
 
                     if (conversion .and. is_conversion_needed(mpas_dynamical_core % map_constituent_index(j))) then
@@ -152,9 +155,12 @@ contains
                 ! `j` is indexing into `constituents`, so it is regarded as constituent index.
                 do j = 1, num_advected
                     if (exchange) then
+                        constituents(i, :, j) = &
+                            real(scalars(mpas_dynamical_core % map_mpas_scalar_index(j), :, i), kind_r8)
+
                         ! Vertical index order is reversed between CAM-SIMA and MPAS.
                         constituents(i, :, j) = &
-                            reverse(real(scalars(mpas_dynamical_core % map_mpas_scalar_index(j), :, i), kind_r8))
+                            reverse(constituents(i, :, j))
                     end if
 
                     if (conversion .and. is_conversion_needed(j)) then

--- a/src/dynamics/mpas/dyn_grid.F90
+++ b/src/dynamics/mpas/dyn_grid.F90
@@ -19,7 +19,6 @@ module dyn_grid
 
     public :: dyn_grid_id
     public :: dyn_grid_name
-    public :: dyn_inquire_mesh_dimensions
     public :: ncells, ncells_solve, nedges, nedges_solve, nvertices, nvertices_solve, nvertlevels
     public :: ncells_global, nedges_global, nvertices_global, ncells_max, nedges_max
     public :: sphere_radius
@@ -28,10 +27,6 @@ module dyn_grid
         module subroutine model_grid_init()
             implicit none
         end subroutine model_grid_init
-
-        module subroutine dyn_inquire_mesh_dimensions()
-            implicit none
-        end subroutine dyn_inquire_mesh_dimensions
 
         module pure function dyn_grid_id(name)
             implicit none

--- a/src/dynamics/mpas/dyn_grid_impl.F90
+++ b/src/dynamics/mpas/dyn_grid_impl.F90
@@ -99,7 +99,7 @@ contains
 
     !> Inquire local and global mesh dimensions. Save them as protected module variables.
     !> (KCW, 2024-11-21)
-    module subroutine dyn_inquire_mesh_dimensions()
+    subroutine dyn_inquire_mesh_dimensions()
         ! Module(s) from CAM-SIMA.
         use cam_logfile, only: debugout_debug
         use dyn_comp, only: dyn_debug_print, mpas_dynamical_core

--- a/src/dynamics/mpas/dyn_procedures.F90
+++ b/src/dynamics/mpas/dyn_procedures.F90
@@ -33,6 +33,11 @@ module dyn_procedures
         module procedure exner_function_of_cpd_p0_rd_p
         module procedure exner_function_of_kappa_p0_p
     end interface exner_function
+
+    interface reverse
+        module procedure reverse_real32
+        module procedure reverse_real64
+    end interface reverse
 contains
     !> Compute the pressure `p` from the density `rho` and the temperature `t` by equation of state. Essentially,
     !> \( P = \rho R T \). Equation of state may take other forms, such as \( P_d = \rho_d R_d T \), \( P = \rho R_d T_v \),
@@ -342,9 +347,29 @@ contains
         tv = tm / (1.0_real64 + qv)
     end function tv_of_tm_qv
 
-    !> Reverse the order of elements in `array`.
+    !> Reverse the order of elements in `array`. Single precision variant.
     !> (KCW, 2024-07-17)
-    pure function reverse(array)
+    pure function reverse_real32(array) result(reverse)
+        use, intrinsic :: iso_fortran_env, only: real32
+
+        real(real32), intent(in) :: array(:)
+        real(real32) :: reverse(size(array))
+
+        integer :: n
+
+        n = size(array)
+
+        ! There is nothing to reverse.
+        if (n == 0) then
+            return
+        end if
+
+        reverse(:) = array(n:1:-1)
+    end function reverse_real32
+
+    !> Reverse the order of elements in `array`. Double precision variant.
+    !> (KCW, 2024-07-17)
+    pure function reverse_real64(array) result(reverse)
         use, intrinsic :: iso_fortran_env, only: real64
 
         real(real64), intent(in) :: array(:)
@@ -360,7 +385,7 @@ contains
         end if
 
         reverse(:) = array(n:1:-1)
-    end function reverse
+    end function reverse_real64
 
     !> Convert second(s) to hour(s), minute(s), and second(s).
     !> (KCW, 2024-02-07)

--- a/src/dynamics/mpas/tests/unit/test_dyn_procedures.pf
+++ b/src/dynamics/mpas/tests/unit/test_dyn_procedures.pf
@@ -33,9 +33,12 @@ module test_dyn_procedures
     public :: test_t_of_tm_qv_and_vice_versa_by_typical_values
     public :: test_tm_of_tv_qv_and_vice_versa_by_known_values
     public :: test_tm_of_tv_qv_and_vice_versa_by_typical_values
-    public :: test_reverse_by_empty_arrays
-    public :: test_reverse_by_single_element_arrays
-    public :: test_reverse_by_multiple_element_arrays
+    public :: test_reverse_by_empty_arrays_real32
+    public :: test_reverse_by_empty_arrays_real64
+    public :: test_reverse_by_single_element_arrays_real32
+    public :: test_reverse_by_single_element_arrays_real64
+    public :: test_reverse_by_multiple_element_arrays_real32
+    public :: test_reverse_by_multiple_element_arrays_real64
     public :: test_sec_to_hour_min_sec_by_positive_time
     public :: test_sec_to_hour_min_sec_by_negative_time
     public :: test_sec_to_hour_min_sec_by_extreme_time
@@ -1348,7 +1351,23 @@ contains
     end subroutine test_tm_of_tv_qv_and_vice_versa_by_typical_values
 
     @test
-    subroutine test_reverse_by_empty_arrays()
+    subroutine test_reverse_by_empty_arrays_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_procedures, only: reverse
+        use funit
+
+        real(real32), allocatable :: array(:), reversed(:)
+
+        allocate(array(0))
+
+        reversed = reverse(array)
+
+        @assertTrue(allocated(reversed))
+        @assertEqual(0, size(reversed))
+    end subroutine test_reverse_by_empty_arrays_real32
+
+    @test
+    subroutine test_reverse_by_empty_arrays_real64()
         use, intrinsic :: iso_fortran_env, only: real64
         use dyn_procedures, only: reverse
         use funit
@@ -1361,10 +1380,31 @@ contains
 
         @assertTrue(allocated(reversed))
         @assertEqual(0, size(reversed))
-    end subroutine test_reverse_by_empty_arrays
+    end subroutine test_reverse_by_empty_arrays_real64
 
     @test
-    subroutine test_reverse_by_single_element_arrays()
+    subroutine test_reverse_by_single_element_arrays_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_procedures, only: reverse
+        use funit
+
+        real(real32), parameter :: expected(*) = [ &
+            1.0_real32 &
+        ]
+
+        real(real32), allocatable :: array(:), reversed(:)
+
+        allocate(array(1))
+
+        array(1) = 1.0_real32
+        reversed = reverse(array)
+
+        @assertTrue(allocated(reversed))
+        @assertEqual(expected, reversed)
+    end subroutine test_reverse_by_single_element_arrays_real32
+
+    @test
+    subroutine test_reverse_by_single_element_arrays_real64()
         use, intrinsic :: iso_fortran_env, only: real64
         use dyn_procedures, only: reverse
         use funit
@@ -1382,10 +1422,39 @@ contains
 
         @assertTrue(allocated(reversed))
         @assertEqual(expected, reversed)
-    end subroutine test_reverse_by_single_element_arrays
+    end subroutine test_reverse_by_single_element_arrays_real64
 
     @test
-    subroutine test_reverse_by_multiple_element_arrays()
+    subroutine test_reverse_by_multiple_element_arrays_real32()
+        use, intrinsic :: iso_fortran_env, only: real32
+        use dyn_procedures, only: reverse
+        use funit
+
+        real(real32), parameter :: expected(*) = [ &
+            5.0_real32, &
+            4.0_real32, &
+            3.0_real32, &
+            2.0_real32, &
+            1.0_real32 &
+        ]
+
+        real(real32), allocatable :: array(:), reversed(:)
+
+        allocate(array(5))
+
+        array(1) = 1.0_real32
+        array(2) = 2.0_real32
+        array(3) = 3.0_real32
+        array(4) = 4.0_real32
+        array(5) = 5.0_real32
+        reversed = reverse(array)
+
+        @assertTrue(allocated(reversed))
+        @assertEqual(expected, reversed)
+    end subroutine test_reverse_by_multiple_element_arrays_real32
+
+    @test
+    subroutine test_reverse_by_multiple_element_arrays_real64()
         use, intrinsic :: iso_fortran_env, only: real64
         use dyn_procedures, only: reverse
         use funit
@@ -1411,7 +1480,7 @@ contains
 
         @assertTrue(allocated(reversed))
         @assertEqual(expected, reversed)
-    end subroutine test_reverse_by_multiple_element_arrays
+    end subroutine test_reverse_by_multiple_element_arrays_real64
 
     @test
     subroutine test_sec_to_hour_min_sec_by_positive_time()


### PR DESCRIPTION
### Tag name (required for release branches):

sima0_13_003 due to newly-added tests, otherwise bit-for-bit.

### Originator(s):

kuanchihwang

### Descriptions (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

This PR fixes a model crash in MPAS dynamical core, which is caused by a regression in recent versions of GNU Fortran compiler. When CAM-SIMA is configured with MPAS dynamical core, and is built with GNU Fortran compiler version 14 in debug mode, running the model will lead to a segmentation fault. However, the crash mysteriously disappears when the model is built in optimized mode. Older GNU Fortran compiler version 12 does not exhibit this behavior, neither does Intel Fortran compiler.

Closes #484

Additionally, this PR also brings the following:

1. Update Python script for generating MPAS namelist definition file
2. Reduce API surface area by making `dyn_inquire_mesh_dimensions` private
3. Add lookup table for mapping indexes from advected to all constituents and refactor the rest of code to use it
4. Fix incorrect constituent indexing inside `set_physics_state_external` during dynamics-physics coupling

The rationale behind each change is described in the commit messages.

### Describe any changes made to the build system:

None

### Describe any changes made to the namelist:

None

### List any changes to the defaults for the input datasets (e.g., boundary datasets):

None

### List all files eliminated and why:

None

### List all files added and what they do:

None

### List all existing files that have been modified, and describe the changes:

```
M       src/dynamics/mpas/assets/generate_namelist_definition.py
  * Update Python script for generating MPAS namelist definition file
M       src/dynamics/mpas/dyn_comp.F90
  * Add lookup table for mapping indexes from advected to all constituents
M       src/dynamics/mpas/dyn_comp_impl.F90
  * Add lookup table for mapping indexes from advected to all constituents
  * Fix MPAS dycore crash due to regression in recent GNU Fortran compiler
M       src/dynamics/mpas/dyn_coupling_impl.F90
  * Fix indentation
  * Add lookup table for mapping indexes from advected to all constituents
  * Fix MPAS dycore crash due to regression in recent GNU Fortran compiler
  * Fix incorrect constituent indexing
M       src/dynamics/mpas/dyn_grid.F90
  * Make `dyn_inquire_mesh_dimensions` private
M       src/dynamics/mpas/dyn_grid_impl.F90
  * Make `dyn_inquire_mesh_dimensions` private
M       src/dynamics/mpas/dyn_procedures.F90
  * Fix MPAS dycore crash due to regression in recent GNU Fortran compiler
M       src/dynamics/mpas/tests/unit/test_dyn_procedures.pf
  * Fix MPAS dycore crash due to regression in recent GNU Fortran compiler
```

### Regression tests:

```
SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam (Overall: FAIL)
SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape (Overall: NLFAIL)
```

Known failing tests.

```
SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 (Overall: DIFF)
SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 (Overall: DIFF)
```

Newly-added tests.