### PR TITLE
sima0_13_004: Fix zmconv_tiedtke_add spelling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "ncar-physics"]
         path          = src/physics/ncar_ccpp
 	url           = https://github.com/ESCOMP/atmospheric_physics
-	fxtag         = 3f5435e8a9a53eb00f14a6b14975f92580b525d4
+	fxtag         = 827909005618d2e7806d0c910b8125f4ddaa0029
         fxrequired    = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 [submodule "rrtmgp-data"]

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_hack_shallow_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_hack_shallow_derecho/user_nl_cam
@@ -21,7 +21,7 @@ zmconv_momcu           =  0.4000D0
 zmconv_num_cin         =  5
 zmconv_parcel_pbl              = .false.
 zmconv_tau             =  3600.0
-zmconv_tiedke_add              =  0.5
+zmconv_tiedtke_add              =  0.5
 
 ! snapshot is sourced from SE dycore
 hkconv_c0 = 1.0e-4


### PR DESCRIPTION
Tag name (required for release branches): sima0_13_004
Originator(s): @jimmielin
AI tools used (if applicable; please also add the "AI-generated code" label to the PR): N/A
  What:
  How:

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- CAM-SIMA fix in https://github.com/ESCOMP/atmospheric_physics/issues/376 since it is mentioned in test `user_nl_cam`

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       cime_config/testdefs/testmods_dirs/cam/outfrq_hack_shallow_derecho/user_nl_cam
  - change spelling of namelist parameter
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:
```
  SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 (Overall: NLFAIL) details:
    FAIL SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 NLCOMP
  SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 (Overall: NLFAIL) details:
    FAIL SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 NLCOMP
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM7.derecho_intel.cam-outfrq_se_cslam_analy_ic (Overall: NLFAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM7.derecho_intel.cam-outfrq_se_cslam_analy_ic NLCOMP
  Differences in namelist 'zmconv_nl':
  missing variable: 'zmconv_tiedke_add'
  found extra variable: 'zmconv_tiedtke_add'
  - rename to zmconv_tiedtke_add (fix #376)

  SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape (Overall: NLFAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape NLCOMP
  - pre-existing failure
```

derecho/gnu/aux_sima:
```
  SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 (Overall: NLFAIL) details:
    FAIL SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 NLCOMP
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_hack_shallow_derecho (Overall: NLFAIL) details:
    FAIL SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_hack_shallow_derecho NLCOMP
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_zm_derecho (Overall: NLFAIL) details:
    FAIL SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_zm_derecho NLCOMP
  SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 (Overall: NLFAIL) details:
    FAIL SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 NLCOMP
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM7.derecho_gnu.cam-outfrq_se_cslam_analy_ic (Overall: NLFAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM7.derecho_gnu.cam-outfrq_se_cslam_analy_ic NLCOMP
  Differences in namelist 'zmconv_nl':
  missing variable: 'zmconv_tiedke_add'
  found extra variable: 'zmconv_tiedtke_add'
  - rename to zmconv_tiedtke_add (fix #376)

  SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam (Overall: FAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam RUN time=9
  - pre-existing failure
```

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines): All PASS

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
