### PR TITLE
Check all constituents in physics_data_check, not just advected

### DIFF
--- a/src/data/write_init_files.py
+++ b/src/data/write_init_files.py
@@ -1291,7 +1291,7 @@ def write_phys_check_subroutine(outfile, host_dict, host_vars, host_imports,
                                    "prot_no_init_idx", "const_idx",
                                    "flush_check_field_verbose"]],
                  ["cam_ccpp_cap", ["ccpp_physics_suite_variables",
-                                   "cam_advected_constituents_array",
+                                   "cam_constituents_array",
                                    "cam_model_const_properties"]],
                  ["cam_constituents", ["const_get_index"]],
                  ["ccpp_kinds", ["kind_phys"]],
@@ -1475,7 +1475,7 @@ def write_phys_check_subroutine(outfile, host_dict, host_vars, host_imports,
     outfile.write("end do !CCPP suites", 2)
     outfile.blank_line()
     outfile.comment("Check constituent variables", 2)
-    outfile.write("field_data_ptr => cam_advected_constituents_array()", 2)
+    outfile.write("field_data_ptr => cam_constituents_array()", 2)
     outfile.write("const_props => cam_model_const_properties()", 2)
     outfile.blank_line()
     outfile.write("do constituent_idx = 1, size(const_props)", 2)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_4D.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_4D.F90
@@ -228,7 +228,7 @@ contains
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,              only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,              only: flush_check_field_verbose
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,          only: const_get_index
       use ccpp_kinds,                only: kind_phys
       use cam_logfile,               only: iulog
@@ -354,7 +354,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_bvd.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_bvd.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,              only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,              only: flush_check_field_verbose
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,          only: const_get_index
       use ccpp_kinds,                only: kind_phys
       use cam_logfile,               only: iulog
@@ -351,7 +351,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_cnst.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_cnst.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,              only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,              only: flush_check_field_verbose
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,          only: const_get_index
       use ccpp_kinds,                only: kind_phys
       use cam_logfile,               only: iulog
@@ -351,7 +351,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_constituent_dim.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_constituent_dim.F90
@@ -233,7 +233,7 @@ contains
       use shr_kind_mod,                         only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,                         only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,                         only: flush_check_field_verbose
-      use cam_ccpp_cap,                         only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,                         only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,                     only: const_get_index
       use ccpp_kinds,                           only: kind_phys
       use cam_logfile,                          only: iulog
@@ -359,7 +359,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_ddt.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_ddt.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,              only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,              only: flush_check_field_verbose
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,          only: const_get_index
       use ccpp_kinds,                only: kind_phys
       use cam_logfile,               only: iulog
@@ -351,7 +351,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_ddt2.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_ddt2.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,              only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,              only: flush_check_field_verbose
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,          only: const_get_index
       use ccpp_kinds,                only: kind_phys
       use cam_logfile,               only: iulog
@@ -351,7 +351,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_ddt_array.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_ddt_array.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,                   only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,                   only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,                   only: flush_check_field_verbose
-      use cam_ccpp_cap,                   only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,                   only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,               only: const_get_index
       use ccpp_kinds,                     only: kind_phys
       use cam_logfile,                    only: iulog
@@ -351,7 +351,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_host_var.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_host_var.F90
@@ -222,7 +222,7 @@ contains
       use shr_kind_mod,                  only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,                  only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,                  only: flush_check_field_verbose
-      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,              only: const_get_index
       use ccpp_kinds,                    only: kind_phys
       use cam_logfile,                   only: iulog
@@ -343,7 +343,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_initial_value.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_initial_value.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,                       only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,                       only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,                       only: flush_check_field_verbose
-      use cam_ccpp_cap,                       only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,                       only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,                   only: const_get_index
       use ccpp_kinds,                         only: kind_phys
       use cam_logfile,                        only: iulog
@@ -351,7 +351,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_mf.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_mf.F90
@@ -226,7 +226,7 @@ contains
       use shr_kind_mod,              only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,              only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,              only: flush_check_field_verbose
-      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,              only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,          only: const_get_index
       use ccpp_kinds,                only: kind_phys
       use cam_logfile,               only: iulog
@@ -352,7 +352,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_no_horiz.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_no_horiz.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,                  only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,                  only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,                  only: flush_check_field_verbose
-      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,                  only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,              only: const_get_index
       use ccpp_kinds,                    only: kind_phys
       use cam_logfile,                   only: iulog
@@ -351,7 +351,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_noreq.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_noreq.F90
@@ -218,7 +218,7 @@ contains
       use shr_kind_mod,               only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,               only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,               only: flush_check_field_verbose
-      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,           only: const_get_index
       use ccpp_kinds,                 only: kind_phys
       use cam_logfile,                only: iulog
@@ -339,7 +339,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_param.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_param.F90
@@ -228,7 +228,7 @@ contains
       use shr_kind_mod,               only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,               only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,               only: flush_check_field_verbose
-      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,               only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,           only: const_get_index
       use ccpp_kinds,                 only: kind_phys
       use cam_logfile,                only: iulog
@@ -354,7 +354,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_protect.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_protect.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,                 only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,                 only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,                 only: flush_check_field_verbose
-      use cam_ccpp_cap,                 only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,                 only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,             only: const_get_index
       use ccpp_kinds,                   only: kind_phys
       use cam_logfile,                  only: iulog
@@ -351,7 +351,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_scalar.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_scalar.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,                only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,                only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,                only: flush_check_field_verbose
-      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,            only: const_get_index
       use ccpp_kinds,                  only: kind_phys
       use cam_logfile,                 only: iulog
@@ -351,7 +351,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_simple.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_simple.F90
@@ -225,7 +225,7 @@ contains
       use shr_kind_mod,                only: SHR_KIND_CS, SHR_KIND_CL, SHR_KIND_CX
       use physics_data,                only: check_field, find_input_name_idx, no_exist_idx, init_mark_idx, prot_no_init_idx, const_idx
       use physics_data,                only: flush_check_field_verbose
-      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_advected_constituents_array, cam_model_const_properties
+      use cam_ccpp_cap,                only: ccpp_physics_suite_variables, cam_constituents_array, cam_model_const_properties
       use cam_constituents,            only: const_get_index
       use ccpp_kinds,                  only: kind_phys
       use cam_logfile,                 only: iulog
@@ -358,7 +358,7 @@ contains
       end do !CCPP suites
 
       ! Check constituent variables
-      field_data_ptr => cam_advected_constituents_array()
+      field_data_ptr => cam_constituents_array()
       const_props => cam_model_const_properties()
 
       do constituent_idx = 1, size(const_props)


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR): N/A
  What:
  How:

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- Use `field_data_ptr` for all constituents, not just advected constituents.
This fixes an overflow bug where non-advected constituents registered and have a `ic_file_input_names` in `registry.xml` will cause an array read overflow:
```
At line 557 of file /glade/derecho/scratch/hplin/260420_sima.FPHYStest.microp.gnu.dbg/bld/atm/obj/phys_init/physics_inputs.F90
Fortran runtime error: Index '14' of dimension 3 of array 'field_data_ptr' outside of expected range (1:13)
dec2435.hsn.de.hpc.ucar.edu 0:
Error termination. Backtrace:
#0  0x4e5c4f in __physics_inputs_MOD_physics_check_data
 at /glade/derecho/scratch/hplin/260420_sima.FPHYStest.microp.gnu.dbg/bld/atm/obj/phys_init/physics_inputs.F90:557
#1  0x4d9ee5 in __phys_comp_MOD_phys_timestep_final
 at /glade/u/home/hplin/2604_dev_microp_ccpp/CAM-SIMA.dev/src/physics/utils/phys_comp.F90:311
#2  0x44b148 in __cam_comp_MOD_cam_timestep_final
 at /glade/u/home/hplin/2604_dev_microp_ccpp/CAM-SIMA.dev/src/control/cam_comp.F90:554
```
since this code cycles through the entire `const_props` but `field_data_ptr` was originally pointing to the **advected** array only, not the full array, and would cause an overflow:
```fortran
        do constituent_idx = 1, size(const_props)
           ! Check if constituent standard name in registered SIMA standard names list:
           call const_props(constituent_idx)%standard_name(std_name)
           if(any(phys_var_stdnames == std_name)) then
              ! Find array index to extract correct input names:
              do n=1, phys_var_num
                 if(trim(phys_var_stdnames(n)) == trim(std_name)) then
                    const_input_idx = n
                    exit
                 end if
              end do
              call check_field(file, input_var_names(:,const_input_idx), 'lev', timestep, field_data_pt
  r(:,:,constituent_idx), std_name, &
                  min_difference, min_relative_value, is_first, diff_found)
```

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       src/data/write_init_files.py
  - change to use cam_constituents_array()
 
M       test/unit/python/sample_files/write_init_files/physics_inputs_4D.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_bvd.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_cnst.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_constituent_dim.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_ddt.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_ddt2.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_ddt_array.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_host_var.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_initial_value.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_mf.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_no_horiz.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_noreq.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_param.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_protect.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_scalar.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_simple.F90
  - update sample files due to write_init_files.py update
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

Pre-existing failures only:

derecho/intel/aux_sima:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape (Overall: NLFAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape NLCOMP

derecho/gnu/aux_sima:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam (Overall: FAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam RUN time=9

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
