### PR TITLE
sima0_13_005: Move nswbands, nlwbands to host namelist (needs atmos_phys update)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 [submodule "ncar-physics"]
         path          = src/physics/ncar_ccpp
 	url           = https://github.com/ESCOMP/atmospheric_physics
-	fxtag         = 827909005618d2e7806d0c910b8125f4ddaa0029
+	fxtag         = ced50be1e685ad812d332f4499e16af28482302f
         fxrequired    = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/atmospheric_physics
 [submodule "rrtmgp-data"]

--- a/cime_config/namelist_definition_cam.xml
+++ b/cime_config/namelist_definition_cam.xml
@@ -315,6 +315,32 @@
 
 <!-- Radiation -->
 
+  <entry id="nswbands">
+    <type>integer</type>
+    <category>radiation</category>
+    <group>radiation_nl</group>
+    <units>count</units>
+    <desc>
+       Number of shortwave bands.
+       Units: count
+    </desc>
+    <values>
+      <value>14</value><!-- rrtmgp -->
+    </values>
+  </entry>
+  <entry id="nlwbands">
+    <type>integer</type>
+    <category>radiation</category>
+    <group>radiation_nl</group>
+    <units>count</units>
+    <desc>
+       Number of longwave bands.
+       Units: count
+    </desc>
+    <values>
+      <value>16</value><!-- rrtmgp -->
+    </values>
+  </entry>
   <entry id="iradsw">
     <type>integer</type>
     <category>radiation</category>

--- a/src/physics/utils/radiation_namelist.F90
+++ b/src/physics/utils/radiation_namelist.F90
@@ -17,6 +17,8 @@ module radiation_namelist
   !> \section arg_table_radiation_namelist Argument Table
   !! \htmlinclude arg_table_radiation_namelist.html
   !!
+  integer, public, protected :: nswbands = -1   ! # of shortwave bands [count]
+  integer, public, protected :: nlwbands = -1   ! # of longwave bands [count]
   integer, public, protected :: iradsw = -1     ! freq. of shortwave radiation calc in time steps (positive)
                                                 ! or hours (negative).
   integer, public, protected :: iradlw = -1     ! frequency of longwave rad. calc. in time steps (positive)
@@ -59,7 +61,8 @@ contains
     character(len=shr_kind_cm)   :: errmsg
     integer                      :: dtime
 
-    namelist /radiation_nl/ iradsw, iradlw, irad_always, use_rad_uniform_angle, &
+    namelist /radiation_nl/ nswbands, nlwbands, &
+                            iradsw, iradlw, irad_always, use_rad_uniform_angle, &
                             rad_uniform_angle
 
     errmsg = ''
@@ -77,6 +80,16 @@ contains
     end if
 
     ! Broadcast namelist variable
+    call mpi_bcast(nswbands, 1, mpi_integer, masterprocid, mpicom, ierr)
+    if (ierr /= 0) then
+       call endrun(sub//": FATAL: mpi_bcast: nswbands",                     &
+            file=__FILE__, line=__LINE__)
+    end if
+    call mpi_bcast(nlwbands, 1, mpi_integer, masterprocid, mpicom, ierr)
+    if (ierr /= 0) then
+       call endrun(sub//": FATAL: mpi_bcast: nlwbands",                     &
+            file=__FILE__, line=__LINE__)
+    end if
     call mpi_bcast(use_rad_uniform_angle, 1, mpi_logical, masterprocid, mpicom, ierr)
     if (ierr /= 0) then
        call endrun(sub//": FATAL: mpi_bcast: use_rad_uniform_angle",      &
@@ -119,6 +132,9 @@ contains
     !-----------------------------------------------------------------------
 
     if (masterproc) then
+       write(iulog,*) 'Radiation scheme parameters:'
+       write(iulog,*) 'Number of shortwave bands: ', nswbands
+       write(iulog,*) 'Number of longwave bands: ', nlwbands
        write(iulog,*) 'RRTMGP radiation scheme parameters:'
        write(iulog,10) iradsw, iradlw, irad_always, use_rad_uniform_angle
     end if

--- a/src/physics/utils/radiation_namelist.meta
+++ b/src/physics/utils/radiation_namelist.meta
@@ -5,6 +5,18 @@
 [ccpp-arg-table]
   name  = radiation_namelist
   type  = module
+[ nlwbands ]
+  standard_name = number_of_bands_for_longwave_radiation
+  units = count
+  type = integer
+  dimensions = ()
+  protected = True
+[ nswbands ]
+  standard_name = number_of_bands_for_shortwave_radiation
+  units = count
+  type = integer
+  dimensions = ()
+  protected = True
 [ iradsw ]
   standard_name = frequency_of_shortwave_radiation_calculation
   units = 1


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What:
  How:

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- Moves nswbands, nlwbands from atmos_phys side rrtmgp_pre_namelist.xml to host-side: companion PR https://github.com/ESCOMP/atmospheric_physics/pull/384

Describe any changes made to build system:

Describe any changes made to the namelist: add nswbands, nlwbands to radiation_nl.

List any changes to the defaults for the input datasets (e.g. boundary datasets):

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       cime_config/namelist_definition_cam.xml
M       src/physics/utils/radiation_namelist.F90
M       src/physics/utils/radiation_namelist.meta
  - add nswbands, nlwbands (previously in rrtmgp_pre_namelist.xml in atmos_phys)
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:
```
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape (Overall: NLFAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape NLCOMP
  - pre-existing failure

  SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 (Overall: NLFAIL) details:
  SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 (Overall: NLFAIL) details:
  SMS_Ln9.mpasa480_mpasa480.FKESSLER.derecho_intel.cam-outfrq_kessler_mpas_derecho (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_intel.cam-outfrq_se_cslam (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM7.derecho_intel.cam-outfrq_se_cslam_analy_ic (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FHS94.derecho_intel.cam-outfrq_se_cslam (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FTJ16.derecho_intel.cam-outfrq_se_cslam (Overall: NLFAIL) details:
  - expected NLFAIL: update to nswbands, nlwbands
  Differences in namelist 'radiation_nl':
  found extra variable: 'nlwbands'
  found extra variable: 'nswbands'
```

derecho/gnu/aux_sima:
```
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam (Overall: FAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam NLCOMP
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam RUN time=15
  - pre-existing failure

  SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_dme_adjust_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_gw_cam4_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_gw_cam7_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_hack_shallow_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_hb_vdiff_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_held_suarez_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_kessler_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_rk_stratiform_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_rrtmgp_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_tj2016_after_coupler_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_tj2016_before_coupler_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_trcdata_bam_derecho (Overall: NLFAIL) details:
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_gnu.cam-outfrq_zm_derecho (Overall: NLFAIL) details:
  SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 (Overall: NLFAIL) details:
  SMS_Ln9.mpasa480_mpasa480.FKESSLER.derecho_gnu.cam-outfrq_kessler_mpas_derecho (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam (Overall: FAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FCAM7.derecho_gnu.cam-outfrq_se_cslam_analy_ic (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FHS94.derecho_gnu.cam-outfrq_se_cslam (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_gnu.cam-outfrq_se_cslam (Overall: NLFAIL) details:
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FTJ16.derecho_gnu.cam-outfrq_se_cslam (Overall: NLFAIL) details:
  - expected NLFAIL due to namelist update (nswbands, nlwbands added to host)
```

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):
```
  SMS_Ln2.ne3pg3_ne3pg3_mg37.FPHYStest.derecho_nvhpc.cam-outfrq_rrtmgp_derecho_gpu (Overall: NLFAIL) details:
  - expected NLFAIL due to namelist update (nswbands, nlwbands added to host)
```

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
