### PR TITLE
Allow for dimensions set to be used in variables in registry.xml

### DIFF
--- a/src/data/generate_registry_data.py
+++ b/src/data/generate_registry_data.py
@@ -1405,6 +1405,15 @@ class File:
         #then this section of code will likely need to be modified:
         if ('number_of_ccpp_constituents' in self.__var_dict.known_dimensions):
             outfile.write("use cam_constituents,   only: number_of_ccpp_constituents=>num_constituents", 2)
+
+        # Collect self-referential dimensions (defined in this module)
+        self_ref_dims = []
+        for dim in sorted(self.__var_dict.known_dimensions):
+            if dim not in var_module_dict and dim != 'number_of_ccpp_constituents':
+                var = self.__var_dict.find_variable_by_standard_name(dim)
+                if var and var.local_name != dim:
+                    self_ref_dims.append((dim, var.local_name))
+
         outfile.blank_line()
 
         # Dummy arguments
@@ -1425,6 +1434,8 @@ class File:
         outfile.write(f'logical                     :: {reall_var}', 2)
         subn_str = f'character(len=*), parameter :: subname = "{subname}"'
         outfile.write(subn_str, 2)
+        for dim_std, _ in self_ref_dims:
+            outfile.write(f'integer                     :: {dim_std}', 2)
         outfile.write('', 0)
         outfile.write('! Set optional argument values', 2)
         outfile.write(f'if (present({init_var}_in)) then', 2)
@@ -1437,6 +1448,11 @@ class File:
         outfile.write('else', 2)
         outfile.write(f'{reall_var} = .false.', 3)
         outfile.write('end if', 2)
+        if self_ref_dims:
+            outfile.blank_line()
+            outfile.write('! Set self-referential dimension variables', 2)
+            for dim_std, dim_loc in self_ref_dims:
+                outfile.write(f'{dim_std} = {dim_loc}', 2)
         outfile.write('', 0)
         for var in self.__var_dict.variable_list():
             var.write_allocate_routine(outfile, 2, init_var, reall_var, '', physconst_vars)

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -1491,6 +1491,18 @@
       <ic_file_input_names>pbuf_VPWP_CLUBB_GW</ic_file_input_names>
     </variable>
 
+    <!-- Aerosol model properties -->
+    <variable local_name="ndust"
+              standard_name="dust_size_bin_dimension"
+              units="count" type="integer">
+      <long_name>number of dust size bins used in aerosol model</long_name>
+      <initial_value>4</initial_value>
+      <!-- this is not runtime configurable, and
+           not even easily compile-time configurable, because the assumption that
+           there are four dust bins is deeply embedded in the microphysics and
+           coupling to the land model (see dstdry1/2/3/4, dstwet1/2/3/4) -->
+    </variable>
+
     <!-- Gravity wave variables - need to be kept in the CAM registry -->
     <variable local_name="kvt"
               standard_name="molecular_kinematic_temperature_conductivity_at_interfaces"
@@ -1705,6 +1717,48 @@
               units="kg kg-1" type="real" constituent="true">
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <ic_file_input_names>dust4 pbuf_dust4 cnst_dust4</ic_file_input_names>
+    </variable>
+
+    <!-- Aerosol nucleation/activation data into microphysics -->
+    <variable local_name="naai"
+              standard_name="tendency_of_number_concentration_of_activated_ice_nuclei"
+              units="kg-1 s-1" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+      <ic_file_input_names>pbuf_NAAI</ic_file_input_names>
+    </variable>
+    <variable local_name="naai_hom"
+              standard_name="tendency_of_number_concentration_of_activated_ice_nuclei_due_to_homogenous_freezing"
+              units="kg-1 s-1" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+      <ic_file_input_names>pbuf_NAAI_HOM</ic_file_input_names>
+    </variable>
+    <variable local_name="npccn"
+              standard_name="tendency_of_activated_cloud_condensation_nuclei_mass_number_concentration"
+              units="kg-1 s-1" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+      <ic_file_input_names>pbuf_NPCCN</ic_file_input_names>
+    </variable>
+    <variable local_name="nacon"
+              standard_name="dust_number_concentration_by_size_bin_for_contact_freezing"
+              units="m-3" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension dust_size_bin_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+      <ic_file_input_names>pbuf_NACON</ic_file_input_names>
+    </variable>
+    <variable local_name="rndst"
+              standard_name="dust_radii_by_size_bin"
+              units="m" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension dust_size_bin_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+      <ic_file_input_names>pbuf_RNDST</ic_file_input_names>
     </variable>
 
     <!-- Zhang McFarlane (ZM) Variables -->

--- a/test/unit/python/sample_files/physics_types_self_ref_dim.F90
+++ b/test/unit/python/sample_files/physics_types_self_ref_dim.F90
@@ -11,10 +11,10 @@
 ! CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 !>
-!! @brief Auto-generated Variables for registry source file, physics_types_parameter
+!! @brief Auto-generated Variables for registry source file, physics_types_self_ref_dim
 !!
 !
-module physics_types_parameter
+module physics_types_self_ref_dim
 
   use ccpp_kinds, only: kind_phys
 
@@ -22,24 +22,24 @@ module physics_types_parameter
   implicit none
   private
 
-!> \section arg_table_physics_types_parameter  Argument Table
-!! \htmlinclude physics_types_parameter.html
+!> \section arg_table_physics_types_self_ref_dim  Argument Table
+!! \htmlinclude physics_types_self_ref_dim.html
   ! ncol: Number of horizontal columns
-  integer,         public,            protected :: ncol = 0
-  ! latitude: Latitude
-  real(kind_phys), public, pointer,   protected :: latitude(:) => NULL()
-  ! longitude: Longitude
-  real(kind_phys), public, pointer,   protected :: longitude(:) => NULL()
-  ! pver: Vertical layer dimension
-  integer,         public, parameter          :: pver = 42
+  integer,         public,              protected :: ncol = 0
+  ! pver: Number of vertical layers
+  integer,         public,              protected :: pver = 0
+  ! ndust: Number of dust size bins
+  integer,         public                       :: ndust = 4
+  ! rndst: Dust radii by size bin
+  real(kind_phys), public, allocatable          :: rndst(:, :, :)
 
 !! public interfaces
-  public :: allocate_physics_types_parameter_fields
-  public :: physics_types_parameter_tstep_init
+  public :: allocate_physics_types_self_ref_dim_fields
+  public :: physics_types_self_ref_dim_tstep_init
 
 contains
 
-  subroutine allocate_physics_types_parameter_fields(set_init_val_in, reallocate_in)
+  subroutine allocate_physics_types_self_ref_dim_fields(set_init_val_in, reallocate_in)
     use shr_infnan_mod,   only: nan => shr_infnan_nan, assignment(=)
     use cam_abortutils,   only: endrun
 
@@ -51,8 +51,10 @@ contains
     !! Local variables
     logical                     :: set_init_val
     logical                     :: reallocate
-    character(len=*), parameter :: subname = "allocate_physics_types_parameter_fields"
+    character(len=*), parameter :: subname = "allocate_physics_types_self_ref_dim_fields"
+    integer                     :: dust_size_bin_dimension
     integer                     :: horizontal_dimension
+    integer                     :: vertical_layer_dimension
 
     ! Set optional argument values
     if (present(set_init_val_in)) then
@@ -67,42 +69,37 @@ contains
     end if
 
     ! Set self-referential dimension variables
+    dust_size_bin_dimension = ndust
     horizontal_dimension = ncol
+    vertical_layer_dimension = pver
 
     if (set_init_val) then
       ncol = 0
     end if
-    if (associated(latitude)) then
+    if (set_init_val) then
+      pver = 0
+    end if
+    if (set_init_val) then
+      ndust = 4
+    end if
+    if (allocated(rndst)) then
       if (reallocate) then
-        deallocate(latitude)
-        nullify(latitude)
+        deallocate(rndst)
       else
-        call endrun(subname//": latitude is already associated, cannot allocate")
+        call endrun(subname//": rndst is already allocated, cannot allocate")
       end if
     end if
-    allocate(latitude(horizontal_dimension))
+    allocate(rndst(horizontal_dimension, vertical_layer_dimension, dust_size_bin_dimension))
     if (set_init_val) then
-      latitude = nan
+      rndst = 0.0_kind_phys
     end if
-    if (associated(longitude)) then
-      if (reallocate) then
-        deallocate(longitude)
-        nullify(longitude)
-      else
-        call endrun(subname//": longitude is already associated, cannot allocate")
-      end if
-    end if
-    allocate(longitude(horizontal_dimension))
-    if (set_init_val) then
-      longitude = nan
-    end if
-  end subroutine allocate_physics_types_parameter_fields
+  end subroutine allocate_physics_types_self_ref_dim_fields
 
-  subroutine physics_types_parameter_tstep_init()
+  subroutine physics_types_self_ref_dim_tstep_init()
 
     !! Local variables
-    character(len=*), parameter :: subname = "physics_types_parameter_tstep_init"
+    character(len=*), parameter :: subname = "physics_types_self_ref_dim_tstep_init"
 
-  end subroutine physics_types_parameter_tstep_init
+  end subroutine physics_types_self_ref_dim_tstep_init
 
-end module physics_types_parameter
+end module physics_types_self_ref_dim

--- a/test/unit/python/sample_files/physics_types_self_ref_dim.meta
+++ b/test/unit/python/sample_files/physics_types_self_ref_dim.meta
@@ -1,0 +1,31 @@
+[ccpp-table-properties]
+  name = physics_types_self_ref_dim
+  type = module
+[ccpp-arg-table]
+  name = physics_types_self_ref_dim
+  type = module
+[ ncol ]
+  standard_name = horizontal_dimension
+  long_name = Number of horizontal columns
+  units = count
+  type = integer
+  dimensions = ()
+  protected = True
+[ pver ]
+  standard_name = vertical_layer_dimension
+  long_name = Number of vertical layers
+  units = count
+  type = integer
+  dimensions = ()
+  protected = True
+[ ndust ]
+  standard_name = dust_size_bin_dimension
+  long_name = Number of dust size bins
+  units = count
+  type = integer
+  dimensions = ()
+[ rndst ]
+  standard_name = dust_radii_by_size_bin
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension, dust_size_bin_dimension)

--- a/test/unit/python/sample_files/physics_types_simple.F90
+++ b/test/unit/python/sample_files/physics_types_simple.F90
@@ -50,6 +50,7 @@ contains
     logical                     :: set_init_val
     logical                     :: reallocate
     character(len=*), parameter :: subname = "allocate_physics_types_simple_fields"
+    integer                     :: horizontal_dimension
 
     ! Set optional argument values
     if (present(set_init_val_in)) then
@@ -62,6 +63,9 @@ contains
     else
       reallocate = .false.
     end if
+
+    ! Set self-referential dimension variables
+    horizontal_dimension = ncol
 
     if (set_init_val) then
       ncol = 0

--- a/test/unit/python/sample_files/reg_good_self_ref_dim.xml
+++ b/test/unit/python/sample_files/reg_good_self_ref_dim.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<registry name="cam_registry" version="1.0">
+  <file name="physics_types_self_ref_dim" type="module">
+    <use module="ccpp_kinds" reference="kind_phys"/>
+    <variable local_name="ncol" standard_name="horizontal_dimension"
+              units="count" type="integer" access="protected">
+      <long_name>Number of horizontal columns</long_name>
+      <initial_value>0</initial_value>
+    </variable>
+    <variable local_name="pver" standard_name="vertical_layer_dimension"
+              units="count" type="integer" access="protected">
+      <long_name>Number of vertical layers</long_name>
+      <initial_value>0</initial_value>
+    </variable>
+    <variable local_name="ndust" standard_name="dust_size_bin_dimension"
+              units="count" type="integer">
+      <long_name>Number of dust size bins</long_name>
+      <initial_value>4</initial_value>
+    </variable>
+    <variable local_name="rndst" standard_name="dust_radii_by_size_bin"
+              units="m" type="real" kind="kind_phys" allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension dust_size_bin_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+    </variable>
+  </file>
+</registry>

--- a/test/unit/python/test_registry.py
+++ b/test/unit/python/test_registry.py
@@ -477,6 +477,41 @@ class RegistryTest(unittest.TestCase):
         amsg = f"Expected 14 metadata variables, found {num_vars}"
         self.assertEqual(num_vars, 14, msg=amsg)
 
+    def test_good_self_ref_dim_registry(self):
+        """Test that a registry with self-referential dimensions
+        (dimensions defined as variables in the same module) generates
+        correct local aliases in the allocate subroutine."""
+        # Setup test
+        filename = os.path.join(_SAMPLE_FILES_DIR, "reg_good_self_ref_dim.xml")
+        out_source_name = "physics_types_self_ref_dim"
+        in_source = os.path.join(_SAMPLE_FILES_DIR, out_source_name + '.F90')
+        in_meta = os.path.join(_SAMPLE_FILES_DIR, out_source_name + '.meta')
+        out_source = os.path.join(_TMP_DIR, out_source_name + '.F90')
+        out_meta = os.path.join(_TMP_DIR, out_source_name + '.meta')
+        remove_files([out_source, out_meta])
+        # Run test
+        retcode, files, _, _, _ = gen_registry(filename, 'fv', _TMP_DIR, 2,
+                                               _SRC_MOD_DIR, _CAM_ROOT,
+                                               loglevel=logging.ERROR,
+                                               error_on_no_validate=True)
+        # Check return code
+        amsg = f"Test failure: retcode={retcode}"
+        self.assertEqual(retcode, 0, msg=amsg)
+        flen = len(files)
+        amsg = f"Test failure: Found {flen} files, expected 1"
+        self.assertEqual(flen, 1, msg=amsg)
+        # Make sure each output file was created
+        amsg = f"{out_meta} does not exist"
+        self.assertTrue(os.path.exists(out_meta), msg=amsg)
+        amsg = f"{out_source} does not exist"
+        self.assertTrue(os.path.exists(out_source), msg=amsg)
+        # For each output file, make sure it matches input file
+        amsg = f"{out_meta} does not match {in_meta}"
+        self.assertTrue(filecmp.cmp(out_meta, in_meta, shallow=False), msg=amsg)
+        amsg = f"{out_source} does not match {in_source}"
+        self.assertTrue(filecmp.cmp(out_source, in_source, shallow=False),
+                        msg=amsg)
+
     def test_no_metadata_file_registry(self):
         """Test code and metadata generation from a good registry with
         a non-existent metadata file.


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What: claude-opus:4.6[1m]
  How: scoped out the work, wrote tests and proposed fix to horizontal_dimensions unassigned in test

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- Fixes #390 
- Fixes #465: Fix self-referential custom dimensions in registry autogen

Background: Variables used in `microp_aero` like `nacon` and `rndst` in `registry.xml` (to be read from snapshot file) use `dust_size_bin_dimension` as a third dimension. That dimension is itself defined as a variable `ndust` (dust_size_bin_dimension) in the same generated module. 

Problem: The autogen code (`generate_registry_data.py`) emits allocate calls using standard names as Fortran identifiers (e.g., allocate(rndst(..., dust_size_bin_dimension))), but only knows how to import dimension variables from external metadata files via use statements. For dimensions defined in the same module, no use statement can be generated (Fortran can't use its own module), so the standard name is undefined at compile time.

This fix generates local integer aliases in the allocate subroutine for any dimension that resolves to a variable in the same module:
```fortran
  integer :: dust_size_bin_dimension  ! local alias
  dust_size_bin_dimension = ndust     ! set before allocate calls
```

  This only triggers when the dimension is not already provided by an external metadata file (i.e., not in `var_module_dict`). The existing `number_of_ccpp_constituents` special case (quoted below) is left untouched:
https://github.com/ESCOMP/CAM-SIMA/blob/a9a626387a0279e96cd5455d303a0da7d3505f0c/src/data/generate_registry_data.py#L1400-L1408

- Fix undefined `horizontal_dimension` variable in tests - Claude pointed out that it was unassigned in the test file. In real builds, `horizontal_dimension` comes from `physics_grid.meta` via a `use` statement, so no alias is generated for it. It should only be fixed in the test sample file.

Describe any changes made to build system:

Describe any changes made to the namelist:

List any changes to the defaults for the input datasets (e.g. boundary datasets):

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       src/data/generate_registry_data.py
  - now assign self-referencing dimensions from registry

M       test/unit/python/sample_files/physics_types_parameter.F90
M       test/unit/python/sample_files/physics_types_simple.F90
  - bugfix for unassigned horizontal_dimensions in original test sample file

A       test/unit/python/sample_files/physics_types_self_ref_dim.F90
A       test/unit/python/sample_files/physics_types_self_ref_dim.meta
A       test/unit/python/sample_files/reg_good_self_ref_dim.xml
M       test/unit/python/test_registry.py
  - dust third dimension specified in registry.xml + variable using that dimension in registry.xml (self-referencing) test in test_registry test

M       src/data/registry.xml
  - add dust_size_bin_dimension set to 4
  - add nacon, rndst variables which use new ndust=4 dimension
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
