### PR TITLE
Fix #324 - Separate CCPP schemes cannot share namelist groups

### DIFF
--- a/cime_config/atm_in_paramgen.py
+++ b/cime_config/atm_in_paramgen.py
@@ -966,7 +966,9 @@ class AtmInParamGen(ParamGen):
         """
         Append a new AtmInParamGen object
         to this one, ensuring that there are
-        no duplicate namelist groups or variables.
+        no duplicate namelist variables.
+        Multiple XML files may contribute variables
+        to the same namelist group.
         ----------
         atm_pg_obj -> An AtmInParamGen object
 
@@ -974,46 +976,24 @@ class AtmInParamGen(ParamGen):
         #Loop over all XML files associated with input atm_pg object:
         for input_file in atm_pg_obj.__nml_def_groups:
 
-            #Extract the group and variable sets from input PG object:
-            input_groups = atm_pg_obj.__nml_def_groups[input_file]
-            input_vars   = atm_pg_obj.__nml_def_vars[input_file]
-
-            #Check that there are no matching namelist groups:
-            #------------------------------------------------
+            #Extract the variable set from input PG object:
+            input_vars = atm_pg_obj.__nml_def_vars[input_file]
 
             #Initialize error message string:
             emsg = ""
-
-            #Loop over all namelist files and namelist group sets:
-            for nml_file, nml_groups in self.__nml_def_groups.items():
-
-                #Determine if any namelist groups are the same
-                #between the two objects:
-                same_groups = nml_groups.intersection(input_groups)
-
-                #If so, then add to error message (as all namelist groups must be unique):
-                if same_groups:
-                    emsg += f"Cannot append:\n'{input_file}'\n"
-                    emsg += " The following namelist groups conflict with those in"
-                    emsg += f"\n'{nml_file} :'\n"
-                    emsg += ", ".join(same_groups)
-                #End if
-            #End for
-
-            #------------------------------------------------
 
             #Check that there are no matching namelist variables:
             #------------------------------------------------
             for nml_file, nml_vars in self.__nml_def_vars.items():
 
-                #Determine if any namelist groups are the same
+                #Determine if any namelist variables are the same
                 #between the two objects:
                 same_vars = nml_vars.intersection(input_vars)
 
                 #If so, then add to error message (as all namelist variable ids must be unique):
                 if same_vars:
                     emsg += f"Cannot append:\n'{input_file}'\n"
-                    emsg += " The following namelist variablesconflict with those in"
+                    emsg += " The following namelist variables conflict with those in"
                     emsg += f"\n'{nml_file} :'\n"
                     emsg += ", ".join(same_vars)
                 #End if
@@ -1026,7 +1006,7 @@ class AtmInParamGen(ParamGen):
         #error(s) here:
         if emsg:
             raise AtmInParamGenError(emsg)
-        #Endd if
+        #End if
 
         #Add input PG object dictionaries to this object's dicts:
         self.__nml_def_groups.update(atm_pg_obj.__nml_def_groups)

--- a/test/unit/python/test_atm_in_paramgen.py
+++ b/test/unit/python/test_atm_in_paramgen.py
@@ -433,9 +433,9 @@ class AtmInParamGenTestRoutine(unittest.TestCase):
 
         """
         Check that using multiple XML namelist
-        definition files that have the same
-        namelist group throws an error and
-        that the error message is correct.
+        definition files that share a namelist
+        group succeeds and merges the variables
+        from both files into the shared group.
         """
 
         # Get XML file paths:
@@ -446,16 +446,17 @@ class AtmInParamGenTestRoutine(unittest.TestCase):
         pg_test = AtmInParamGen.from_namelist_xml(xml_test_fil)
         pg_ext  = AtmInParamGen.from_namelist_xml(extra_xml_fil)
 
-        # Append the extra PG object to the other:
-        with self.assertRaises(AtmInParamGenError) as cerr:
-            pg_test.append_atm_in_pg(pg_ext)
+        # Append should succeed:
+        pg_test.append_atm_in_pg(pg_ext)
 
-        # Check exception message:
-        emsg = f"Cannot append:\n'{extra_xml_fil}'\n"
-        emsg += " The following namelist groups conflict with those in"
-        emsg += f"\n'{xml_test_fil} :'\n"
-        emsg += "bird_sounds_nl"
-        self.assertEqual(emsg, str(cerr.exception))
+        # Check that the shared group contains variables from both files:
+        shared_group = pg_test.data["bird_sounds_nl"]
+        self.assertIn("duck_quack", shared_group)
+        self.assertIn("turkey_leg", shared_group)
+        self.assertIn("laser_beam", shared_group)
+
+        # Check that a group unique to the extra file is also present:
+        self.assertIn("sci_fi_sounds_nl", pg_test.data)
 
     #++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -482,7 +483,7 @@ class AtmInParamGenTestRoutine(unittest.TestCase):
 
         # Check exception message:
         emsg = f"Cannot append:\n'{extra_xml_fil}'\n"
-        emsg += " The following namelist variablesconflict with those in"
+        emsg += " The following namelist variables conflict with those in"
         emsg += f"\n'{xml_test_fil} :'\n"
         emsg += "duck_quack"
         self.assertEqual(emsg, str(cerr.exception))


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What: claude-opus:4.6[1m]
  How: found the fix, wrote the fix

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- Fixes #324 where separate CCPP scheme namelist files could not share namelist groups.
Now the namelist groups from separate files are merged. Duplicate keys are still disallowed.

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       cime_config/atm_in_paramgen.py
  - do not disallow duplicate namelist groups, instead merge them

M       test/unit/python/test_atm_in_paramgen.py
  - update test
  - fix typo
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
