### PR TITLE
sima0_14_002: Harden find_input_name_idx: prevent use of constituent index if not found in standard names array

### DIFF
--- a/src/physics/utils/physics_data.F90
+++ b/src/physics/utils/physics_data.F90
@@ -74,11 +74,13 @@ CONTAINS
       ! to test read_from_file status
       logical                       :: is_read
       logical                       :: is_constituent
+      logical                       :: found_in_phys_vars
 
       !Initialize function:
       find_input_name_idx = no_exist_idx
       constituent_index = no_exist_idx
       is_constituent = .false.
+      found_in_phys_vars = .false.
 
       !First check if quantity is a constituent:
       call const_get_index(trim(stdname), find_input_name_idx, abort=.false., warning=.false.)
@@ -93,6 +95,7 @@ CONTAINS
       do idx = 1, phys_var_num
          !Check if provided name is in required names array:
          if (trim(phys_var_stdnames(idx)) == trim(stdname)) then
+            found_in_phys_vars = .true.
             !Check if this variable has already been initialized.
             !If so, then set the index to a quantity that will be skipped:
             if (is_initialized(stdname)) then
@@ -126,6 +129,14 @@ CONTAINS
             exit
          end if
       end do
+      ! If the variable was not found in phys_var_stdnames but is a known
+      ! constituent, return const_idx so the caller handles it via the
+      ! constituent path.  Without this, the raw constituent index from
+      ! const_get_index would leak through as a phys_var_stdnames array
+      ! index, causing an unrelated variable to be accessed.
+      if (.not. found_in_phys_vars .and. is_constituent) then
+         find_input_name_idx = const_idx
+      end if
       ! If not found, loop through the excluded variable standard names
       if (find_input_name_idx == no_exist_idx) then
          do idx = 1, phys_const_num


### PR DESCRIPTION
Tag name (required for release branches): sima0_14_002
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What: claude-opus:4.6[1m]
  How: proposed the fix after being provided with the failing scenario

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- This hardens `find_input_name_idx` to prevent an issue if the underlying CCPP framework is broken and does not construct a full `phys_var_stdnames` array, leading to constituent indices leaking through the match and not returning `const_idx = -4` as it should.

The bug manifests itself as follows as described by Claude:

> 1. Line 84: const_get_index() sets find_input_name_idx to the constituent's raw index (e.g., 3)
> 2. Lines 93-128: Loops through phys_var_stdnames. If the variable is NOT found (e.g., the framework is broken), the loop finishes without modifying find_input_name_idx: it's still 3 (the constituent index)
> 3. Line 130: The no_exist_idx check is skipped because find_input_name_idx == 3, not no_exist_idx
> 4. Back in caller (line 1126): phys_var_stdnames(3) is accessed — landing on whatever unrelated variable is at index 3 (e.g., pver, rair)
> 
> The constituent index leaks into the return value and gets misinterpreted as a phys_var_stdnames array index. The fix is to reset find_input_name_idx after the loop if it wasn't matched.

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       src/physics/utils/physics_data.F90
   - harden find_input_name_idx
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:
```
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape (Overall: NLFAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape NLCOMP
  - pre-existing failure
```

derecho/gnu/aux_sima:
```
  SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam (Overall: FAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam RUN time=13
  - pre-existing failure
```

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines): All PASS

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
