### PR TITLE
sima0_14_004: Fix average field accumulation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 [submodule "history"]
 	path          = src/history/buffers
 	url           = https://github.com/peverwhee/history_output
-	fxtag         = 5bb5d7bea115924887603a2428bfe6581f5b0315
+	fxtag         = 2f8cf735276c4a44b4316ed43a3eeb4b8a6a6107
 	fxrequired    = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESMCI/history_output
 [submodule "mpas"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,8 @@
 	fxDONOTUSEurl = https://github.com/NCAR/ccpp-framework
 [submodule "history"]
 	path          = src/history/buffers
-	url           = https://github.com/ESMCI/history_output
-	fxtag         = history01_01
+	url           = https://github.com/peverwhee/history_output
+	fxtag         = 5bb5d7bea115924887603a2428bfe6581f5b0315
 	fxrequired    = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESMCI/history_output
 [submodule "mpas"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,8 @@
 	fxDONOTUSEurl = https://github.com/NCAR/ccpp-framework
 [submodule "history"]
 	path          = src/history/buffers
-	url           = https://github.com/peverwhee/history_output
-	fxtag         = 2f8cf735276c4a44b4316ed43a3eeb4b8a6a6107
+	url           = https://github.com/ESMCI/history_output
+	fxtag         = history01_02
 	fxrequired    = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESMCI/history_output
 [submodule "mpas"]

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_kessler_mpas_derecho_history/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_kessler_mpas_derecho_history/user_nl_cam
@@ -1,8 +1,8 @@
 debug_output=0
-hist_add_inst_fields;h3: Q,T,U,V,PS
-hist_add_avg_fields;h3: PSDRY
-hist_add_max_fields;h3: PHIS
-hist_add_min_fields;h3: PDEL, PDELDRY
+hist_add_inst_fields;h3: Q,T,U,V
+hist_add_avg_fields;h3: PSDRY, CLDLIQ
+hist_add_max_fields;h3: PHIS, PINTDRY
+hist_add_min_fields;h3: PDEL, PS
 hist_add_var_fields;h3: ZM, PRECT
 hist_output_frequency;h3: 2*nsteps
 hist_write_nstep0;h3: .true.


### PR DESCRIPTION
Tag name (required for release branches): sima0_14_004
Originator(s): peverwhee
AI tools used (if applicable; please also add the "AI-generated code" label to the PR): n/a
  What:
  How:

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
```
Fixes bug with average fields with two dimensions. 
Amends existing history test to include both 1D and 2D average fields.
```

Describe any changes made to build system: n/a

Describe any changes made to the namelist: n/a

List any changes to the defaults for the input datasets (e.g. boundary datasets): n/a

List all files eliminated and why: n/a

List all files added and what they do: n/a

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

```
M   .gitmodules
M   src/history/buffers
- update history tag

M   cime_config/testdefs/testmods_dirs/cam/outfrq_kessler_mpas_derecho_history/user_nl_cam
- ensure each accumulated field we're testing includes one 1D and one 2D field
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:
```
SMS_Ln9.mpasa480_mpasa480.FKESSLER.derecho_intel.cam-outfrq_kessler_mpas_derecho_history (Overall: DIFF)
- differences vs baseline because history configuration has been altered

SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape (Overall: NLFAIL)
- existing failure
```

derecho/gnu/aux_sima:
```
SMS_Ln9.mpasa480_mpasa480.FKESSLER.derecho_gnu.cam-outfrq_kessler_mpas_derecho_history (Overall: DIFF)
- differences vs baseline because history configuration has been altered

SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam (Overall: FAIL)
- existing failure
```

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines): run through github

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced: n/a

CAM-SIMA date used for the baseline comparison tests if different than latest:
