### PR TITLE
Misc code fixes identified by Claude (batch 1)

### DIFF
--- a/cime_config/create_readnl_files.py
+++ b/cime_config/create_readnl_files.py
@@ -915,7 +915,7 @@ class SchemeNamelistInfo:
     def nlread_file(self):
         """Return the generated namelist read filename for this
         SchemeNamelistInfo object"""
-        return self._nlread_file
+        return self.__nlread_file
 
     @property
     def nlread_module(self):

--- a/src/data/generate_registry_data.py
+++ b/src/data/generate_registry_data.py
@@ -300,7 +300,7 @@ class VarBase:
                 else:
                     outfile.write(f'{var_name} = (0.0, 0.0)', indent)
             elif self.var_type.lower() == 'logical':
-                outfile.write('{var_name} = .false.', indent)
+                outfile.write(f'{var_name} = .false.', indent)
             else:
                 emsg = 'Variable "{}" is of type "{}", which is not a supported type\n'
                 emsg += 'for use with "phys_timestep_init_zero".'

--- a/src/dynamics/none/dyn_grid.F90
+++ b/src/dynamics/none/dyn_grid.F90
@@ -268,6 +268,7 @@ CONTAINS
             else
                write(errormsg, '(4a)') subname, "Unknown dimension, '",       &
                     trim(dimnames(lindex)), "'"
+               call endrun(errormsg)
             end if
          end do
       else

--- a/src/physics/utils/gravity_wave_drag_ridge_read.F90
+++ b/src/physics/utils/gravity_wave_drag_ridge_read.F90
@@ -143,6 +143,9 @@ contains
     errmsg = ''
     errflg = 0
 
+    nullify(fh_topo)
+    nullify(fh_rdggm)
+
     has_gbxar_from_topo = .false.
     call mark_as_initialized('number_of_ridges_in_ridge_gravity_wave_drag')
 
@@ -265,7 +268,7 @@ contains
       call cam_pio_openfile(fh_rdggm, bnd_rdggm_loc, pio_nowrite)
 
       if(masterproc) then
-        write (iulog,*) trim(subname)//': Reading meso-Gamma ridge data from ', trim(bnd_topo_loc)
+        write (iulog,*) trim(subname)//': Reading meso-Gamma ridge data from ', trim(bnd_rdggm_loc)
       endif
 
       ! Allocate meso-Gamma ridge data arrays

--- a/src/physics/utils/physics_data.F90
+++ b/src/physics/utils/physics_data.F90
@@ -826,11 +826,12 @@ CONTAINS
                   diff_found = .true.
                end if
                ! Store verbose entry for later printing (after all diffs)
-               if ((debug_output >= DEBUGOUT_INFO) .and.                 &
-                   diff_count_gl == 0 .and. global_count > 0) then
-                  call store_verbose_entry(stdname, global_count,           &
-                                           global_avg_model,               &
-                                           global_avg_snapshot)
+               if (debug_output >= DEBUGOUT_INFO) then
+                  if (diff_count_gl == 0 .and. global_count > 0) then
+                     call store_verbose_entry(stdname, global_count,        &
+                                              global_avg_model,             &
+                                              global_avg_snapshot)
+                  end if
                end if
             end if
          end if
@@ -872,7 +873,7 @@ CONTAINS
       logical,           intent(out)   :: diff_found
 
       !Local variables:
-      logical                          :: var_found = .true.
+      logical                          :: var_found
       character(len=std_name_len)      :: found_name
       type(var_desc_t)                 :: vardesc
       character(len=*),  parameter     :: subname = 'check_field_3d'
@@ -1099,7 +1100,7 @@ CONTAINS
       logical,           intent(out)   :: diff_found
 
       !Local variables:
-      logical                          :: var_found = .true.
+      logical                          :: var_found
       character(len=std_name_len)      :: found_name
       type(var_desc_t)                 :: vardesc
       character(len=*),  parameter     :: subname = 'check_field_4d'
@@ -1303,11 +1304,12 @@ CONTAINS
                end if
 
                ! Store verbose entry for later printing (after all diffs)
-               if ((debug_output >= DEBUGOUT_INFO) .and.                 &
-                   diff_count_gl == 0 .and. global_count > 0) then
-                  call store_verbose_entry(stdname, global_count,          &
-                                           global_avg_model,               &
-                                           global_avg_snapshot)
+               if (debug_output >= DEBUGOUT_INFO) then
+                  if(diff_count_gl == 0 .and. global_count > 0) then
+                     call store_verbose_entry(stdname, global_count,          &
+                                              global_avg_model,               &
+                                              global_avg_snapshot)
+                  end if
                end if
             end if
          end if

--- a/src/physics/utils/physics_grid.F90
+++ b/src/physics/utils/physics_grid.F90
@@ -284,10 +284,10 @@ CONTAINS
 
          ! We need a global minimum longitude and latitude
          temp = lonmin
-         call MPI_allreduce(temp, lonmin, 1, MPI_INTEGER, MPI_MIN,         &
+         call MPI_allreduce(temp, lonmin, 1, MPI_REAL8, MPI_MIN,         &
               mpicom, ierr)
          temp = latmin
-         call MPI_allreduce(temp, latmin, 1, MPI_INTEGER, MPI_MIN,         &
+         call MPI_allreduce(temp, latmin, 1, MPI_REAL8, MPI_MIN,         &
               mpicom, ierr)
          ! Create lon coord map which only writes from one of each unique lon
          where(latvals == latmin)

--- a/src/utils/gmean_mod.F90
+++ b/src/utils/gmean_mod.F90
@@ -124,9 +124,8 @@ CONTAINS
       integer, parameter    :: nflds = 1
       real(r8)              :: gmean_array(nflds)
       real(r8)              :: array(pcols, nflds)
-      integer               :: ncols, lchnk
 
-      array(:ncols, 1) = arr(:ncols)
+      array(:, 1) = arr(:)
       call gmean_arr(array, gmean_array, nflds)
       gmean = gmean_array(1)
 

--- a/test/unit/python/test_hist_config.py
+++ b/test/unit/python/test_hist_config.py
@@ -131,7 +131,7 @@ class HistConfigTest(unittest.TestCase):
         self.assertTrue(os.path.exists(out_source), msg=amsg)
         # Make sure the output file is correct
         amsg = f"{out_source} does not match {out_test}"
-        self.assertTrue(filecmp.cmp(out_test, out_source, shallow='.false.'),
+        self.assertTrue(filecmp.cmp(out_test, out_source, shallow=False),
                         msg=amsg)
 
     def test_multi_user_nl_cam(self):
@@ -171,7 +171,7 @@ class HistConfigTest(unittest.TestCase):
         self.assertTrue(os.path.exists(out_source), msg=amsg)
         # Make sure the output file is correct
         amsg = f"{out_source} does not match {out_test}"
-        self.assertTrue(filecmp.cmp(out_test, out_source, shallow='.false.'),
+        self.assertTrue(filecmp.cmp(out_test, out_source, shallow=False),
                         msg=amsg)
 
     def test_bad_user_nl_cam(self):

--- a/test/unit/python/test_registry.py
+++ b/test/unit/python/test_registry.py
@@ -454,7 +454,7 @@ class RegistryTest(unittest.TestCase):
         amsg = f"Test failure: retcode={retcode}"
         self.assertEqual(retcode, 0, msg=amsg)
         flen = len(files)
-        amsg = f"Test failure: Found {flen} files, expected 2"
+        amsg = f"Test failure: Found {flen} files, expected 4"
         self.assertEqual(flen, 4, msg=amsg)
 
         # Make sure each output file was created


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What: claude-opus:4.8[1m], claude-opus:4.6[1m]
  How: identified the fixes and subsequent triage

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

An assorted grab bag of fixes for robustness. 

Claude identified the issues, then an independent model run verified them.

I then verified and wrote the fixes, these are small and I could readily understand Claude's reasoning.

- generate_registry_data.py: add missing f-string prefix on logical tstep_init branch that emitted literal '{var_name}' into generated Fortran
- create_readnl_files.py: fix nlread_file property to return self.__nlread_file (double-underscore) matching the actual mangled attribute
- gmean_mod.F90: remove uninitialized ncols/lchnk locals in gmean_scl; use full-extent array slices
- physics_grid.F90: fix MPI_allreduce datatype from MPI_INTEGER to MPI_REAL8 for real(r8) lon/lat coordinate minima
- gravity_wave_drag_ridge_read.F90: nullify fh_topo/fh_rdggm pointers at subroutine entry to establish defined association status
- gravity_wave_drag_ridge_read.F90: fix meso-Gamma ridge log message to print bnd_rdggm_loc instead of bnd_topo_loc
- physics_data.F90: nest store_verbose_entry guard inside debug_output check to avoid reading uninitialized global_count in check_field_2d/4d
- physics_data.F90: remove initializer from var_found declaration in check_field_3d/4d to avoid implicit SAVE attribute
- test_hist_config.py: fix filecmp.cmp shallow='.false.' (truthy string) to shallow=False for byte-level content comparison
- test_registry.py: fix diagnostic message in test_good_complete_registry from "expected 2" to "expected 4"
- none/dyn_grid.F90: fix errormsg not calling endrun after


Describe any changes made to build system:

Describe any changes made to the namelist:

List any changes to the defaults for the input datasets (e.g. boundary datasets):

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       cime_config/create_readnl_files.py
  - fix nlread_file property to return self.__nlread_file (double-underscore) matching the actual mangled attribute

M       src/data/generate_registry_data.py
  - add missing f-string prefix on logical tstep_init branch that emitted literal '{var_name}' into generated Fortran

M       test/unit/python/test_hist_config.py
  - fix filecmp.cmp shallow='.false.' (truthy string) to shallow=False for byte-level content comparison

M       test/unit/python/test_registry.py
  - fix diagnostic message in test_good_complete_registry from "expected 2" to "expected 4"

M       src/dynamics/none/dyn_grid.F90
  - fix errormsg not calling endrun after

M       src/physics/utils/gravity_wave_drag_ridge_read.F90
  - nullify fh_topo/fh_rdggm pointers at subroutine entry to establish defined association status
  - fix meso-Gamma ridge log message to print bnd_rdggm_loc instead of bnd_topo_loc

M       src/physics/utils/physics_data.F90
  - nest store_verbose_entry guard inside debug_output check to avoid reading uninitialized global_count in check_field_2d/4d
  - remove initializer from var_found declaration in check_field_3d/4d to avoid implicit SAVE attribute

M       src/physics/utils/physics_grid.F90
  - fix MPI_allreduce datatype from MPI_INTEGER to MPI_REAL8 for real(r8) lon/lat coordinate minima

M       src/utils/gmean_mod.F90
  - remove uninitialized ncols/lchnk locals in gmean_scl; use full-extent array slices
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
