### PR TITLE
Complete CCPPization of CAM7 hb_free_atm: add regression test

### DIFF
--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -88,6 +88,15 @@
       <option name="comment">Test for Holtslag-Boville boundary layer scheme and vertical diffusion</option>
     </options>
   </test>
+  <test compset="FPHYStest" grid="ne3pg3_ne3pg3_mg37" name="SMS_Ln2" testmods="cam/outfrq_hb_freeatm_vdiff_derecho">
+    <machines>
+      <machine name="derecho" compiler="gnu" category="aux_sima"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:10:00</option>
+      <option name="comment">Test for Holtslag-Boville boundary layer scheme for free atm above CLUBB and vertical diffusion</option>
+    </options>
+  </test>
   <test compset="FPHYStest" grid="ne3pg3_ne3pg3_mg37" name="SMS_Ln2" testmods="cam/outfrq_uw_vdiff_derecho">
     <machines>
       <machine name="derecho" compiler="gnu" category="aux_sima"/>

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_hb_freeatm_vdiff_derecho/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_hb_freeatm_vdiff_derecho/shell_commands
@@ -1,0 +1,1 @@
+ ./xmlchange CAM_CONFIG_OPTS="--dyn none --physics-suites vdiff_holtslag_boville_free_atm"

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_hb_freeatm_vdiff_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_hb_freeatm_vdiff_derecho/user_nl_cam
@@ -1,0 +1,13 @@
+! CAM7 FHISTC_LTso snapshot:
+ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_vertical_diffusion_hb_free_atm_snapshot_derecho_gnu_before_c20260604.nc'
+ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_vertical_diffusion_hb_free_atm_snapshot_derecho_gnu_after_c20260604.nc'
+pver = 58
+
+do_iss = .true.
+
+hist_output_frequency;h1: 1*nsteps
+hist_max_frames;h1: 1
+hist_add_inst_fields;h1:QT,SL,SLV,SLFLX,QTFLX,UFLX,VFLX
+hist_add_inst_fields;h1:DTV,DUV,DVV,DTVKE
+hist_precision;h1: REAL64
+


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What:
  How:

Companion PR: https://github.com/ESCOMP/atmospheric_physics/pull/414

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- Add regression test for `hb_free_atm` for CAM7 above CLUBB

Describe any changes made to build system:

Describe any changes made to the namelist:

List any changes to the defaults for the input datasets (e.g. boundary datasets):

List all files eliminated and why:

List all files added and what they do:
```
A       cime_config/testdefs/testmods_dirs/cam/outfrq_hb_freeatm_vdiff_derecho/shell_commands
A       cime_config/testdefs/testmods_dirs/cam/outfrq_hb_freeatm_vdiff_derecho/user_nl_cam
  - new testmod
```

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       cime_config/testdefs/testlist_cam.xml
  - new testmod
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
