### PR TITLE
part of sima0_20_000: Bug fix: only split namelist by first =, do not clobber namelist field values

### DIFF
--- a/cime_config/atm_in_paramgen.py
+++ b/cime_config/atm_in_paramgen.py
@@ -1383,7 +1383,7 @@ class AtmInParamGen(ParamGen):
 
                     #Now parse the line:
                     if "=" in line and (line.strip()[0] != "=") and not (is_array and is_continue_line):
-                        line_ss   = line.split("=")       # Split line into before/after equals sign
+                        line_ss   = line.split("=", 1)    # Split only on first '=' (key=value separator)
                         var_str   = (line_ss[0]).strip()  # the first element is the variable name
 
                         #Check if this variable is an array, and if so,
@@ -1410,7 +1410,7 @@ class AtmInParamGen(ParamGen):
                         #End if (array indices)
 
                         #Extract value string:
-                        val_str   = ' '.join(line_ss[1:]).strip() # the rest is the value string
+                        val_str   = line_ss[1].strip() # the rest is the value string
 
                         #Check if value string ends in array continuation:
                         if is_array:


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What: claude-opus-4-8
  How: proposed fix after prompting with the issue.

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- The current namelist line parse splits by all `=` in a given line and not just the first one, leading to legitimate lines like this one
```
mode_defs              = 'mam4_mode1:accum:=', 'A:num_a1:N:num_c1:num_mr:+',
         'A:so4_a1:N:so4_c1:sulfate:/glade/campaign/cesm/cesmdata/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
```

being erroneously clobbered into
```
                                 ----------v  note the = got transformed into a space here
mode_defs              = 'mam4_mode1:accum: ', 'A:num_a1:N:num_c1:num_mr:+',
         'A:so4_a1:N:so4_c1:sulfate:/glade/campaign/cesm/cesmdata/inputdata/atm/cam/physprops/sulfate_rrtmg_c080918.nc:+',
```

Describe any changes made to build system: changed `atm_in_paramgen.py`

Describe any changes made to the namelist:

List any changes to the defaults for the input datasets (e.g. boundary datasets):

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M cime_config/atm_in_paramgen.py
  - now split by first = only to avoid clobbering namelist values with = character
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
