### PR TITLE
Resolve registry parameter dimensions after the whole registry is parsed

### DIFF
--- a/src/data/generate_registry_data.py
+++ b/src/data/generate_registry_data.py
@@ -364,6 +364,28 @@ class VarBase:
         """Return the dimension string for allocating this variable"""
         return '(' + ', '.join(self.allocation_dimensions) + ')'
 
+    def fix_parameter_dimensions(self, vdict):
+        """Re-resolve this variable's allocation dimensions against the
+        complete variable dictionary, <vdict>, replacing the standard name
+        of any dimension provided by a parameter variable with that
+        variable's local name. The resolution done while parsing the
+        variable can only see variables declared earlier in the registry,
+        so a parameter declared after a variable using it as a dimension
+        is missed there."""
+        for ind, adim in enumerate(self.__allocation_dimensions):
+            dimstrs = [x.strip() for x in adim.split(':')]
+            ldimstrs = []
+            for ddim in dimstrs:
+                dvar = vdict.find_variable_by_standard_name(ddim)
+                if dvar and (dvar.allocatable == 'parameter'):
+                    ldimstrs.append(dvar.local_name)
+                else:
+                    ldimstrs.append(ddim)
+                # end if
+            # end for
+            self.__allocation_dimensions[ind] = ':'.join(ldimstrs)
+        # end for
+
     @property
     def long_name(self):
         """Return the long_name for this variable"""
@@ -1298,6 +1320,20 @@ class File:
                 emsg = "Unknown registry File element, '{}'"
                 raise CCPPError(emsg.format(obj.tag))
             # end if
+        # end for
+        # A dimension may be provided by a parameter variable declared later
+        # in the registry than a variable using it; the resolution done while
+        # parsing each variable sees only earlier declarations, so redo it
+        # now that every variable is known. DDT members must be visited via
+        # their DDT because the DDT constructor removes them from the
+        # variable dictionary.
+        for var in self.__var_dict.variable_list():
+            var.fix_parameter_dimensions(self.__var_dict)
+        # end for
+        for ddt in self.__ddts.values():
+            for var in ddt.variable_list():
+                var.fix_parameter_dimensions(self.__var_dict)
+            # end for
         # end for
 
     def add_variable(self, var_node, logger):

--- a/test/unit/python/sample_files/physics_types_self_ref_dim.F90
+++ b/test/unit/python/sample_files/physics_types_self_ref_dim.F90
@@ -22,16 +22,27 @@ module physics_types_self_ref_dim
   implicit none
   private
 
+!> \section arg_table_cam_in_srd_t  Argument Table
+!! \htmlinclude cam_in_srd_t.html
+  type, public :: cam_in_srd_t
+    ! dstflx: Surface upward dust fluxes from coupler
+    real(kind_phys),         allocatable          :: dstflx(:, :)
+  end type cam_in_srd_t
+
 !> \section arg_table_physics_types_self_ref_dim  Argument Table
 !! \htmlinclude physics_types_self_ref_dim.html
   ! ncol: Number of horizontal columns
-  integer,         public,              protected :: ncol = 0
+  integer,            public,              protected :: ncol = 0
   ! pver: Number of vertical layers
-  integer,         public,              protected :: pver = 0
+  integer,            public,              protected :: pver = 0
+  ! dust_dmt: Dust diameter by size bin
+  real(kind_phys),    public, allocatable          :: dust_dmt(:)
   ! ndust: Number of dust size bins
-  integer,         public, parameter            :: ndust = 4
+  integer,            public, parameter            :: ndust = 4
   ! rndst: Dust radii by size bin
-  real(kind_phys), public, allocatable          :: rndst(:, :, :)
+  real(kind_phys),    public, allocatable          :: rndst(:, :, :)
+  ! cam_in: Cam in object self ref dim
+  type(cam_in_srd_t), public                       :: cam_in
 
 !! public interfaces
   public :: allocate_physics_types_self_ref_dim_fields
@@ -71,6 +82,17 @@ contains
     if (set_init_val) then
       pver = 0
     end if
+    if (allocated(dust_dmt)) then
+      if (reallocate) then
+        deallocate(dust_dmt)
+      else
+        call endrun(subname//": dust_dmt is already allocated, cannot allocate")
+      end if
+    end if
+    allocate(dust_dmt(ndust))
+    if (set_init_val) then
+      dust_dmt = 0.0_kind_phys
+    end if
     if (allocated(rndst)) then
       if (reallocate) then
         deallocate(rndst)
@@ -81,6 +103,17 @@ contains
     allocate(rndst(horizontal_dimension, vertical_layer_dimension, ndust))
     if (set_init_val) then
       rndst = 0.0_kind_phys
+    end if
+    if (allocated(cam_in%dstflx)) then
+      if (reallocate) then
+        deallocate(cam_in%dstflx)
+      else
+        call endrun(subname//": cam_in%dstflx is already allocated, cannot allocate")
+      end if
+    end if
+    allocate(cam_in%dstflx(horizontal_dimension, ndust))
+    if (set_init_val) then
+      cam_in%dstflx = 0.0_kind_phys
     end if
   end subroutine allocate_physics_types_self_ref_dim_fields
 

--- a/test/unit/python/sample_files/physics_types_self_ref_dim.meta
+++ b/test/unit/python/sample_files/physics_types_self_ref_dim.meta
@@ -1,4 +1,15 @@
 [ccpp-table-properties]
+  name = cam_in_srd_t
+  type = ddt
+[ccpp-arg-table]
+  name = cam_in_srd_t
+  type = ddt
+[ dstflx ]
+  standard_name = surface_upward_dust_fluxes_from_coupler
+  units = kg m-2 s-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, dust_size_bin_dimension)
+[ccpp-table-properties]
   name = physics_types_self_ref_dim
   type = module
 [ccpp-arg-table]
@@ -18,6 +29,11 @@
   type = integer
   dimensions = ()
   protected = True
+[ dust_dmt ]
+  standard_name = dust_diameter_by_size_bin
+  units = m
+  type = real | kind = kind_phys
+  dimensions = (dust_size_bin_dimension)
 [ ndust ]
   standard_name = dust_size_bin_dimension
   long_name = Number of dust size bins
@@ -30,3 +46,8 @@
   units = m
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension, vertical_layer_dimension, dust_size_bin_dimension)
+[ cam_in ]
+  standard_name = cam_in_object_self_ref_dim
+  units = None
+  type = cam_in_srd_t
+  dimensions = ()

--- a/test/unit/python/sample_files/reg_good_self_ref_dim.xml
+++ b/test/unit/python/sample_files/reg_good_self_ref_dim.xml
@@ -13,6 +13,20 @@
       <long_name>Number of vertical layers</long_name>
       <initial_value>0</initial_value>
     </variable>
+    <!-- dstflx and dust_dmt use a dimension whose parameter (ndust) is
+         declared later in the registry; dstflx is additionally a DDT
+         member. Both must still resolve to the parameter's local name in
+         the allocate subroutine. -->
+    <variable local_name="dstflx" standard_name="surface_upward_dust_fluxes_from_coupler"
+              units="kg m-2 s-1" type="real" kind="kind_phys" allocatable="allocatable">
+      <dimensions>horizontal_dimension dust_size_bin_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+    </variable>
+    <variable local_name="dust_dmt" standard_name="dust_diameter_by_size_bin"
+              units="m" type="real" kind="kind_phys" allocatable="allocatable">
+      <dimensions>dust_size_bin_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+    </variable>
     <variable local_name="ndust" standard_name="dust_size_bin_dimension"
               units="count" type="integer" allocatable="parameter">
       <long_name>Number of dust size bins</long_name>
@@ -22,6 +36,12 @@
               units="m" type="real" kind="kind_phys" allocatable="allocatable">
       <dimensions>horizontal_dimension vertical_layer_dimension dust_size_bin_dimension</dimensions>
       <initial_value>0.0_kind_phys</initial_value>
+    </variable>
+    <ddt type="cam_in_srd_t">
+      <data>surface_upward_dust_fluxes_from_coupler</data>
+    </ddt>
+    <variable local_name="cam_in" standard_name="cam_in_object_self_ref_dim"
+              units="None" type="cam_in_srd_t">
     </variable>
   </file>
 </registry>


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What: claude-fable:5, claude-opus:4.8
  How: proposed the fix, reviewed the fix

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

If a dimensions variable declared in the registry has its declaration **after** the variable which uses that dimension, it is currently not resolved correctly leading to a compile error on the `allocate()` call created by autogen.

This fixes the issue by resolving the dimensions after the whole registry is parsed, with extra care handling DDTs since they also have the dust size dimension (4).

This is a cherry-pick from issues discovered during MAM work in CAM-SIMA.

Describe any changes made to build system:

Describe any changes made to the namelist:

List any changes to the defaults for the input datasets (e.g. boundary datasets):

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       src/data/generate_registry_data.py
  - fix bug in dimension resolution

M       test/unit/python/sample_files/reg_good_self_ref_dim.xml
M       test/unit/python/sample_files/physics_types_self_ref_dim.F90
M       test/unit/python/sample_files/physics_types_self_ref_dim.meta
  - update self-referencing dimensions test
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
