### PR TITLE
Add new 'SIMA_TESTDIR' case variable.

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -306,6 +306,17 @@
     <desc>User mods to apply to specific compset matches. </desc>
   </entry>
 
+  <entry id="SIMA_TESTDIR">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value>/glade/campaign/cesm/community/amwg/sima_baselines</default_value>
+    <group>run_component_cam</group>
+    <file>env_run.xml</file>
+    <desc>
+      Path to directory where CAM-SIMA regression testing files are stored.
+    </desc>
+  </entry>
+
   <entry id="CAM_LINKED_LIBS">
     <type>char</type>
     <valid_values></valid_values>

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_beljaars_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_beljaars_derecho/user_nl_cam
@@ -1,6 +1,6 @@
 ! CAM6 snapshot:
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhist_beljaars_snapshot_derecho_gnu_before_c20260614.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhist_beljaars_snapshot_derecho_gnu_after_c20260614.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhist_beljaars_snapshot_derecho_gnu_before_c20260614.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhist_beljaars_snapshot_derecho_gnu_after_c20260614.nc'
 pver = 32
 
 ! tolerances for testing

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_dme_adjust_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_dme_adjust_derecho/user_nl_cam
@@ -1,5 +1,8 @@
 ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_dme_adjust_snapshot_derecho_gnu_before_c20250416.nc'
 ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_dme_adjust_snapshot_derecho_gnu_after_c20250416.nc'
+ncdata_check_err = .true.
+min_difference = 2e-15
+
 debug_output=0
 pver=32
 hist_add_inst_fields;h2: Q,PS

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_dme_adjust_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_dme_adjust_derecho/user_nl_cam
@@ -1,5 +1,5 @@
-ncdata='/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_dme_adjust_snapshot_derecho_gnu_before_c20250416.nc'
-ncdata_check='/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_dme_adjust_snapshot_derecho_gnu_after_c20250416.nc'
+ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_dme_adjust_snapshot_derecho_gnu_before_c20250416.nc'
+ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_dme_adjust_snapshot_derecho_gnu_after_c20250416.nc'
 debug_output=0
 pver=32
 hist_add_inst_fields;h2: Q,PS

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_gw_cam4_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_gw_cam4_derecho/user_nl_cam
@@ -1,7 +1,7 @@
 ! cam4 snapshot
 pver = 26
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_gw_drag_cam4_oro_snapshot_derecho_gnu_before_c20250826.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_gw_drag_cam4_oro_snapshot_derecho_gnu_after_c20250826.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_gw_drag_cam4_oro_snapshot_derecho_gnu_before_c20250826.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_gw_drag_cam4_oro_snapshot_derecho_gnu_after_c20250826.nc'
 
 debug_output = 0
 

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_gw_cam7_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_gw_cam7_derecho/user_nl_cam
@@ -1,7 +1,7 @@
 ! fhistc_ltso snapshot
 pver = 58
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_gw_drag_cam7se_snapshot_derecho_gnu_before_c20260105.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_gw_drag_cam7se_snapshot_derecho_gnu_after_c20260105.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_gw_drag_cam7se_snapshot_derecho_gnu_before_c20260105.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_gw_drag_cam7se_snapshot_derecho_gnu_after_c20260105.nc'
 
 debug_output = 0
 

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_hack_shallow_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_hack_shallow_derecho/user_nl_cam
@@ -1,6 +1,8 @@
 ! these are QPC4 snapshots and require custom physical constant definitions.
 ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne5np4_hack_convect_shallow_snapshot_derecho_gnu_before_c20250220.nc'
 ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne5np4_hack_convect_shallow_snapshot_derecho_gnu_after_c20250220.nc'
+ncdata_check_err = .true.
+min_difference = 2e-15
 
 pver = 26
 user_defined_cpwv       = 1.846e3

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_hack_shallow_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_hack_shallow_derecho/user_nl_cam
@@ -1,6 +1,6 @@
 ! these are QPC4 snapshots and require custom physical constant definitions.
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne5np4_hack_convect_shallow_snapshot_derecho_gnu_before_c20250220.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne5np4_hack_convect_shallow_snapshot_derecho_gnu_after_c20250220.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne5np4_hack_convect_shallow_snapshot_derecho_gnu_before_c20250220.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne5np4_hack_convect_shallow_snapshot_derecho_gnu_after_c20250220.nc'
 
 pver = 26
 user_defined_cpwv       = 1.846e3

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_hb_vdiff_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_hb_vdiff_derecho/user_nl_cam
@@ -1,6 +1,6 @@
 ! these are FHIST_C4 snapshots
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_vertical_diffusion_hb_snapshot_derecho_gnu_before_c20260609.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_vertical_diffusion_hb_snapshot_derecho_gnu_after_c20260609.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_vertical_diffusion_hb_snapshot_derecho_gnu_before_c20260609.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_vertical_diffusion_hb_snapshot_derecho_gnu_after_c20260609.nc'
 
 ! tolerances for testing
 ncdata_check_err = .true.

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_held_suarez_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_held_suarez_derecho/user_nl_cam
@@ -1,5 +1,7 @@
 ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_held_suarez_snapshot_derecho_gnu_cam_before_c20240412.nc'
 ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_held_suarez_snapshot_derecho_gnu_cam_after_c20240412.nc'
+ncdata_check_err=.true.
+
 debug_output=0
 pver=30
 hist_add_inst_fields;h2: ZM, T

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_held_suarez_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_held_suarez_derecho/user_nl_cam
@@ -1,5 +1,5 @@
-ncdata=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_held_suarez_snapshot_derecho_gnu_cam_before_c20240412.nc
-ncdata_check=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_held_suarez_snapshot_derecho_gnu_cam_after_c20240412.nc
+ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_held_suarez_snapshot_derecho_gnu_cam_before_c20240412.nc'
+ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_held_suarez_snapshot_derecho_gnu_cam_after_c20240412.nc'
 debug_output=0
 pver=30
 hist_add_inst_fields;h2: ZM, T

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_kessler_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_kessler_derecho/user_nl_cam
@@ -1,5 +1,5 @@
-ncdata=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_kessler_snapshot_derecho_gnu_before_c20240412.nc
-ncdata_check=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_kessler_snapshot_derecho_gnu_after_c20240412.nc
+ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_kessler_snapshot_derecho_gnu_before_c20240412.nc'
+ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_kessler_snapshot_derecho_gnu_after_c20240412.nc'
 ncdata_check_err=.true.
 debug_output=0
 pver=30

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_rk_stratiform_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_rk_stratiform_derecho/user_nl_cam
@@ -1,6 +1,6 @@
 ! these are FHIST_C4 snapshots.
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_rasch_kristjansson_rk_stratiform_snapshot_derecho_gnu_before_c20250716.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_rasch_kristjansson_rk_stratiform_snapshot_derecho_gnu_after_c20250716.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_rasch_kristjansson_rk_stratiform_snapshot_derecho_gnu_before_c20250716.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_rasch_kristjansson_rk_stratiform_snapshot_derecho_gnu_after_c20250716.nc'
 
 ! tolerances for testing
 ncdata_check_err = .true.

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_rrtmgp_cirrus_gpu/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_rrtmgp_cirrus_gpu/user_nl_cam
@@ -1,6 +1,6 @@
 ! these are CPU FHISTC_LTso snapshots
-ncdata = '/glade/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_before_c20251013.nc'
-ncdata_check = '/glade/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_after_c20251013.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_before_c20251013.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_after_c20251013.nc'
 
 ! tolerances for testing (currently have high tolerance due to CPU snapshots)
 ncdata_check_err = .true.

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_rrtmgp_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_rrtmgp_derecho/user_nl_cam
@@ -1,6 +1,6 @@
 ! these are FHISTC_LTso snapshots
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_before_c20251013.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_after_c20251013.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_before_c20251013.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_after_c20251013.nc'
 
 ! tolerances for testing
 ncdata_check_err = .true.

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_rrtmgp_derecho_gpu/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_rrtmgp_derecho_gpu/user_nl_cam
@@ -1,6 +1,6 @@
 ! these are CPU FHISTC_LTso snapshots
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_before_c20251013.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_after_c20251013.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_before_c20251013.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc_ltso_rrtmgp_derecho_gnu_after_c20251013.nc'
 
 ! tolerances for testing (currently have high tolerance due to CPU snapshots)
 ncdata_check_err = .true.

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_after_coupler_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_after_coupler_derecho/user_nl_cam
@@ -1,5 +1,5 @@
-ncdata=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_tj2016_sfc_pbl_hs_ne3pg3mg37_derecho_gnu_before.nc
-ncdata_check=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_tj2016_sfc_pbl_hs_ne3pg3mg37_derecho_gnu_after.nc
+ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_tj2016_sfc_pbl_hs_ne3pg3mg37_derecho_gnu_before.nc'
+ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_tj2016_sfc_pbl_hs_ne3pg3mg37_derecho_gnu_after.nc'
 debug_output=0
 pver=30
 hist_add_inst_fields;h2: Q, T

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_after_coupler_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_after_coupler_derecho/user_nl_cam
@@ -1,5 +1,8 @@
 ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_tj2016_sfc_pbl_hs_ne3pg3mg37_derecho_gnu_before.nc'
 ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_tj2016_sfc_pbl_hs_ne3pg3mg37_derecho_gnu_after.nc'
+ncdata_check_err=.true.
+min_difference=2e-12  !Note that this is higher than normal.
+
 debug_output=0
 pver=30
 hist_add_inst_fields;h2: Q, T

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_before_coupler_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_before_coupler_derecho/user_nl_cam
@@ -1,6 +1,8 @@
 ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_tj2016_precip_tend_ne3pg3mg37_derecho_gnu_before.nc'
 ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_tj2016_precip_tend_ne3pg3mg37_derecho_gnu_after.nc'
 ncdata_check_err=.true.
+min_difference=2e-15
+
 debug_output=0
 pver=30
 hist_add_inst_fields;h2: Q, T

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_before_coupler_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_before_coupler_derecho/user_nl_cam
@@ -1,5 +1,5 @@
-ncdata=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_tj2016_precip_tend_ne3pg3mg37_derecho_gnu_before.nc
-ncdata_check=/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_tj2016_precip_tend_ne3pg3mg37_derecho_gnu_after.nc
+ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_tj2016_precip_tend_ne3pg3mg37_derecho_gnu_before.nc'
+ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_tj2016_precip_tend_ne3pg3mg37_derecho_gnu_after.nc'
 ncdata_check_err=.true.
 debug_output=0
 pver=30

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_trcdata_bam_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_trcdata_bam_derecho/user_nl_cam
@@ -15,8 +15,8 @@
 ! the test will pass iff. the tracer_data utility in CAM-SIMA and the prescribed_ozone/aerosols schemes
 ! can populate the prescribed fields bit-for-bit compared to the original snapshot file.
 
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_tracer_data_0xprescribed-ozone-aero-volcaero_from_energy_fixer_derecho_gnu_before_c20260312.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_tracer_data_0xprescribed-ozone-aero-volcaero_from_energy_fixer_derecho_gnu_after_c20260312.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_tracer_data_0xprescribed-ozone-aero-volcaero_from_energy_fixer_derecho_gnu_before_c20260312.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhistc4_tracer_data_0xprescribed-ozone-aero-volcaero_from_energy_fixer_derecho_gnu_after_c20260312.nc'
 
 ! tolerances for testing
 ncdata_check_err = .true.

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_uw_vdiff_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_uw_vdiff_derecho/user_nl_cam
@@ -1,6 +1,6 @@
 ! these are FHIST_C5 snapshots
-ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhist_c5_vertical_diffusion_uw_snapshot_derecho_gnu_before_c20260309.nc'
-ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_fhist_c5_vertical_diffusion_uw_snapshot_derecho_gnu_after_c20260309.nc'
+ncdata = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhist_c5_vertical_diffusion_uw_snapshot_derecho_gnu_before_c20260309.nc'
+ncdata_check = '${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_fhist_c5_vertical_diffusion_uw_snapshot_derecho_gnu_after_c20260309.nc'
 
 ! tolerances for testing
 ncdata_check_err = .true.

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_zm_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_zm_derecho/user_nl_cam
@@ -1,5 +1,5 @@
-ncdata='/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_ZM_snapshot_derecho_gnu_before_c20250116.nc'
-ncdata_check='/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam_ne3pg3_ZM_snapshot_derecho_gnu_after_c20250116.nc'
+ncdata='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_ZM_snapshot_derecho_gnu_before_c20250116.nc'
+ncdata_check='${SIMA_TESTDIR}/cam_sima_test_snapshots/cam_ne3pg3_ZM_snapshot_derecho_gnu_after_c20250116.nc'
 debug_output=0
 pver=32
 zmconv_momcd=.7D0


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): nusbaume

AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What: Claude Code Opus 4.8
  How:  Modified all of the `user_nl_cam` test files to use the new `SIMA_TESTDIR` variable.

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):

This PR brings in the new `SIMA_TESTDIR` CIME case variable, which allows for a developer to change the path for all CAM-SIMA physics snapshot test files in a single location, which should make it much easier for any future path changes, or if porting the tests to a new machine.

Fixes #522 

Describe any changes made to build system:

M       cime_config/config_component.xml
  - Added new 'SIMA_TESTDIR' CIME case variable.

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets): N/A

List all files eliminated and why: N/A

List all files added and what they do: N/A

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)

M       cime_config/testdefs/testmods_dirs/cam/outfrq_beljaars_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_dme_adjust_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_gw_cam4_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_gw_cam7_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_hack_shallow_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_hb_vdiff_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_held_suarez_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_kessler_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_rk_stratiform_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_rrtmgp_cirrus_gpu/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_rrtmgp_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_rrtmgp_derecho_gpu/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_after_coupler_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_tj2016_before_coupler_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_trcdata_bam_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_uw_vdiff_derecho/user_nl_cam
M       cime_config/testdefs/testmods_dirs/cam/outfrq_zm_derecho/user_nl_cam
  - Modified all physics snapshot 'user_nl_cam' testmod files to use new 'SIMA_TESTDIR' variable.

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

  SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape (Overall: NLFAIL)
    - Known failure

derecho/gnu/aux_sima:

  SMS_Ln9.ne3pg3_ne3pg3_mg37.FADIAB.derecho_gnu.cam-outfrq_se_cslam (Overall: DIFF)
     - Known failure

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
