### PR TITLE
CCPPize conv_water_4rad, cloud_water_paths

### DIFF
--- a/cime_config/testdefs/testlist_cam.xml
+++ b/cime_config/testdefs/testlist_cam.xml
@@ -218,6 +218,17 @@
     </options>
   </test>
 
+  <!-- radiation convective cloud water path test -->
+  <test compset="FPHYStest" grid="ne3pg3_ne3pg3_mg37" name="SMS_Ln2" testmods="cam/outfrq_cloud_water_derecho">
+    <machines>
+      <machine name="derecho" compiler="gnu" category="aux_sima"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:10:00</option>
+      <option name="comment">Test for convective cloud water path for radiation</option>
+    </options>
+  </test>
+
   <!-- tracer_data chemistry and aerosols input utility test -->
   <test compset="FPHYStest" grid="ne3pg3_ne3pg3_mg37" name="SMS_Ln2" testmods="cam/outfrq_trcdata_bam_derecho">
     <machines>

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_cloud_water_derecho/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_cloud_water_derecho/shell_commands
@@ -1,0 +1,1 @@
+ ./xmlchange CAM_CONFIG_OPTS="--dyn none --physics-suites cloud_water"

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_cloud_water_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_cloud_water_derecho/user_nl_cam
@@ -1,0 +1,21 @@
+ncdata = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam6_4_185_ne3pg3_fhist_convective_cloud_water_snapshot_derecho_gnu_before_c20260716.nc'
+ncdata_check = '/glade/campaign/cesm/community/amwg/sima_baselines/cam_sima_test_snapshots/cam6_4_185_ne3pg3_fhist_convective_cloud_water_snapshot_derecho_gnu_after_c20260716.nc'
+
+! fhist:
+pver = 32
+
+debug_output = 1
+ncdata_check_err = .true.
+
+conv_water_in_rad = 1
+conv_water_frac_limit = 0.01D0
+
+! ---------------------------------------------------------------------------
+! Convective cloud water baseline history (h1): the CAM conv_water fields
+! emitted by the convective_cloud_water_diagnostics scheme in this suite.
+! ---------------------------------------------------------------------------
+hist_add_inst_fields;h1: ICLMRCU, ICIMRCU, ICLMRTOT, ICIMRTOT, GCLMRSH, GCLMRDP, GCIMRSH, GCIMRDP, FRESH, FREDP, FRECU, FRETOT
+hist_output_frequency;h1: 1*nsteps
+hist_write_nstep0;h1: .true.
+hist_precision;h1: REAL64
+hist_max_frames;h1: 3

--- a/cime_config/testdefs/testmods_dirs/cam/outfrq_cloud_water_derecho/user_nl_cam
+++ b/cime_config/testdefs/testmods_dirs/cam/outfrq_cloud_water_derecho/user_nl_cam
@@ -10,10 +10,14 @@ ncdata_check_err = .true.
 conv_water_in_rad = 1
 conv_water_frac_limit = 0.01D0
 
-! ---------------------------------------------------------------------------
-! Convective cloud water baseline history (h1): the CAM conv_water fields
-! emitted by the convective_cloud_water_diagnostics scheme in this suite.
-! ---------------------------------------------------------------------------
+! Exclude snow/graupel outputs as qsout/qgout are PUMAS outputs
+! with no CAM pbuf so they cannot be passed into the snapshot:
+! the standalone suite can only run with zero snow/graupel so
+! snowy cells:
+!ncdata_check_exclude = 'liquid_plus_snow_stratiform_cloud_area_fraction',
+!    'liquid_plus_graupel_stratiform_cloud_area_fraction',
+!    'in_cloud_snow_water_path', 'stratiform_in_cloud_graupel_water_path'
+
 hist_add_inst_fields;h1: ICLMRCU, ICIMRCU, ICLMRTOT, ICIMRTOT, GCLMRSH, GCLMRDP, GCIMRSH, GCIMRDP, FRESH, FREDP, FRECU, FRETOT
 hist_output_frequency;h1: 1*nsteps
 hist_write_nstep0;h1: .true.

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -198,6 +198,14 @@
       <initial_value>0.0_kind_phys</initial_value>
       <ic_file_input_names>dlfzm pbuf_DLFZM</ic_file_input_names>
     </variable>
+    <variable local_name="icwmrsh"
+              standard_name="in_cloud_water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_due_to_shallow_convection"
+              units="kg kg-1" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+      <ic_file_input_names>ICWMRSH pbuf_ICWMRSH</ic_file_input_names>
+    </variable>
     <variable local_name="dlf"
               standard_name="detrainment_of_cloud_liquid_water_wrt_moist_air_and_condensed_water_due_to_all_convection"
               units="kg kg-1 s-1" type="real" kind="kind_phys"
@@ -221,6 +229,22 @@
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
       <initial_value>0.0_kind_phys</initial_value>
       <ic_file_input_names>pbuf_RPRDDP</ic_file_input_names>
+    </variable>
+    <variable local_name="dp_frac"
+              standard_name="deep_convective_cloud_area_fraction"
+              units="fraction" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+      <ic_file_input_names>DP_FRAC pbuf_DP_FRAC</ic_file_input_names>
+    </variable>
+    <variable local_name="sh_frac"
+              standard_name="shallow_convective_cloud_area_fraction"
+              units="fraction" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0.0_kind_phys</initial_value>
+      <ic_file_input_names>SH_FRAC pbuf_SH_FRAC</ic_file_input_names>
     </variable>
     <variable local_name="rliq"
               standard_name="vertically_integrated_cloud_liquid_water_tendency_due_to_all_convection_to_be_applied_later_in_time_loop"
@@ -1959,9 +1983,10 @@
     <!-- convective_cloud_water + cloud_water_paths inputs for RRTMGP cloud optics -->
     <variable local_name="effi_external_in"
               standard_name="effective_radius_of_stratiform_cloud_ice_particle"
-              units="micron" type="real" kind="kind_phys"
+              units="um" type="real" kind="kind_phys"
               allocatable="allocatable">
       <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0._kind_phys</initial_value>
       <ic_file_input_names>REI pbuf_REI</ic_file_input_names>
     </variable>
     <variable local_name="concld"

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -1956,6 +1956,63 @@
       <initial_value>0._kind_phys</initial_value>
       <ic_file_input_names>DES pbuf_DES</ic_file_input_names>
     </variable>
+    <!-- convective_cloud_water + cloud_water_paths inputs for RRTMGP cloud optics -->
+    <variable local_name="effi_external_in"
+              standard_name="effective_radius_of_stratiform_cloud_ice_particle"
+              units="micron" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <ic_file_input_names>REI pbuf_REI</ic_file_input_names>
+    </variable>
+    <variable local_name="concld"
+              standard_name="convective_cloud_area_fraction"
+              units="fraction" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0._kind_phys</initial_value>
+      <ic_file_input_names>CONCLD pbuf_CONCLD</ic_file_input_names>
+    </variable>
+    <variable local_name="qsout"
+              standard_name="snow_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state"
+              units="kg kg-1" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0._kind_phys</initial_value>
+      <ic_file_input_names>QSOUT pbuf_QSOUT</ic_file_input_names>
+    </variable>
+    <variable local_name="qgout"
+              standard_name="graupel_water_mixing_ratio_wrt_moist_air_and_condensed_water_of_new_state"
+              units="kg kg-1" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0._kind_phys</initial_value>
+      <ic_file_input_names>QGOUT pbuf_QGOUT</ic_file_input_names>
+    </variable>
+    <variable local_name="totg_liq"
+              standard_name="gridbox_total_cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water"
+              units="kg kg-1" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0._kind_phys</initial_value>
+      <ic_file_input_names>GB_TOTCLDLIQMR pbuf_GB_TOTCLDLIQMR</ic_file_input_names>
+    </variable>
+    <variable local_name="totg_ice"
+              standard_name="gridbox_total_cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water"
+              units="kg kg-1" type="real" kind="kind_phys"
+              allocatable="allocatable">
+      <dimensions>horizontal_dimension vertical_layer_dimension</dimensions>
+      <initial_value>0._kind_phys</initial_value>
+      <ic_file_input_names>GB_TOTCLDICEMR pbuf_GB_TOTCLDICEMR</ic_file_input_names>
+    </variable>
+    <!-- One-moment (RK) microphysics is not a supported CAM-SIMA
+         configuration; hardcoded false (selects the two-moment rei clamp in
+         convective_cloud_water). Revisit if an RK+RRTMGP config arrives. -->
+    <variable local_name="one_mom_clouds"
+              standard_name="flag_for_one_moment_cloud_microphysics"
+              units="flag" type="logical">
+      <long_name>flag indicating one-moment (RK) cloud microphysics is active</long_name>
+      <initial_value>.false.</initial_value>
+    </variable>
     <variable local_name="qrs"
               standard_name="tendency_of_dry_air_enthalpy_at_constant_pressure_due_to_shortwave_radiation_adjusted_by_air_pressure_thickness"
               units="J Pa kg-1 s-1" type="real" kind="kind_phys"

--- a/src/data/registry.xml
+++ b/src/data/registry.xml
@@ -2029,9 +2029,6 @@
       <initial_value>0._kind_phys</initial_value>
       <ic_file_input_names>GB_TOTCLDICEMR pbuf_GB_TOTCLDICEMR</ic_file_input_names>
     </variable>
-    <!-- One-moment (RK) microphysics is not a supported CAM-SIMA
-         configuration; hardcoded false (selects the two-moment rei clamp in
-         convective_cloud_water). Revisit if an RK+RRTMGP config arrives. -->
     <variable local_name="one_mom_clouds"
               standard_name="flag_for_one_moment_cloud_microphysics"
               units="flag" type="logical">


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What:
  How:

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- Companion PR to https://github.com/ESCOMP/atmospheric_physics/pull/428 to add registry fields and testmod

Describe any changes made to build system: N/A

Describe any changes made to the namelist: N/A

List any changes to the defaults for the input datasets (e.g. boundary datasets):

List all files eliminated and why:

List all files added and what they do:
```
A       cime_config/testdefs/testmods_dirs/cam/outfrq_cloud_water_derecho/shell_commands
A       cime_config/testdefs/testmods_dirs/cam/outfrq_cloud_water_derecho/user_nl_cam
  - new testmod
```

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       cime_config/testdefs/testlist_cam.xml
   - add outfrq_cloud_water_derecho testmod
M       src/data/registry.xml
   - add registry fields necessary
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
