### PR TITLE
sima0_18_000: Various IC related fixes for standalone SE dycore runs.

### DIFF
--- a/src/control/cam_comp.F90
+++ b/src/control/cam_comp.F90
@@ -224,6 +224,12 @@ CONTAINS
       ! Initialize constituent data
       call cam_ccpp_initialize_constituents(columns_on_task, pver, errflg, errmsg)
 
+      ! Ensure the constituents object is locked and allocated:
+      if (errflg /= 0) then
+         call endrun('cam_init: cam_ccpp_initialize_constituents failure: '//trim(errmsg), &
+                     file=__FILE__, line=__LINE__)
+      end if
+
       ! Initialize ghg surface values before default initial distributions
       ! are set in dyn_init
       !!XXgoldyXX: This needs to be converted to CCPP and the issue of

--- a/src/data/write_init_files.py
+++ b/src/data/write_init_files.py
@@ -979,6 +979,7 @@ def write_phys_read_subroutine(outfile, host_dict, host_vars, host_imports,
                  [phys_check_fname_str, ["phys_var_num", "phys_var_stdnames",
                                          "input_var_names", "std_name_len",
                                          "is_initialized"]],
+                 ["cam_constituents", ["const_is_initialized"]],
                  ["ccpp_constituent_prop_mod", ["ccpp_constituent_prop_ptr_t"]],
                  ["cam_logfile", ["iulog"]]]
 
@@ -1180,6 +1181,13 @@ def write_phys_read_subroutine(outfile, host_dict, host_vars, host_imports,
     outfile.comment("Iterate over all registered constituents", 2)
     outfile.write("do constituent_idx = 1, size(const_props)", 2)
     outfile.write("var_found = .false.", 3)
+    outfile.comment("Skip constituents from physics grid initial condition read for", 3)
+    outfile.comment("constituents whose initial values are already set", 3)
+    # Uses indices rather than standard names because phys_var_stdnames does not have access
+    # to runtime constituents' standard names at the point of code generation:
+    outfile.write("if (const_is_initialized(constituent_idx)) then", 3)
+    outfile.write("cycle", 4)
+    outfile.write("end if", 3)
     outfile.comment("Check if constituent standard name in registered SIMA standard names list:", 3)
     outfile.write("call const_props(constituent_idx)%standard_name(std_name)", 3)
     outfile.comment("Find array index to extract correct input names", 3)

--- a/src/dynamics/mpas/dyn_comp_impl.F90
+++ b/src/dynamics/mpas/dyn_comp_impl.F90
@@ -953,7 +953,8 @@ contains
     !> (KCW, 2024-05-23)
     subroutine mark_variables_as_initialized()
         ! Module(s) from CAM-SIMA.
-        use cam_constituents, only: const_name, &
+        use cam_constituents, only: const_mark_as_initialized, &
+                                    const_name, &
                                     num_advected
         use cam_logfile, only: debugout_debug
         ! Module(s) from CCPP.
@@ -1002,8 +1003,12 @@ contains
         call mark_as_initialized('tendency_of_northward_wind_due_to_model_physics')
 
         ! CCPP standard names of constituents.
+        ! The name-based `mark_as_initialized` silently ignores runtime-registered constituents
+        ! because they have no registry entry, so also mark each constituent by index to keep
+        ! the physics-grid initial condition read from overwriting any advected constituent.
         do i = 1, num_advected
             call mark_as_initialized(trim(adjustl(const_name(advected_constituent_index(i)))))
+            call const_mark_as_initialized(advected_constituent_index(i))
         end do
 
         ! The variables below are not managed by dynamics interface. They are used by external CCPP physics schemes.

--- a/src/dynamics/se/dp_coupling.F90
+++ b/src/dynamics/se/dp_coupling.F90
@@ -401,7 +401,7 @@ subroutine p_d_coupling(cam_runtime_opts, phys_state, phys_tend, dyn_in, tl_f, t
 
    !Convert wet mixing ratios to dry, which for CAM
    !configurations is only the water species:
-   !$omp parallel do num_threads(max_num_threads) private (k, i, m)
+   !$omp parallel do num_threads(max_num_threads) private (ilyr, icol, m, m_cnst, factor)
    do ilyr = 1, nlev
       do icol=1, pcols
 
@@ -696,7 +696,7 @@ subroutine derived_phys_dry(cam_runtime_opts, phys_state, phys_tend)
 
    ! wet pressure variables (should be removed from physics!)
    factor_array(:,:) = 1.0_kind_phys
-   !$omp parallel do num_threads(horz_num_threads) private (k, i, m_cnst)
+   ! shared factor_array, do not parallelize:
    do m_cnst = dry_air_species_num + 1, thermodynamic_active_species_num
       ! include all water species in the factor array.
       m = thermodynamic_active_species_idx(m_cnst)

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -1742,9 +1742,6 @@ subroutine read_inidat(dyn_in)
    call check_allocate(ierr, subname, 'const_ic_name(num_advected)', &
                        file=__FILE__, line=__LINE__, errmsg=errmsg)
 
-   ! Initialize to variable name that will likely never be found in the IC file:
-   const_ic_name(:) = 'NONAME_NEVERFOUND'
-
    do m_cnst = 1, num_advected
 
       ! Extract constituent standard name:
@@ -1759,14 +1756,11 @@ subroutine read_inidat(dyn_in)
          end if
       end do
 
-      if (const_ic_names_idx < 0) then
-         ! Constituents registered at run time have no registry entry so they are not in
-         ! phys_var_stdnames. Use the IC file field name:
-         const_ic_name(m_cnst) = trim(std_name)
-      else
+      ! Initialize IC name array with the constituent standard name
+      const_ic_name(m_cnst) = trim(std_name)
+      if (const_ic_names_idx > 0) then
          ! Scan the IC file variables for the first name in the registry IC names list.
-         ! If none are found, uses the first name as the default so there is a reportable name:
-         const_ic_name(m_cnst) = input_var_names(1, const_ic_names_idx)
+         ! If none are found, then the standard name is the default:
          do k = 1, size(input_var_names, 1)
             ! Unused name slots are blank-padded:
             if (len_trim(input_var_names(k, const_ic_names_idx)) == 0) then

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -1519,8 +1519,17 @@ subroutine read_inidat(dyn_in)
       call check_allocate(ierr, subname, 'm_ind(qsize)', &
                           file=__FILE__, line=__LINE__, errmsg=errmsg)
 
+      ! Map each GLL tracer slot to its constituent index
       do m_cnst = 1, qsize
-         m_ind(m_cnst) = thermodynamic_active_species_idx(m_cnst)
+         if (use_cslam) then
+            ! with CSLAM the GLL tracers are the condensate-loading water species
+            ! (qsize = thermodynamic_active_species_num):
+            m_ind(m_cnst) = thermodynamic_active_species_idx(m_cnst)
+         else
+            ! without CSLAM they are all of the advected constituents
+            ! (qsize = num_advected):
+            m_ind(m_cnst) = advected_constituent_index(m_cnst)
+         end if
       end do
 
       ! Init tracers on the GLL grid.  Note that analytic_ic_set_ic makes

--- a/src/dynamics/se/dyn_comp.F90
+++ b/src/dynamics/se/dyn_comp.F90
@@ -1347,6 +1347,7 @@ subroutine read_inidat(dyn_in)
    use cam_initfiles,        only: pertlim, initial_file_get_id, topo_file_get_id
    use cam_constituents,     only: num_advected, const_name
    use cam_constituents,     only: const_is_water_species, const_qmin, const_is_wet
+   use cam_constituents,     only: const_mark_as_initialized
    use dyn_tests_utils,      only: vcoord=>vc_dry_pressure
 
    !This should eventually be replaced with the "const_diag_name" function from "cam_constituents".
@@ -1749,12 +1750,25 @@ subroutine read_inidat(dyn_in)
          end if
       end do
 
-      ! Skip to next constituent if not found in input names list:
-      if (const_ic_names_idx < 0) cycle
-
-      ! The first name in IC names list should be the correct
-      ! name for standard CAM IC (ncdata) files:
-      const_ic_name(m_cnst) = input_var_names(1, const_ic_names_idx)
+      if (const_ic_names_idx < 0) then
+         ! Constituents registered at run time have no registry entry so they are not in
+         ! phys_var_stdnames. Use the IC file field name:
+         const_ic_name(m_cnst) = trim(std_name)
+      else
+         ! Scan the IC file variables for the first name in the registry IC names list.
+         ! If none are found, uses the first name as the default so there is a reportable name:
+         const_ic_name(m_cnst) = input_var_names(1, const_ic_names_idx)
+         do k = 1, size(input_var_names, 1)
+            ! Unused name slots are blank-padded:
+            if (len_trim(input_var_names(k, const_ic_names_idx)) == 0) then
+               exit
+            end if
+            if (dyn_field_exists(fh_ini, trim(input_var_names(k, const_ic_names_idx)), required=.false.)) then
+               const_ic_name(m_cnst) = input_var_names(k, const_ic_names_idx)
+               exit
+            end if
+         end do
+      end if
    end do
    !-------------
 
@@ -1786,7 +1800,11 @@ subroutine read_inidat(dyn_in)
 
       if (found) then
          call read_dyn_var(trim(const_ic_name(m_cnst)), fh_ini, dimname, dbuf3)
+         ! Tell the physics initial conditions read to leave this constituent alone:
+         ! (it holds dynamics-grid data that physics cannot re-read)
+         call const_mark_as_initialized(advected_constituent_index(m_cnst))
       else
+         ! Not on the file: cold start from the constituent minimum below:
          dbuf3 = 0._r8
       end if
 

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -24,9 +24,18 @@ module cam_constituents
    public :: const_set_water_species
    public :: const_qmin
    public :: const_set_qmin
+   public :: const_mark_as_initialized ! Mark constituent initial value as set
+   public :: const_is_initialized      ! Has constituent initial value been set?
 
    ! Private array of constituent properties (for property interface functions)
    type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:) => NULL()
+
+   ! Tracks constituents (by index) whose initial values have already been provided,
+   ! e.g., read by the dycore on the dynamics grid, so that
+   ! the initial conditions read does not overwrite them on the physics grid.
+   ! phys_vars_init_check cannot track these because it only covers registry variables
+   ! and not runtime constituents (which is why we have to use indices here:)
+   logical, allocatable, private :: const_initialized(:)
 
    ! Namelist variable
    ! Only allow initialization once
@@ -101,7 +110,7 @@ CONTAINS
    !#######################################################################
 
    subroutine cam_constituents_init(cnst_prop_ptr, num_advect)
-      use cam_abortutils, only: endrun
+      use cam_abortutils, only: endrun, check_allocate
       use spmd_utils,     only: masterproc
       use cam_logfile,    only: iulog, debug_output
       use cam_logfile,    only: DEBUGOUT_VERBOSE
@@ -112,6 +121,9 @@ CONTAINS
 
       !For log output:
       integer :: cnst_idx
+      !For allocation:
+      integer            :: iret
+      character(len=256) :: errmsg
 
       if (initialized) then
          call endrun("cam_constituents_init: already initialized",            &
@@ -120,6 +132,12 @@ CONTAINS
       const_props => cnst_prop_ptr
       num_advected = num_advect
       num_constituents = size(const_props)
+
+      allocate(const_initialized(num_constituents), stat=iret, errmsg=errmsg)
+      call check_allocate(iret, 'cam_constituents_init',                      &
+           'const_initialized(num_constituents)', file=__FILE__,              &
+           line=__LINE__, errmsg=errmsg)
+      const_initialized = .false.
 
       initialized = .true.
 
@@ -169,6 +187,44 @@ CONTAINS
       end if
 
    end function check_index_bounds
+
+   !#######################################################################
+
+   subroutine const_mark_as_initialized(const_ind)
+
+      ! Mark the constituent at <const_ind> as having had its initial value
+      ! set (e.g., by the dycore on the dyn grid for advected constituents),
+      ! so that the initial conditions read leaves it alone.
+
+      ! Dummy argument
+      integer, intent(in)         :: const_ind
+      ! Local variable
+      character(len=*), parameter :: subname = 'const_mark_as_initialized: '
+
+      if (check_index_bounds(const_ind, subname)) then
+         const_initialized(const_ind) = .true.
+      end if
+
+   end subroutine const_mark_as_initialized
+
+   !#######################################################################
+
+   logical function const_is_initialized(const_ind)
+
+      ! Return whether the initial value of the constituent at <const_ind>
+      ! has already been set (see const_mark_as_initialized).
+
+      ! Dummy argument
+      integer, intent(in)         :: const_ind
+      ! Local variable
+      character(len=*), parameter :: subname = 'const_is_initialized: '
+
+      const_is_initialized = .false.
+      if (check_index_bounds(const_ind, subname)) then
+         const_is_initialized = const_initialized(const_ind)
+      end if
+
+   end function const_is_initialized
 
    !#######################################################################
 

--- a/src/physics/utils/cam_constituents.F90
+++ b/src/physics/utils/cam_constituents.F90
@@ -35,7 +35,7 @@ module cam_constituents
    ! the initial conditions read does not overwrite them on the physics grid.
    ! phys_vars_init_check cannot track these because it only covers registry variables
    ! and not runtime constituents (which is why we have to use indices here:)
-   logical, allocatable, private :: const_initialized(:)
+   logical, allocatable :: const_initialized(:)
 
    ! Namelist variable
    ! Only allow initialization once

--- a/src/physics/utils/phys_comp.F90
+++ b/src/physics/utils/phys_comp.F90
@@ -184,6 +184,7 @@ CONTAINS
       use cam_ccpp_cap,              only: cam_model_const_properties
       use cam_constituents,          only: num_constituents
       use cam_constituents,          only: const_mark_as_initialized
+      use cam_constituents,          only: const_is_initialized
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       use runtime_obj,               only: cam_runtime_opts
 
@@ -235,6 +236,10 @@ CONTAINS
          const_props => cam_model_const_properties()
          const_array => cam_constituents_array()
          do const_idx = 1, num_constituents
+            ! Constituents the dycore already marked in (1) need no value check:
+            if (const_is_initialized(const_idx)) then
+               cycle
+            end if
             ! We call the framework default_value here because for constituents that do not have
             ! a default value, it is huge(1.0) and that magic value is private to the framework:
             call const_props(const_idx)%default_value(const_default, errcode, errmsg)

--- a/src/physics/utils/phys_comp.F90
+++ b/src/physics/utils/phys_comp.F90
@@ -211,7 +211,7 @@ CONTAINS
       ! (1) For all non-null dycores:
       !     The dycore reads advected constituent ICs (and marks them initialized)
       !     from the IC file which is on the dynamics grid.
-      !     It is "pushed" to physics via d_p_coupling.
+      !     It is "pushed" to physics via the dynamics-physics coupling layer.
       ! (2) Other constituent values come from physics schemes.
       !     If physics init schemes have set values for constituents
       !     (e.g., prescribe_radiative_gas_concentrations), then we also mark it as being
@@ -222,7 +222,7 @@ CONTAINS
       ! constituents object initialized it to. This avoids schemes having dependencies
       ! on host-side subroutines like const_mark_as_initialized.
       !
-      ! In phys_timestep_init (!), the physics-side IC read (3) runs:
+      ! In phys_timestep_init (careful! not init), the physics-side IC read (3) runs:
       ! (3) For all uninitialized variables, the generated physics_read_data runs
       !     on the physics grid for all time steps (null dycore) or initial step.
       ! Because it runs in timestep_init phase and not init, any quantities not marked as

--- a/src/physics/utils/phys_comp.F90
+++ b/src/physics/utils/phys_comp.F90
@@ -173,13 +173,25 @@ CONTAINS
    end subroutine phys_register
 
    subroutine phys_init()
-      use cam_abortutils,       only: endrun
-      use physics_grid,         only: columns_on_task
-      use vert_coord,           only: pver, pverp
-      use cam_thermo,           only: cam_thermo_init
-      use cam_thermo_formula,   only: cam_thermo_formula_init
-      use physics_types,        only: allocate_physics_types_fields
-      use cam_ccpp_cap,         only: cam_ccpp_physics_initialize
+      use cam_abortutils,            only: endrun
+      use physics_grid,              only: columns_on_task
+      use vert_coord,                only: pver, pverp
+      use cam_thermo,                only: cam_thermo_init
+      use cam_thermo_formula,        only: cam_thermo_formula_init
+      use physics_types,             only: allocate_physics_types_fields
+      use cam_ccpp_cap,              only: cam_ccpp_physics_initialize
+      use cam_ccpp_cap,              only: cam_constituents_array
+      use cam_ccpp_cap,              only: cam_model_const_properties
+      use cam_constituents,          only: num_constituents
+      use cam_constituents,          only: const_mark_as_initialized
+      use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
+      use runtime_obj,               only: cam_runtime_opts
+
+      ! Local variables
+      type(ccpp_constituent_prop_ptr_t), pointer :: const_props(:)
+      real(kind_phys),                   pointer :: const_array(:,:,:)
+      real(kind_phys)                            :: const_default
+      integer                                    :: const_idx
 
       call cam_thermo_init(columns_on_task, pver, pverp)
       call cam_thermo_formula_init()
@@ -191,6 +203,48 @@ CONTAINS
       call cam_ccpp_physics_initialize(phys_suite_name)
       if (errcode /= 0) then
          call endrun('cam_ccpp_physics_initialize: '//trim(errmsg))
+      end if
+
+      ! There are two ways constituents acquire their initial conditions (ICs) at this point
+      ! before the physics-side IC read (see below) runs:
+      ! (1) For all non-null dycores:
+      !     The dycore reads advected constituent ICs (and marks them initialized)
+      !     from the IC file which is on the dynamics grid.
+      !     It is "pushed" to physics via d_p_coupling.
+      ! (2) Other constituent values come from physics schemes.
+      !     If physics init schemes have set values for constituents
+      !     (e.g., prescribe_radiative_gas_concentrations), then we also mark it as being
+      !     initialized so the physics-side IC read does not overwrite them or set them
+      !     to the constituent minimum.
+      !
+      ! We recognize (2) by checking whether it holds the default value the
+      ! constituents object initialized it to. This avoids schemes having dependencies
+      ! on host-side subroutines like const_mark_as_initialized.
+      !
+      ! In phys_timestep_init (!), the physics-side IC read (3) runs:
+      ! (3) For all uninitialized variables, the generated physics_read_data runs
+      !     on the physics grid for all time steps (null dycore) or initial step.
+      ! Because it runs in timestep_init phase and not init, any quantities not marked as
+      ! initialized get clobbered (with qmin, if it is not in the IC file on the physics grid)
+      ! in this phase.
+      !   n.b.: the null dycore does NOT implement (1), and relies on (3) for all snapshot fields.
+      !
+      ! For null dycores, snapshots are read from the physics grid, so nothing is marked
+      ! as initialized at this point.
+      if (cam_runtime_opts%get_dycore() /= 'null') then
+         const_props => cam_model_const_properties()
+         const_array => cam_constituents_array()
+         do const_idx = 1, num_constituents
+            ! We call the framework default_value here because for constituents that do not have
+            ! a default value, it is huge(1.0) and that magic value is private to the framework:
+            call const_props(const_idx)%default_value(const_default, errcode, errmsg)
+            if (errcode /= 0) then
+               call endrun('phys_init: default_value: '//trim(errmsg))
+            end if
+            if (any(const_array(:,:,const_idx) /= const_default)) then
+               call const_mark_as_initialized(const_idx)
+            end if
+         end do
       end if
 
    end subroutine phys_init

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_4D.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_4D.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                only: kind_phys
       use string_utils,              only: to_lower, to_upper
       use phys_vars_init_check_4D,   only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,          only: const_is_initialized
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       use cam_logfile,               only: iulog
       use physics_types_4D,          only: eddy_len, slp, theta
@@ -183,6 +184,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_bvd.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_bvd.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                only: kind_phys
       use string_utils,              only: to_lower, to_upper
       use phys_vars_init_check_bvd,  only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,          only: const_is_initialized
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       use cam_logfile,               only: iulog
       use physics_types_bad_vertdim, only: band_no, slp, theta
@@ -183,6 +184,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_cnst.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_cnst.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                only: kind_phys
       use string_utils,              only: to_lower, to_upper
       use phys_vars_init_check_cnst, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,          only: const_is_initialized
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       use cam_logfile,               only: iulog
       use physics_types_simple,      only: slp, theta
@@ -180,6 +181,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_constituent_dim.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_constituent_dim.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                           only: kind_phys
       use string_utils,                         only: to_lower, to_upper
       use phys_vars_init_check_constituent_dim, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,                     only: const_is_initialized
       use ccpp_constituent_prop_mod,            only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                          only: iulog
       use physics_types_simple_constituent_dim, only: cool_cat_for_each_const, cool_default_cat_for_each_const, slp, theta
@@ -188,6 +189,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_ddt.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_ddt.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                only: kind_phys
       use string_utils,              only: to_lower, to_upper
       use phys_vars_init_check_ddt,  only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,          only: const_is_initialized
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       use cam_logfile,               only: iulog
       use physics_types_ddt,         only: phys_state, slp
@@ -180,6 +181,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_ddt2.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_ddt2.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                only: kind_phys
       use string_utils,              only: to_lower, to_upper
       use phys_vars_init_check_ddt2, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,          only: const_is_initialized
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       use cam_logfile,               only: iulog
       use physics_types_ddt2,        only: phys_state
@@ -180,6 +181,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_ddt_array.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_ddt_array.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                     only: kind_phys
       use string_utils,                   only: to_lower, to_upper
       use phys_vars_init_check_ddt_array, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,               only: const_is_initialized
       use ccpp_constituent_prop_mod,      only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                    only: iulog
       use physics_types_ddt_array,        only: ix_theta, phys_state
@@ -180,6 +181,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_host_var.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_host_var.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                    only: kind_phys
       use string_utils,                  only: to_lower, to_upper
       use phys_vars_init_check_host_var, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,              only: const_is_initialized
       use ccpp_constituent_prop_mod,     only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                   only: iulog
       use physics_types_host_var,        only: slp
@@ -177,6 +178,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_initial_value.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_initial_value.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                         only: kind_phys
       use string_utils,                       only: to_lower, to_upper
       use phys_vars_init_check_initial_value, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,                   only: const_is_initialized
       use ccpp_constituent_prop_mod,          only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                        only: iulog
       use physics_types_simple_initial_value, only: slp, theta
@@ -180,6 +181,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_mf.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_mf.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                only: kind_phys
       use string_utils,              only: to_lower, to_upper
       use phys_vars_init_check_mf,   only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,          only: const_is_initialized
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       use cam_logfile,               only: iulog
       use ref_theta,                 only: theta
@@ -181,6 +182,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_no_horiz.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_no_horiz.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                    only: kind_phys
       use string_utils,                  only: to_lower, to_upper
       use phys_vars_init_check_no_horiz, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,              only: const_is_initialized
       use ccpp_constituent_prop_mod,     only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                   only: iulog
       use physics_types_no_horiz,        only: slp, theta
@@ -180,6 +181,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_noreq.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_noreq.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                 only: kind_phys
       use string_utils,               only: to_lower, to_upper
       use phys_vars_init_check_noreq, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,           only: const_is_initialized
       use ccpp_constituent_prop_mod,  only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                only: iulog
 
@@ -173,6 +174,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_param.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_param.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                 only: kind_phys
       use string_utils,               only: to_lower, to_upper
       use phys_vars_init_check_param, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,           only: const_is_initialized
       use ccpp_constituent_prop_mod,  only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                only: iulog
       use physics_types_param,        only: g, slp, theta
@@ -183,6 +184,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_protect.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_protect.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                   only: kind_phys
       use string_utils,                 only: to_lower, to_upper
       use phys_vars_init_check_protect, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,             only: const_is_initialized
       use ccpp_constituent_prop_mod,    only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                  only: iulog
       use physics_types_protected,      only: slp, theta
@@ -180,6 +181,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_scalar.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_scalar.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                  only: kind_phys
       use string_utils,                only: to_lower, to_upper
       use phys_vars_init_check_scalar, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,            only: const_is_initialized
       use ccpp_constituent_prop_mod,   only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                 only: iulog
       use physics_types_scalar_var,    only: slp, theta
@@ -180,6 +181,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names

--- a/test/unit/python/sample_files/write_init_files/physics_inputs_simple.F90
+++ b/test/unit/python/sample_files/write_init_files/physics_inputs_simple.F90
@@ -38,6 +38,7 @@ contains
       use ccpp_kinds,                  only: kind_phys
       use string_utils,                only: to_lower, to_upper
       use phys_vars_init_check_simple, only: phys_var_num, phys_var_stdnames, input_var_names, std_name_len, is_initialized
+      use cam_constituents,            only: const_is_initialized
       use ccpp_constituent_prop_mod,   only: ccpp_constituent_prop_ptr_t
       use cam_logfile,                 only: iulog
       use physics_types_simple,        only: slp, theta
@@ -180,6 +181,11 @@ contains
       ! Iterate over all registered constituents
       do constituent_idx = 1, size(const_props)
          var_found = .false.
+         ! Skip constituents from physics grid initial condition read for
+         ! constituents whose initial values are already set
+         if (const_is_initialized(constituent_idx)) then
+            cycle
+         end if
          ! Check if constituent standard name in registered SIMA standard names list:
          call const_props(constituent_idx)%standard_name(std_name)
          ! Find array index to extract correct input names


### PR DESCRIPTION
Tag name (required for release branches): sima0_18_000
Originator(s): @jimmielin 
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What: claude-fable:5, claude-opus:4.8
  How: drafted the fixes for reading runtime constituents in the dycore

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
- Read dynamic (runtime) constituents IC values in dycore
- Do not clobber dynamics read constituents in physics IC read
- Do not clobber physics init constituents with qmin in physics IC read (fixes https://github.com/ESCOMP/CAM-SIMA/issues/525)

Describe any changes made to build system:

Describe any changes made to the namelist:

List any changes to the defaults for the input datasets (e.g. boundary datasets):

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       src/dynamics/se/dp_coupling.F90
  - fixes for omp

M       src/dynamics/se/dyn_comp.F90
  - mark constituents read by dyn as initialized
  - new way to check for IC input files for constituent IC

M       src/dynamics/mpas/dyn_comp_impl.F90
  - mark constituents read by dyn as initialized

M       src/physics/utils/cam_constituents.F90
  - implement const_mark_as_initialized, const_is_initialized

M       src/physics/utils/phys_comp.F90
  - mark constituents written by physics init as initialized

M       src/data/write_init_files.py
  - Skip constituents from physics grid initial condition read for constituents already set

M       test/unit/python/sample_files/write_init_files/physics_inputs_4D.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_bvd.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_cnst.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_constituent_dim.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_ddt.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_ddt2.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_ddt_array.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_host_var.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_initial_value.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_mf.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_no_horiz.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_noreq.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_param.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_protect.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_scalar.F90
M       test/unit/python/sample_files/write_init_files/physics_inputs_simple.F90
  - update tests
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:
```
  SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 (Overall: DIFF) details:
    FAIL SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 BASELINE /glade/campaign/cesm/community/amwg/sima_baselines/latest_intel: DIFF
  SMS_D_Ln9.ne3pg3_ne3pg3_mt232.QPC4.derecho_intel.cam-outfrq_se_cam4 (Overall: DIFF) details:
    FAIL SMS_D_Ln9.ne3pg3_ne3pg3_mt232.QPC4.derecho_intel.cam-outfrq_se_cam4 BASELINE /glade/campaign/cesm/community/amwg/sima_baselines/latest_intel: DIFF
  SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 (Overall: DIFF) details:
    FAIL SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_intel.cam-outfrq_analy_ic_cam4 BASELINE /glade/campaign/cesm/community/amwg/sima_baselines/latest_intel: DIFF
  SMS_Ln9.ne3pg3_ne3pg3_mt232.QPC4.derecho_intel.cam-outfrq_se_cam4 (Overall: DIFF) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mt232.QPC4.derecho_intel.cam-outfrq_se_cam4 BASELINE /glade/campaign/cesm/community/amwg/sima_baselines/latest_intel: DIFF
  - baseline changes due to prescribed_radiative_gas_concentrations & other constituents no longer being clobbered to zero

  SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape (Overall: NLFAIL) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mg37.FKESSLER.derecho_intel.cam-outfrq_se_cslam_multitape NLCOMP
  - pre-existing failure

```

derecho/gnu/aux_sima:
```
  SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 (Overall: DIFF) details:
    FAIL SMS_D_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 BASELINE /glade/campaign/cesm/community/amwg/sima_baselines/latest_gnu: DIFF
  SMS_D_Ln9.ne3pg3_ne3pg3_mt232.QPC4.derecho_gnu.cam-outfrq_se_cam4 (Overall: DIFF) details:
    FAIL SMS_D_Ln9.ne3pg3_ne3pg3_mt232.QPC4.derecho_gnu.cam-outfrq_se_cam4 BASELINE /glade/campaign/cesm/community/amwg/sima_baselines/latest_gnu: DIFF
  SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 (Overall: DIFF) details:
    FAIL SMS_Ln9.mpasa120_mpasa120.QPC4.derecho_gnu.cam-outfrq_analy_ic_cam4 BASELINE /glade/campaign/cesm/community/amwg/sima_baselines/latest_gnu: DIFF
  SMS_Ln9.ne3pg3_ne3pg3_mt232.QPC4.derecho_gnu.cam-outfrq_se_cam4 (Overall: DIFF) details:
    FAIL SMS_Ln9.ne3pg3_ne3pg3_mt232.QPC4.derecho_gnu.cam-outfrq_se_cam4 BASELINE /glade/campaign/cesm/community/amwg/sima_baselines/latest_gnu: DIFF
  - baseline changes due to prescribed_radiative_gas_concentrations & other constituents no longer being clobbered to zero

```

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines): All PASS

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
