### PR TITLE
Add defaults for BAM aerosols in CAM4 F-compsets; support sim_year for climatological year

### DIFF
--- a/cime_config/cam_config.py
+++ b/cime_config/cam_config.py
@@ -182,6 +182,7 @@ class ConfigCAM:
         nthrds = case.get_value("NTHRDS_ATM")               # Number of model OpenMP threads
         start_date = case.get_value("RUN_STARTDATE")        # Model simulation start date
         debug_case = case.get_value("DEBUG")                # Case debug flag
+        sim_year = case.get_value("CAM_SIM_YEAR")           # Simulation (climatology) year
 
         # Save case variables needed for code auto-generation:
         self.__atm_root = case.get_value("COMP_ROOT_DIR_ATM")
@@ -272,6 +273,20 @@ class ConfigCAM:
 
         self.create_config("ic_ymd", "Start date of model run.",
                            start_date_cam, is_nml_attr=True)
+
+        #----------------------------------------------------
+        # Set simulation year (needed for namelist generation)
+        #----------------------------------------------------
+
+        # CAM_SIM_YEAR is empty for compsets without a recognized
+        # time period, which CIME returns as None:
+        if sim_year is None:
+            sim_year = ""
+        # End if
+
+        self.create_config("sim_year",
+                           "Simulation (climatology) year used for namelist defaults.",
+                           sim_year, is_nml_attr=True)
 
         #----------------------------------------------------
         # Set CAM debug flag (needed for namelist generation)

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -118,6 +118,23 @@
     <desc>User mods to apply to specific compset matches. </desc>
   </entry>
 
+  <entry id="CAM_SIM_YEAR">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <values match="last">
+      <value compset="^1850_">1850</value>
+      <value compset="^2000_">2000</value>
+    </values>
+    <group>run_component_cam</group>
+    <file>env_run.xml</file>
+    <desc>
+      Simulation (climatology) year, set from the time period at the start of the compset name.
+      Namelist defaults can be filtered by the sim_year XML attribute.
+      A compset without a recognized time period is empty so no sim_year default applies.
+    </desc>
+  </entry>
+
   <entry id="CAM_LINKED_LIBS">
     <type>char</type>
     <valid_values></valid_values>

--- a/cime_config/namelist_definition_cam.xml
+++ b/cime_config/namelist_definition_cam.xml
@@ -63,8 +63,8 @@
       <value aquaplanet="1" dyn="se" hgrid="ne240np4" ic_ymd="10101" nlev="32">${DIN_LOC_ROOT}/atm/cam/inic/se/ape_cam6_ne240np4_L32_c170908.nc</value>
       <value dyn="se" hgrid="ne0np4CONUS.ne30x8" nlev="32">${DIN_LOC_ROOT}/atm/cam/inic/se/f2000_conus_ne30x8_L32_c190712.nc</value>
       <value dyn="se" hgrid="ne5np4" nlev="66">${DIN_LOC_ROOT}/atm/waccm/ic/wa3_ne5np4_1950_spinup.cam2.i.1960-01-01-00000_c150810.nc</value>
-      <value dyn="se" hgrid="ne30np4" nlev="70" sim_year="1850">${DIN_LOC_ROOT}/atm/waccm/ic/waccm5_1850_ne30np4_L70_0001-01-11-00000_c151217.nc</value>
       <value dyn="se" hgrid="ne30np4" nlev="70">${DIN_LOC_ROOT}/atm/waccm/ic/fw2000_ne30np4_L70_c181221.nc</value>
+      <value dyn="se" hgrid="ne30np4" nlev="70" sim_year="1850">${DIN_LOC_ROOT}/atm/waccm/ic/waccm5_1850_ne30np4_L70_0001-01-11-00000_c151217.nc</value>
       <value dyn="se" hgrid="ne16np4" nlev="58">${DIN_LOC_ROOT}/atm/cam/inic/se/FHISTC_LTso_ne16pg3_ne16pg3_mg17.i.c260220.nc</value>
       <value dyn="se" hgrid="ne16np4" nlev="93">${DIN_LOC_ROOT}/atm/cam/inic/se/FHISTC_MTso_ne16pg3_ne16pg3_mg17.i.c260220.nc</value>
 

--- a/cime_config/namelist_definition_cam.xml
+++ b/cime_config/namelist_definition_cam.xml
@@ -437,7 +437,7 @@
       rad_aer_diag_* variables.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -451,7 +451,7 @@
       rad_aer_diag_* variables.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -465,7 +465,25 @@
       climate simulation via the radiative heating rate calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
+      <!-- cam4: bulk (BAM) aerosols registered by the prescribed_aerosols scheme.
+           The species names must match the constituent names in prescribed_aero_specifier.
+           Aquaplanet runs have no prescribed aerosols, so they keep the empty default. -->
+      <value phys_suite="cam4" aquaplanet="0">
+        'N:sulf:${DIN_LOC_ROOT}/atm/cam/physprops/sulfate_rrtmg_c080918.nc',
+        'N:dust1:${DIN_LOC_ROOT}/atm/cam/physprops/dust1_rrtmg_c080918.nc',
+        'N:dust2:${DIN_LOC_ROOT}/atm/cam/physprops/dust2_rrtmg_c080918.nc',
+        'N:dust3:${DIN_LOC_ROOT}/atm/cam/physprops/dust3_rrtmg_c080918.nc',
+        'N:dust4:${DIN_LOC_ROOT}/atm/cam/physprops/dust4_rrtmg_c080918.nc',
+        'N:bcar1:${DIN_LOC_ROOT}/atm/cam/physprops/bcpho_rrtmg_c080918.nc',
+        'N:bcar2:${DIN_LOC_ROOT}/atm/cam/physprops/bcphi_rrtmg_c080918.nc',
+        'N:ocar1:${DIN_LOC_ROOT}/atm/cam/physprops/ocpho_rrtmg_c080918.nc',
+        'N:ocar2:${DIN_LOC_ROOT}/atm/cam/physprops/ocphi_rrtmg_c080918.nc',
+        'N:sslt1:${DIN_LOC_ROOT}/atm/cam/physprops/seasalt1_rrtmg_c080918.nc',
+        'N:sslt2:${DIN_LOC_ROOT}/atm/cam/physprops/seasalt2_rrtmg_c080918.nc',
+        'N:sslt3:${DIN_LOC_ROOT}/atm/cam/physprops/seasalt3_rrtmg_c080918.nc',
+        'N:sslt4:${DIN_LOC_ROOT}/atm/cam/physprops/seasalt4_rrtmg_c080918.nc'
+      </value>
     </values>
   </entry>
 
@@ -480,7 +498,7 @@
       simulation. This is a hook for performing radiative forcing calculations.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -493,7 +511,7 @@
       Analogous to rad_aer_diag_1, but for the 2nd diagnostic calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -506,7 +524,7 @@
       Analogous to rad_aer_diag_1, but for the 3rd diagnostic calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -519,7 +537,7 @@
       Analogous to rad_aer_diag_1, but for the 4th diagnostic calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -532,7 +550,7 @@
       Analogous to rad_aer_diag_1, but for the 5th diagnostic calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -545,7 +563,7 @@
       Analogous to rad_aer_diag_1, but for the 6th diagnostic calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -558,7 +576,7 @@
       Analogous to rad_aer_diag_1, but for the 7th diagnostic calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -571,7 +589,7 @@
       Analogous to rad_aer_diag_1, but for the 8th diagnostic calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -584,7 +602,7 @@
       Analogous to rad_aer_diag_1, but for the 9th diagnostic calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 
@@ -597,7 +615,7 @@
       Analogous to rad_aer_diag_1, but for the 10th diagnostic calculation.
     </desc>
     <values>
-      <value>UNSET</value>
+      <value>''</value>
     </values>
   </entry>
 

--- a/test/unit/python/test_cam_config.py
+++ b/test/unit/python/test_cam_config.py
@@ -72,6 +72,7 @@ class FakeCase:
             "CAM_CPPDEFS" : "UNSET",
             "NTHRDS_ATM" : 1,
             "RUN_STARTDATE" : "101",
+            "CAM_SIM_YEAR" : "2000",
             "DEBUG" : False,
             "OPENACC_GPU_OFFLOAD": False
             }
@@ -350,6 +351,8 @@ class CamConfigTestRoutine(unittest.TestCase):
                   'DEBUG:print_config:-----------------------------',
                   'DEBUG:print_config:# Start date of model run.',
                   'DEBUG:print_config:ic_ymd = 101',
+                  'DEBUG:print_config:# Simulation (climatology) year used for namelist defaults.',
+                  'DEBUG:print_config:sim_year = 2000',
                   'DEBUG:print_config:# Flag to check if debug mode is enabled.',
                   'DEBUG:print_config:debug = 0',
                   'DEBUG:print_config:# Maximum number of columns assigned to a thread.',


### PR DESCRIPTION
Tag name (required for release branches):
Originator(s):
AI tools used (if applicable; please also add the "AI-generated code" label to the PR):
  What: Claude Code `claude-fable-5`, `claude-opus-5`
  How: triaged rad_aer_climate issue. verified populated values matched CAM

Description (include the issue title, and the keyword ['closes', 'fixes', 'resolves'] followed by the issue number):
Companion PR to https://github.com/ESCOMP/atmospheric_physics/pull/439

Describe any changes made to build system: see below; added `CAM_SIM_YEAR` support

Describe any changes made to the namelist:

List any changes to the defaults for the input datasets (e.g. boundary datasets):

List all files eliminated and why:

List all files added and what they do:

List all existing files that have been modified, and describe the changes: 
(Helpful git command: `git diff --name-status development...<your_branch_name>`)
```
M       cime_config/cam_config.py
M       cime_config/config_component.xml
M       test/unit/python/test_cam_config.py
  - support sim_year attribute for namelist defaults

M       cime_config/namelist_definition_cam.xml
  - add defaults for rad_aer_climate for CAM4
```

If there are new failures (compared to the `test/existing-test-failures.txt` file),
have them OK'd by the gatekeeper, note them here, and add them to the file.
If there are baseline differences, include the test and the reason for the
diff. What is the nature of the change? Roundoff?

derecho/intel/aux_sima:

derecho/gnu/aux_sima:

derecho/nvhpc/aux_sima (test is run via Github workflow. Only run the test manually if we need to save new baselines):

If this changes climate describe any run(s) done to evaluate the new
climate in enough detail that it(they) could be reproduced:

CAM-SIMA date used for the baseline comparison tests if different than latest:
